### PR TITLE
Add Be/NotBe and BeOfType/NotBeOfType to managers

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -46,6 +46,12 @@ public struct Operations
 
         [EnumStringValue("notbeequivalentto")]
         NotBeEquivalentTo,
+
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
     }
 
     /// <summary>
@@ -974,6 +980,12 @@ public struct Operations
 
         [EnumStringValue("havelengthlessthan")]
         HaveLengthLessThan,
+
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
     }
 
     /// <summary>
@@ -989,6 +1001,12 @@ public struct Operations
 
         [EnumStringValue("havelengthlessthan")]
         HaveLengthLessThan,
+
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
     }
 
     /// <summary>
@@ -1019,6 +1037,12 @@ public struct Operations
 
         [EnumStringValue("notbeempty")]
         NotBeEmpty,
+
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
     }
 
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -34,6 +34,156 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
     }
 
     /// <summary>
+    /// Asserts that the array is the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected array/collection reference.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> Be(IEnumerable<T> expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Array.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(Be)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the array is not the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The collection reference that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotBe(IEnumerable<T> expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Array.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBe)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the array is exactly <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The expected runtime type.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> BeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the array is exactly <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected runtime type.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> BeOfType(Type expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        ValidateBeOfTypeOperation(reason, expected);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the array is not <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The type that should not match.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotBeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateNotBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the array is not <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The type that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotBeOfType(Type expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        ValidateNotBeOfTypeOperation(reason, expected);
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the array has exactly the specified number of elements.
     /// </summary>
     /// <param name="expected">The expected element count. Must be non-negative.</param>
@@ -1915,4 +2065,76 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
             PrincipalChain.GetSubject()
         );
     }
+
+    #region PRIVATE METHODS
+
+    private void ValidateBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceBeOfTypeValidator<IEnumerable<T>>.New(PrincipalChain, type!))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the array was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    private void ValidateNotBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                ReferenceNotBeOfTypeValidator<IEnumerable<T>>.New(PrincipalChain, type!)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the array was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    #endregion
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -24,18 +24,171 @@ public class CollectionOperationsManager<T>
     /// <summary>
     /// Initializes a new instance for testing the specified collection.
     /// </summary>
-    /// <param name="value">The collection value to test. Materialized eagerly to avoid multiple enumeration. Null is accepted and deferred to FailIf guards.</param>
+    /// <param name="value">The collection value to test.
+    /// Already-materialized collections (ICollection&lt;T&gt;) are stored as-is, preserving their original reference.
+    /// Lazy enumerables (LINQ queries, yield return, IQueryable) are materialized once to avoid multiple enumeration.
+    /// Null is accepted and deferred to FailIf guards.</param>
     /// <param name="caller">The caller expression name, captured automatically.</param>
     public CollectionOperationsManager(IEnumerable<T> value, string caller)
     {
-        var materialized = value switch
-                           {
-                               null => null,
-                               ICollection<T> col => col.ToList(),
-                               _ => value.ToList()
-                           };
-        PrincipalChain = PrincipalChain<IEnumerable<T>>.Get(materialized!, caller);
+        var safeValue = value switch
+        {
+            null => null,
+            ICollection<T> => value,
+            _ => value.ToList()
+        };
+        PrincipalChain = PrincipalChain<IEnumerable<T>>.Get(safeValue!, caller);
         GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the collection is the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected collection reference.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> Be(IEnumerable<T> expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(Be)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the collection is not the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The collection reference that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotBe(IEnumerable<T> expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotBeValidator<T>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBe)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the collection is exactly <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The expected runtime type.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> BeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the collection is exactly <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected runtime type.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> BeOfType(Type expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        ValidateBeOfTypeOperation(reason, expected);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the collection is not <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The type that should not match.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotBeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateNotBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the collection is not <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The type that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotBeOfType(Type expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        ValidateNotBeOfTypeOperation(reason, expected);
+        return this;
     }
 
     /// <summary>
@@ -1937,4 +2090,76 @@ public class CollectionOperationsManager<T>
             PrincipalChain.GetSubject()
         );
     }
+
+    #region PRIVATE METHODS
+
+    private void ValidateBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceBeOfTypeValidator<IEnumerable<T>>.New(PrincipalChain, type!))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the collection was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    private void ValidateNotBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                ReferenceNotBeOfTypeValidator<IEnumerable<T>>.New(PrincipalChain, type!)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the collection was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    #endregion
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/DictionaryOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DictionaryOperationsManager.cs
@@ -33,6 +33,165 @@ public class DictionaryOperationsManager<TKey, TValue>
     }
 
     /// <summary>
+    /// Asserts that the dictionary is the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected dictionary reference.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> Be(
+        IDictionary<TKey, TValue> expected,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Dictionary.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(DictionaryBeValidator<TKey, TValue>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(Be)} operation failed because the dictionary was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the dictionary is not the same reference as <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The dictionary reference that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> NotBe(
+        IDictionary<TKey, TValue> expected,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Dictionary.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(DictionaryNotBeValidator<TKey, TValue>.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotBe)} operation failed because the dictionary was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the dictionary is exactly <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The expected runtime type.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> BeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the dictionary is exactly <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected runtime type.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> BeOfType(Type expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeOfType))
+        {
+            return this;
+        }
+
+        ValidateBeOfTypeOperation(reason, expected);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the dictionary is not <typeparamref name="TType"/>.
+    /// </summary>
+    /// <typeparam name="TType">The type that should not match.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> NotBeOfType<TType>(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        var type = typeof(TType);
+        ValidateNotBeOfTypeOperation(reason, type);
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the runtime type of the dictionary is not <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The type that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> NotBeOfType(
+        Type expected,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeOfType))
+        {
+            return this;
+        }
+
+        ValidateNotBeOfTypeOperation(reason, expected);
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the dictionary contains an entry with the specified key.
     /// </summary>
     /// <param name="key">The key expected to be present in the dictionary.</param>
@@ -408,4 +567,81 @@ public class DictionaryOperationsManager<TKey, TValue>
             PrincipalChain.GetSubject()
         );
     }
+
+    #region PRIVATE METHODS
+
+    private void ValidateBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(
+                ReferenceBeOfTypeValidator<IDictionary<TKey, TValue>>.New(PrincipalChain, type!)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(BeOfType)} operation failed because the dictionary was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    private void ValidateNotBeOfTypeOperation(Reason? reason, Type? type)
+    {
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(
+                ReferenceNotBeOfTypeValidator<IDictionary<TKey, TValue>>.New(
+                    PrincipalChain,
+                    type!
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        type is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the expected type was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotBeOfType)} operation failed because the dictionary was <null>."
+                        )
+                    )
+            )
+            .Execute();
+    }
+
+    #endregion
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/ObjectOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ObjectOperationsManager.cs
@@ -3,6 +3,7 @@ using JAAvila.FluentOperations.Comparators;
 using JAAvila.FluentOperations.Config;
 using JAAvila.FluentOperations.Connector;
 using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
 using JAAvila.FluentOperations.Model;
 using JAAvila.FluentOperations.Utils;
 using JAAvila.FluentOperations.Validators;
@@ -121,6 +122,66 @@ public class ObjectOperationsManager
                     template
                         .WithSubject(PrincipalChain.GetSubject())
                         .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the object equals <paramref name="expected"/> using <see cref="object.Equals(object?, object?)"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ObjectOperationsManager Be(object? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ObjectOperationsManager, object?>
+            .New(this)
+            .WithOperation(ObjectBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the object does not equal <paramref name="expected"/> using <see cref="object.Equals(object?, object?)"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ObjectOperationsManager NotBe(object? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ObjectOperationsManager, object?>
+            .New(this)
+            .WithOperation(ObjectNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
                         .WithReason(reason?.ToString())
             )
             .Execute();

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionBeValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection reference equals the expected reference (reference equality).
+/// </summary>
+internal class CollectionBeValidator<T>(PrincipalChain<IEnumerable<T>> chain, IEnumerable<T> expected)
+    : IValidator
+{
+    public static CollectionBeValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        IEnumerable<T> expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (ReferenceEquals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting collection was expected to be the same reference as {0}, but a different reference was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotBeValidator.cs
@@ -1,0 +1,39 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection reference does not equal the expected reference (reference equality).
+/// </summary>
+internal class CollectionNotBeValidator<T>(
+    PrincipalChain<IEnumerable<T>> chain,
+    IEnumerable<T> expected
+) : IValidator
+{
+    public static CollectionNotBeValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        IEnumerable<T> expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!ReferenceEquals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting collection was expected to not be the same reference as {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/DictionaryBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DictionaryBeValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the dictionary reference equals the expected reference (reference equality).
+/// </summary>
+internal class DictionaryBeValidator<TKey, TValue>(
+    PrincipalChain<IDictionary<TKey, TValue>> chain,
+    IDictionary<TKey, TValue> expected
+) : IValidator
+    where TKey : notnull
+{
+    public static DictionaryBeValidator<TKey, TValue> New(
+        PrincipalChain<IDictionary<TKey, TValue>> chain,
+        IDictionary<TKey, TValue> expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (ReferenceEquals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting dictionary was expected to be the same reference as {0}, but a different reference was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/DictionaryNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DictionaryNotBeValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the dictionary reference does not equal the expected reference (reference equality).
+/// </summary>
+internal class DictionaryNotBeValidator<TKey, TValue>(
+    PrincipalChain<IDictionary<TKey, TValue>> chain,
+    IDictionary<TKey, TValue> expected
+) : IValidator
+    where TKey : notnull
+{
+    public static DictionaryNotBeValidator<TKey, TValue> New(
+        PrincipalChain<IDictionary<TKey, TValue>> chain,
+        IDictionary<TKey, TValue> expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!ReferenceEquals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting dictionary was expected to not be the same reference as {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ObjectBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ObjectBeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the object value equals the expected value using <see cref="object.Equals(object?, object?)"/>.
+/// </summary>
+internal class ObjectBeValidator(PrincipalChain<object?> chain, object? expected) : IValidator
+{
+    public static ObjectBeValidator New(PrincipalChain<object?> chain, object? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Equals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ObjectNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ObjectNotBeValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the object value does not equal the expected value using <see cref="object.Equals(object?, object?)"/>.
+/// </summary>
+internal class ObjectNotBeValidator(PrincipalChain<object?> chain, object? expected) : IValidator
+{
+    public static ObjectNotBeValidator New(PrincipalChain<object?> chain, object? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!Equals(value, expected))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -389,6 +389,12 @@ Manager: `CollectionOperationsManager<T>`
 | `BeSequenceEqualTo(IEnumerable<T>)` | Same elements, same order |
 | `NotBeEquivalentTo(IEnumerable<T>)` | NOT same elements (any order) |
 | `NotBeSequenceEqualTo(IEnumerable<T>)` | NOT same elements/order |
+| `Be(IEnumerable<T>)` | Same reference as expected |
+| `NotBe(IEnumerable<T>)` | Not the same reference |
+| `BeOfType<TType>()` | Runtime type is exactly TType |
+| `BeOfType(Type)` | Runtime type is exactly the specified type |
+| `NotBeOfType<TType>()` | Runtime type is not TType |
+| `NotBeOfType(Type)` | Runtime type is not the specified type |
 
 ---
 
@@ -403,6 +409,12 @@ All Collection operations plus (including equivalence: `BeEquivalentTo`, `NotBeE
 | `HaveLength(int)` | Exact array length |
 | `HaveLengthGreaterThan(int)` | More than N |
 | `HaveLengthLessThan(int)` | Fewer than N |
+| `Be(IEnumerable<T>)` | Same reference as expected |
+| `NotBe(IEnumerable<T>)` | Not the same reference |
+| `BeOfType<TType>()` | Runtime type is exactly TType |
+| `BeOfType(Type)` | Runtime type is exactly the specified type |
+| `NotBeOfType<TType>()` | Runtime type is not TType |
+| `NotBeOfType(Type)` | Runtime type is not the specified type |
 
 ---
 
@@ -420,6 +432,12 @@ Manager: `DictionaryOperationsManager<TKey, TValue>`
 | `HaveCount(int)` | Exact count |
 | `BeEmpty()` | No entries |
 | `NotBeEmpty()` | Has entries |
+| `Be(IDictionary<TKey, TValue>)` | Same reference as expected |
+| `NotBe(IDictionary<TKey, TValue>)` | Not the same reference |
+| `BeOfType<TType>()` | Runtime type is exactly TType |
+| `BeOfType(Type)` | Runtime type is exactly the specified type |
+| `NotBeOfType<TType>()` | Runtime type is not TType |
+| `NotBeOfType(Type)` | Runtime type is not the specified type |
 | `Which<TResult>(Func<IDictionary<TKey, TValue>, TResult>)` | Extract sub-value for chained assertions |
 
 ---
@@ -506,6 +524,8 @@ Manager: `ObjectOperationsManager` / `ReferenceOperationsManager`
 | `BeOfType<T>()` | Is exact type |
 | `BeCastTo<T>()` | Can be cast to type |
 | `Evaluate(Func<T, bool>)` | Custom predicate |
+| `Be(object?)` | Equals expected (using `Equals()`) |
+| `NotBe(object?)` | Does not equal expected |
 | `BeEquivalentTo(object)` | Deep structural equality |
 | `BeEquivalentTo(object, ComparisonOptions)` | Deep structural equality with options |
 | `NotBeEquivalentTo(object)` | Not structurally equal |


### PR DESCRIPTION
  Add equality and type-checking operations to managers that were missing them:

  - Object: Be/NotBe using Equals() comparison (handles null-null as equal)
  - Collection/Array/Dictionary: Be/NotBe using ReferenceEquals()
  - Collection/Array/Dictionary: BeOfType/NotBeOfType reusing existing ReferenceBeOfTypeValidator<TSubject> and ReferenceNotBeOfTypeValidator<TSubject>

  New files:
  - 6 validators: ObjectBeValidator, ObjectNotBeValidator, CollectionBeValidator, CollectionNotBeValidator, DictionaryBeValidator, DictionaryNotBeValidator
  - 1 test file: BeNotBeBeOfTypeTests.cs (180 tests covering all 6 pilares)

  Changes:
  - Operations.cs: Add Be/NotBe entries to Common, Collection, Array, Dictionary enums
  - ObjectOperationsManager: Add Be/NotBe methods (no FailIf null guard)
  - CollectionOperationsManager: Add Be/NotBe/BeOfType/NotBeOfType + fix constructor to preserve reference for ICollection<T> while materializing lazy enumerables
  - ArrayOperationsManager: Add Be/NotBe/BeOfType/NotBeOfType (reuses Collection validators)
  - DictionaryOperationsManager: Add Be/NotBe/BeOfType/NotBeOfType
  - API.md: Update Object, Collection, Array, Dictionary documentation tables