### PR TITLE
Add BeInRange/NotBeInRange for nullable date/time types and TimeSpan

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -759,6 +759,9 @@ public struct Operations
         [EnumStringValue("beinrange")]
         BeInRange,
 
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
         [EnumStringValue("havedays")]
         HaveDays,
 
@@ -791,6 +794,9 @@ public struct Operations
 
         [EnumStringValue("beinrange")]
         BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
 
         [EnumStringValue("havehour")]
         HaveHour,

--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -1798,15 +1798,6 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
                         )
                     )
             )
-            .FailIf(
-                manager =>
-                    (
-                        manager.PrincipalChain.GetValue().IsNull(),
-                        Fail.New(
-                            $"The {nameof(NotBeEquivalentTo)} operation failed because the array was null."
-                        )
-                    )
-            )
             .Execute();
 
         return this;
@@ -1893,15 +1884,6 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
                         manager.PrincipalChain.GetValue().IsNull() && expected.IsNull(),
                         Fail.New(
                             $"The {nameof(NotBeSequenceEqualTo)} operation failed because both collections are null and therefore sequence-equal."
-                        )
-                    )
-            )
-            .FailIf(
-                manager =>
-                    (
-                        manager.PrincipalChain.GetValue().IsNull(),
-                        Fail.New(
-                            $"The {nameof(NotBeSequenceEqualTo)} operation failed because the array was null."
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -1403,15 +1403,6 @@ public class CollectionOperationsManager<T>
                         )
                     )
             )
-            .FailIf(
-                manager =>
-                    (
-                        manager.PrincipalChain.GetValue().IsNull(),
-                        Fail.New(
-                            $"The {nameof(NotBeEquivalentTo)} operation failed because the collection was null."
-                        )
-                    )
-            )
             .Execute();
 
         return this;
@@ -1452,15 +1443,6 @@ public class CollectionOperationsManager<T>
                         manager.PrincipalChain.GetValue().IsNull() && expected.IsNull(),
                         Fail.New(
                             $"The {nameof(NotBeSequenceEqualTo)} operation failed because both collections are null and therefore sequence-equal."
-                        )
-                    )
-            )
-            .FailIf(
-                manager =>
-                    (
-                        manager.PrincipalChain.GetValue().IsNull(),
-                        Fail.New(
-                            $"The {nameof(NotBeSequenceEqualTo)} operation failed because the collection was null."
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDateOnlyOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDateOnlyOperationsManager.cs
@@ -144,4 +144,106 @@ public class NullableDateOnlyOperationsManager
 
         return this;
     }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateOnlyOperationsManager BeInRange(DateOnly min, DateOnly max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateOnly.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateOnlyOperationsManager, DateOnly?>
+            .New(this)
+            .WithOperation(NullableDateOnlyBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateOnlyOperationsManager NotBeInRange(DateOnly min, DateOnly max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateOnly.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateOnlyOperationsManager, DateOnly?>
+            .New(this)
+            .WithOperation(NullableDateOnlyNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOffsetOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOffsetOperationsManager.cs
@@ -144,4 +144,106 @@ public class NullableDateTimeOffsetOperationsManager
 
         return this;
     }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateTimeOffsetOperationsManager BeInRange(DateTimeOffset min, DateTimeOffset max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTimeOffset.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOffsetOperationsManager, DateTimeOffset?>
+            .New(this)
+            .WithOperation(NullableDateTimeOffsetBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateTimeOffsetOperationsManager NotBeInRange(DateTimeOffset min, DateTimeOffset max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTimeOffset.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOffsetOperationsManager, DateTimeOffset?>
+            .New(this)
+            .WithOperation(NullableDateTimeOffsetNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOperationsManager.cs
@@ -144,4 +144,106 @@ public class NullableDateTimeOperationsManager
 
         return this;
     }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateTimeOperationsManager BeInRange(DateTime min, DateTime max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTime.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOperationsManager, DateTime?>
+            .New(this)
+            .WithOperation(NullableDateTimeBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableDateTimeOperationsManager NotBeInRange(DateTime min, DateTime max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTime.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOperationsManager, DateTime?>
+            .New(this)
+            .WithOperation(NullableDateTimeNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableTimeOnlyOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableTimeOnlyOperationsManager.cs
@@ -144,4 +144,106 @@ public class NullableTimeOnlyOperationsManager
 
         return this;
     }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableTimeOnlyOperationsManager BeInRange(TimeOnly min, TimeOnly max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeOnly.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableTimeOnlyOperationsManager, TimeOnly?>
+            .New(this)
+            .WithOperation(NullableTimeOnlyBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min:HH:mm:ss}) > max ({max:HH:mm:ss})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableTimeOnlyOperationsManager NotBeInRange(TimeOnly min, TimeOnly max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeOnly.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableTimeOnlyOperationsManager, TimeOnly?>
+            .New(this)
+            .WithOperation(NullableTimeOnlyNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min:HH:mm:ss}) > max ({max:HH:mm:ss})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableTimeSpanOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableTimeSpanOperationsManager.cs
@@ -144,4 +144,106 @@ public class NullableTimeSpanOperationsManager
 
         return this;
     }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableTimeSpanOperationsManager BeInRange(TimeSpan min, TimeSpan max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeSpan.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableTimeSpanOperationsManager, TimeSpan?>
+            .New(this)
+            .WithOperation(NullableTimeSpanBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard).
+    /// Also throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public NullableTimeSpanOperationsManager NotBeInRange(TimeSpan min, TimeSpan max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeSpan.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableTimeSpanOperationsManager, TimeSpan?>
+            .New(this)
+            .WithOperation(NullableTimeSpanNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/TimeOnlyOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/TimeOnlyOperationsManager.cs
@@ -208,6 +208,52 @@ public class TimeOnlyOperationsManager : ITestManager<TimeOnlyOperationsManager,
     }
 
     /// <summary>
+    /// Asserts that the value does not fall within the range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public TimeOnlyOperationsManager NotBeInRange(TimeOnly min, TimeOnly max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeOnly.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TimeOnlyOperationsManager, TimeOnly>
+            .New(this)
+            .WithOperation(TimeOnlyNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min:HH:mm:ss}) > max ({max:HH:mm:ss})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the hour component of the value equals <paramref name="hour"/>.
     /// </summary>
     /// <param name="hour">The expected hour (0–23).</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/TimeSpanOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/TimeSpanOperationsManager.cs
@@ -298,6 +298,52 @@ public class TimeSpanOperationsManager : ITestManager<TimeSpanOperationsManager,
     }
 
     /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range guard).
+    /// </remarks>
+    public TimeSpanOperationsManager NotBeInRange(TimeSpan min, TimeSpan max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.TimeSpan.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TimeSpanOperationsManager, TimeSpan>
+            .New(this)
+            .WithOperation(TimeSpanNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the whole-day component of the value equals <paramref name="days"/>.
     /// </summary>
     /// <param name="days">The expected number of whole days.</param>

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeEquivalentToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeEquivalentToValidator.cs
@@ -22,6 +22,13 @@ internal class CollectionNotBeEquivalentToValidator<T>(
     public bool Validate()
     {
         var actual = chain.GetValue();
+
+        // If actual is null but expected is not, they are NOT equivalent => pass
+        if (actual is null)
+        {
+            return true;
+        }
+
         var actualList = actual.ToList();
         var expectedList = expected.ToList();
 

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeSequenceEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeSequenceEqualToValidator.cs
@@ -22,6 +22,13 @@ internal class CollectionNotBeSequenceEqualToValidator<T>(
     public bool Validate()
     {
         var actual = chain.GetValue();
+
+        // If actual is null but expected is not, they are NOT sequence-equal => pass
+        if (actual is null)
+        {
+            return true;
+        }
+
         var actualList = actual.ToList();
         var expectedList = expected.ToList();
 

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateOnlyBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateOnlyBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable dateonly value is within the specified inclusive range.
+/// </summary>
+internal class NullableDateOnlyBeInRangeValidator(
+    PrincipalChain<DateOnly?> chain,
+    DateOnly min,
+    DateOnly max
+) : IValidator
+{
+    public static NullableDateOnlyBeInRangeValidator New(
+        PrincipalChain<DateOnly?> chain,
+        DateOnly min,
+        DateOnly max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateOnlyNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateOnlyNotBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable dateonly value is outside the specified inclusive range.
+/// </summary>
+internal class NullableDateOnlyNotBeInRangeValidator(
+    PrincipalChain<DateOnly?> chain,
+    DateOnly min,
+    DateOnly max
+) : IValidator
+{
+    public static NullableDateOnlyNotBeInRangeValidator New(
+        PrincipalChain<DateOnly?> chain,
+        DateOnly min,
+        DateOnly max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetime value is within the specified inclusive range.
+/// </summary>
+internal class NullableDateTimeBeInRangeValidator(
+    PrincipalChain<DateTime?> chain,
+    DateTime min,
+    DateTime max
+) : IValidator
+{
+    public static NullableDateTimeBeInRangeValidator New(
+        PrincipalChain<DateTime?> chain,
+        DateTime min,
+        DateTime max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeNotBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetime value is outside the specified inclusive range.
+/// </summary>
+internal class NullableDateTimeNotBeInRangeValidator(
+    PrincipalChain<DateTime?> chain,
+    DateTime min,
+    DateTime max
+) : IValidator
+{
+    public static NullableDateTimeNotBeInRangeValidator New(
+        PrincipalChain<DateTime?> chain,
+        DateTime min,
+        DateTime max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetimeoffset value is within the specified inclusive range.
+/// </summary>
+internal class NullableDateTimeOffsetBeInRangeValidator(
+    PrincipalChain<DateTimeOffset?> chain,
+    DateTimeOffset min,
+    DateTimeOffset max
+) : IValidator
+{
+    public static NullableDateTimeOffsetBeInRangeValidator New(
+        PrincipalChain<DateTimeOffset?> chain,
+        DateTimeOffset min,
+        DateTimeOffset max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetNotBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetimeoffset value is outside the specified inclusive range.
+/// </summary>
+internal class NullableDateTimeOffsetNotBeInRangeValidator(
+    PrincipalChain<DateTimeOffset?> chain,
+    DateTimeOffset min,
+    DateTimeOffset max
+) : IValidator
+{
+    public static NullableDateTimeOffsetNotBeInRangeValidator New(
+        PrincipalChain<DateTimeOffset?> chain,
+        DateTimeOffset min,
+        DateTimeOffset max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableTimeOnlyBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableTimeOnlyBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable timeonly value is within the specified inclusive range.
+/// </summary>
+internal class NullableTimeOnlyBeInRangeValidator(
+    PrincipalChain<TimeOnly?> chain,
+    TimeOnly min,
+    TimeOnly max
+) : IValidator
+{
+    public static NullableTimeOnlyBeInRangeValidator New(
+        PrincipalChain<TimeOnly?> chain,
+        TimeOnly min,
+        TimeOnly max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.Value.IsBetween(min, max))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableTimeOnlyNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableTimeOnlyNotBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable timeonly value is outside the specified inclusive range.
+/// </summary>
+internal class NullableTimeOnlyNotBeInRangeValidator(
+    PrincipalChain<TimeOnly?> chain,
+    TimeOnly min,
+    TimeOnly max
+) : IValidator
+{
+    public static NullableTimeOnlyNotBeInRangeValidator New(
+        PrincipalChain<TimeOnly?> chain,
+        TimeOnly min,
+        TimeOnly max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!value.Value.IsBetween(min, max))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableTimeSpanBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableTimeSpanBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable timespan value is within the specified inclusive range.
+/// </summary>
+internal class NullableTimeSpanBeInRangeValidator(
+    PrincipalChain<TimeSpan?> chain,
+    TimeSpan min,
+    TimeSpan max
+) : IValidator
+{
+    public static NullableTimeSpanBeInRangeValidator New(
+        PrincipalChain<TimeSpan?> chain,
+        TimeSpan min,
+        TimeSpan max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableTimeSpanNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableTimeSpanNotBeInRangeValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable timespan value is outside the specified inclusive range.
+/// </summary>
+internal class NullableTimeSpanNotBeInRangeValidator(
+    PrincipalChain<TimeSpan?> chain,
+    TimeSpan min,
+    TimeSpan max
+) : IValidator
+{
+    public static NullableTimeSpanNotBeInRangeValidator New(
+        PrincipalChain<TimeSpan?> chain,
+        TimeSpan min,
+        TimeSpan max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/TimeOnlyNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/TimeOnlyNotBeInRangeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the timeonly value is outside the specified inclusive range.
+/// </summary>
+internal class TimeOnlyNotBeInRangeValidator(PrincipalChain<TimeOnly> chain, TimeOnly min, TimeOnly max) : IValidator
+{
+    public static TimeOnlyNotBeInRangeValidator New(PrincipalChain<TimeOnly> chain, TimeOnly min, TimeOnly max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().IsBetween(min, max))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/TimeSpanNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/TimeSpanNotBeInRangeValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the timespan value is outside the specified inclusive range.
+/// </summary>
+internal class TimeSpanNotBeInRangeValidator(
+    PrincipalChain<TimeSpan> chain,
+    TimeSpan min,
+    TimeSpan max
+) : IValidator
+{
+    public static TimeSpanNotBeInRangeValidator New(
+        PrincipalChain<TimeSpan> chain,
+        TimeSpan min,
+        TimeSpan max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -302,6 +302,7 @@ Manager: `TimeOnlyOperationsManager` / `NullableTimeOnlyOperationsManager`
 | `BeAfter(TimeOnly)` | After time |
 | `BeBefore(TimeOnly)` | Before time |
 | `BeInRange(TimeOnly, TimeOnly)` | Within range |
+| `NotBeInRange(TimeOnly, TimeOnly)` | Outside range |
 | `HaveHour(int)` | Specific hour |
 | `HaveMinute(int)` | Specific minute |
 | `HaveSecond(int)` | Specific second |
@@ -323,6 +324,7 @@ Manager: `TimeSpanOperationsManager` / `NullableTimeSpanOperationsManager`
 | `BeGreaterThan(TimeSpan)` | Longer than |
 | `BeLessThan(TimeSpan)` | Shorter than |
 | `BeInRange(TimeSpan, TimeSpan)` | Within range |
+| `NotBeInRange(TimeSpan, TimeSpan)` | Outside range |
 | `HaveDays(int)` | Specific days component |
 | `HaveHours(int)` | Specific hours component |
 | `HaveMinutes(int)` | Specific minutes component |


### PR DESCRIPTION
(feat): add BeInRange/NotBeInRange for nullable date/time types and NotBeInRange for TimeSpan/TimeOnly

  Complete BeInRange/NotBeInRange coverage across all date and time types.

  Changes:
  - Add NotBeInRange to TimeSpanOperationsManager and TimeOnlyOperationsManager
  - Add BeInRange/NotBeInRange to NullableDateTimeOperationsManager, NullableDateOnlyOperationsManager, NullableDateTimeOffsetOperationsManager, NullableTimeSpanOperationsManager, and NullableTimeOnlyOperationsManager
  - Create 12 new validators for all new operations
  - Add NotBeInRange enum values to Operations.TimeSpan and Operations.TimeOnly
  - Fix NotBeEquivalentTo/NotBeSequenceEqualTo null handling: remove overly aggressive FailIf guard that blocked valid null-vs-non-null comparisons
  - Update docs/API.md with new operations in TimeSpan and TimeOnly sections