### PR TITLE
Add NullableEnumOperationsManager for nullable enum validation

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -1085,6 +1085,18 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for nullable enum values (used with <c>NullableEnumOperationsManager&lt;T&gt;</c>).
+    /// </summary>
+    public enum NullableEnum
+    {
+        [EnumStringValue("havevalueenum")]
+        HaveValue,
+
+        [EnumStringValue("nothavevalueenum")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="System.Uri"/> values.
     /// </summary>
     public enum Uri

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableEnumOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableEnumOperationsManager.cs
@@ -1,0 +1,394 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>T?</c> nullable enum values.
+/// Supports value presence, null-checking, equality, flag, definition, and membership validations.
+/// </summary>
+public class NullableEnumOperationsManager<T>
+    : BaseNullableOperationsManager<NullableEnumOperationsManager<T>, T?>,
+        ITestManager<NullableEnumOperationsManager<T>, T?>
+    where T : struct, Enum
+{
+    /// <inheritdoc />
+    public PrincipalChain<T?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified nullable enum value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableEnumOperationsManager(T? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<T?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable enum has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableEnum.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumHaveValueValidator<T>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable enum is <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableEnum.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumNotHaveValueValidator<T>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            PrincipalChain.GetValue()?.ToString() ?? "<null>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> Be(T? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> NotBe(T? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumNotBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is a defined member of the <typeparamref name="T"/> enum type.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> BeDefined(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.BeDefined))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumBeDefinedValidator<T>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            typeof(T).Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDefined)} operation failed because the value was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="expected"/> values.
+    /// </summary>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> BeOneOf(params T[] expected)
+    {
+        return BeOneOf(null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="expected"/> values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> BeOneOf(Reason? reason, params T[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumBeOneOfValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the value was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="expected"/> values.
+    /// </summary>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> NotBeOneOf(params T[] expected)
+    {
+        return NotBeOneOf(null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="expected"/> values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> NotBeOneOf(Reason? reason, params T[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumNotBeOneOfValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e)))
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the value was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value has the specified <paramref name="flag"/> set
+    /// (for <c>[Flags]</c> enums).
+    /// </summary>
+    /// <param name="flag">The flag to check for.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> HaveFlag(T flag, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.HaveFlag))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumHaveFlagValidator<T>.New(PrincipalChain, flag))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(flag)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveFlag)} operation failed because the value was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not have the specified <paramref name="flag"/> set
+    /// (for <c>[Flags]</c> enums).
+    /// </summary>
+    /// <param name="flag">The flag that must not be set.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableEnumOperationsManager<T> NotHaveFlag(T flag, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Enum.NotHaveFlag))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableEnumOperationsManager<T>, T?>
+            .New(this)
+            .WithOperation(NullableEnumNotHaveFlagValidator<T>.New(PrincipalChain, flag))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(flag)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveFlag)} operation failed because the value was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -220,6 +220,11 @@ internal class PropertyProxy<TProp, TManager>(
                 var defaultVal = Activator.CreateInstance(enumType)!;
                 return (TManager)Activator.CreateInstance(typeof(TManager), defaultVal, propertyName)!;
             }
+
+            if (genericDef == typeof(NullableEnumOperationsManager<>))
+            {
+                return (TManager)Activator.CreateInstance(typeof(TManager), (object?)null, propertyName)!;
+            }
         }
 
         return (TManager)(object)new ObjectOperationsManager(null, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForAdvanced.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForAdvanced.cs
@@ -74,6 +74,71 @@ public abstract partial class QualityBlueprint<T>
     }
 
     /// <summary>
+    /// Defines a validation rule for a nullable enum property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable enum assertions.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type of the property. Must be a struct and derive from <see cref="Enum"/>.</typeparam>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable enum property to validate (e.g., <c>x =&gt; x.Status</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableEnumOperationsManager{TEnum}"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableEnumOperationsManager<TEnum>> ForEnum<TEnum>(
+        Expression<Func<T, TEnum?>> propertyExpression
+    )
+        where TEnum : struct, Enum
+    {
+        var propertyName = GetPropertyName(propertyExpression);
+        var valueExtractor = propertyExpression.Compile();
+        _extractors[propertyName] = x => valueExtractor(x);
+        var currentScenario = _currentScenario;
+        RuleCaptureContext.BeginPropertyCapture(
+            _capturedDuringDefinition,
+            propertyName,
+            currentScenario
+        );
+        RuleCaptureContext.SetRuleConfig(null);
+        return new PropertyProxy<TEnum?, NullableEnumOperationsManager<TEnum>>(
+            propertyName,
+            _capturedDuringDefinition,
+            () => currentScenario,
+            caller => new NullableEnumOperationsManager<TEnum>(null, caller)
+        );
+    }
+
+    /// <summary>
+    /// Defines a validation rule for a nullable enum property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type of the property. Must be a struct and derive from <see cref="Enum"/>.</typeparam>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable enum property to validate (e.g., <c>x =&gt; x.Status</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableEnumOperationsManager{TEnum}"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableEnumOperationsManager<TEnum>> ForEnum<TEnum>(
+        Expression<Func<T, TEnum?>> propertyExpression,
+        RuleConfig config
+    )
+        where TEnum : struct, Enum
+    {
+        var propertyName = GetPropertyName(propertyExpression);
+        var valueExtractor = propertyExpression.Compile();
+        _extractors[propertyName] = x => valueExtractor(x);
+        var currentScenario = _currentScenario;
+        RuleCaptureContext.BeginPropertyCapture(
+            _capturedDuringDefinition,
+            propertyName,
+            currentScenario
+        );
+        RuleCaptureContext.SetRuleConfig(config);
+        return new PropertyProxy<TEnum?, NullableEnumOperationsManager<TEnum>>(
+            propertyName,
+            _capturedDuringDefinition,
+            () => currentScenario,
+            caller => new NullableEnumOperationsManager<TEnum>(null, caller)
+        );
+    }
+
+    /// <summary>
     /// Defines a cross-property validation rule that compares one property against another on the same model.
     /// Use the returned manager to assert relational constraints (e.g., StartDate &lt; EndDate).
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/TestExtension.SpecialTypes.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.SpecialTypes.cs
@@ -85,6 +85,26 @@ public static partial class TestExtension
     }
 
     /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable enum value.
+    /// </summary>
+    /// <typeparam name="T">The enum type to test. Must be a struct and derive from <see cref="Enum"/>.</typeparam>
+    /// <param name="value">The nullable enum value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableEnumOperationsManager{T}"/> for chaining nullable enum-specific assertions.</returns>
+    [Pure]
+    public static NullableEnumOperationsManager<T> TestEnum<T>(
+        this T? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+        where T : struct, Enum
+    {
+        return new NullableEnumOperationsManager<T>(value, callerName);
+    }
+
+    /// <summary>
     /// Begins a fluent assertion chain for the specified nullable <see cref="Uri"/> value.
     /// </summary>
     /// <param name="value">The Uri value to test. Can be null.</param>

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeDefinedValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeDefinedValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value is a defined member of the enumeration.
+/// </summary>
+internal class NullableEnumBeDefinedValidator<T>(PrincipalChain<T?> chain) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumBeDefinedValidator<T> New(PrincipalChain<T?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (Enum.IsDefined(typeof(T), chain.GetValue()!.Value))
+        {
+            return true;
+        }
+
+        ResultValidation = "The value {0} is not a defined member of enum {1}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value is one of the specified allowed values.
+/// </summary>
+internal class NullableEnumBeOneOfValidator<T>(PrincipalChain<T?> chain, params T[] expected) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumBeOneOfValidator<T> New(PrincipalChain<T?> chain, params T[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+        if (value.HasValue && expected.Contains(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumBeValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value equals the expected value.
+/// </summary>
+internal class NullableEnumBeValidator<T>(PrincipalChain<T?> chain, T? expected) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumBeValidator<T> New(PrincipalChain<T?> chain, T? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (EqualityComparer<T?>.Default.Equals(chain.GetValue(), expected))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumHaveFlagValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumHaveFlagValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value has the expected flag set.
+/// </summary>
+internal class NullableEnumHaveFlagValidator<T>(PrincipalChain<T?> chain, T flag) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumHaveFlagValidator<T> New(PrincipalChain<T?> chain, T flag) =>
+        new(chain, flag);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue()!.Value.HasFlag(flag))
+        {
+            return true;
+        }
+
+        ResultValidation = "The value {0} was expected to have the flag {1}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumHaveValueValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum has a value (is not null).
+/// </summary>
+internal class NullableEnumHaveValueValidator<T>(PrincipalChain<T?> chain) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumHaveValueValidator<T> New(PrincipalChain<T?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to have a value, but it was <null>.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableEnumNotBeOneOfValidator<T>(PrincipalChain<T?> chain, params T[] expected) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumNotBeOneOfValidator<T> New(PrincipalChain<T?> chain, params T[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+        if (!value.HasValue || !expected.Contains(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}].";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotBeValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value does not equal the expected value.
+/// </summary>
+internal class NullableEnumNotBeValidator<T>(PrincipalChain<T?> chain, T? expected) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumNotBeValidator<T> New(PrincipalChain<T?> chain, T? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!EqualityComparer<T?>.Default.Equals(chain.GetValue(), expected))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotHaveFlagValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotHaveFlagValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum value does not have the expected flag set.
+/// </summary>
+internal class NullableEnumNotHaveFlagValidator<T>(PrincipalChain<T?> chain, T flag) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumNotHaveFlagValidator<T> New(PrincipalChain<T?> chain, T flag) =>
+        new(chain, flag);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue()!.Value.HasFlag(flag))
+        {
+            return true;
+        }
+
+        ResultValidation = "The value {0} was expected to not have the flag {1}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableEnumNotHaveValueValidator.cs
@@ -1,0 +1,32 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable enum does not have a value (is null).
+/// </summary>
+internal class NullableEnumNotHaveValueValidator<T>(PrincipalChain<T?> chain) : IValidator
+    where T : struct, Enum
+{
+    public static NullableEnumNotHaveValueValidator<T> New(PrincipalChain<T?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not have a value, but it was {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -455,6 +455,26 @@ Manager: `EnumOperationsManager<T>` (via `.TestEnum<T>()`)
 
 ---
 
+### Nullable Enum Validations
+
+Manager: `NullableEnumOperationsManager<T>` (via `.TestEnum<T>()` on `T?`)
+
+| Method | Description |
+|--------|-------------|
+| `HaveValue()` | Has a non-null value |
+| `NotHaveValue()` | Is null |
+| `Be(T?)` | Equals expected (supports null) |
+| `NotBe(T?)` | Does not equal (supports null) |
+| `BeDefined()` | Is a defined enum value (null guard) |
+| `BeOneOf(params T[])` | In set (null guard) |
+| `NotBeOneOf(params T[])` | Not in set (null guard) |
+| `HaveFlag(T)` | Has flag (for `[Flags]`) (null guard) |
+| `NotHaveFlag(T)` | Does not have flag (null guard) |
+| `BeNull()` | Is null (inherited) |
+| `NotBeNull()` | Is not null (inherited) |
+
+---
+
 ### Uri Validations
 
 Manager: `UriOperationsManager`


### PR DESCRIPTION
Add NullableEnumOperationsManager for nullable enum validation support

  Add complete validation support for nullable enum types (T? where T : struct, Enum),
  the only generic type that was missing a nullable counterpart.

  Changes:
  - Create NullableEnumOperationsManager<T> with 9 operations: HaveValue, NotHaveValue, Be, NotBe, BeDefined, BeOneOf, NotBeOneOf, HaveFlag, NotHaveFlag
  - Create 9 validators with where T : struct, Enum constraint
  - Add Operations.NullableEnum enum with HaveValue/NotHaveValue
  - Add TestEnum<T>(this T?) extension in TestExtension.SpecialTypes.cs
  - Register NullableEnumOperationsManager<> in PropertyProxy generic type switch
  - Add ForEnum<TEnum>(Expression<Func<T, TEnum?>>) overloads to QualityBlueprint
  - Update docs/API.md with Nullable Enum Validations section