### PR TITLE
Add NotContainAny and NotContainAll operations to Collection and Array managers

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -906,6 +906,12 @@ public struct Operations
         [EnumStringValue("containany")]
         ContainAny,
 
+        [EnumStringValue("notcontainany")]
+        NotContainAny,
+
+        [EnumStringValue("notcontainall")]
+        NotContainAll,
+
         [EnumStringValue("besubsetof")]
         BeSubsetOf,
 

--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -1008,6 +1008,132 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
     }
 
     /// <summary>
+    /// Asserts that the array does not contain any of the specified items.
+    /// </summary>
+    /// <param name="items">The items that must all be absent from the array.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotContainAny(params T[] items)
+    {
+        return NotContainAny(null, items);
+    }
+
+    /// <summary>
+    /// Asserts that the array does not contain any of the specified items.
+    /// Fails if even one of the specified items is found in the array.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="items">The items that must all be absent from the array.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the array is <c>null</c> or if <paramref name="items"/> is <c>null</c>.
+    /// </remarks>
+    public ArrayOperationsManager<T> NotContainAny(Reason? reason, params T[] items)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainAny))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotContainAnyValidator<T>.New(PrincipalChain, items))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", items.Select(BaseFormatter.Format))
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAny)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        items.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAny)} operation failed because the items parameter cannot be null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the array does not contain all of the specified items simultaneously.
+    /// </summary>
+    /// <param name="items">The items that must not all be present in the array.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotContainAll(params T[] items)
+    {
+        return NotContainAll(null, items);
+    }
+
+    /// <summary>
+    /// Asserts that the array does not contain all of the specified items simultaneously.
+    /// At least one of the specified items must be absent from the array.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="items">The items that must not all be present simultaneously.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the array is <c>null</c> or if <paramref name="items"/> is <c>null</c>.
+    /// </remarks>
+    public ArrayOperationsManager<T> NotContainAll(Reason? reason, params T[] items)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainAll))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotContainAllValidator<T>.New(PrincipalChain, items))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", items.Select(BaseFormatter.Format))
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAll)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        items.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAll)} operation failed because the items parameter cannot be null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that every element in the array is also present in the specified superset.
     /// </summary>
     /// <param name="superset">The collection that must contain all elements of the tested array.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -856,6 +856,132 @@ public class CollectionOperationsManager<T>
     }
 
     /// <summary>
+    /// Asserts that the collection does not contain any of the specified items.
+    /// </summary>
+    /// <param name="items">The items that must all be absent from the collection.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotContainAny(params T[] items)
+    {
+        return NotContainAny(null, items);
+    }
+
+    /// <summary>
+    /// Asserts that the collection does not contain any of the specified items.
+    /// Fails if even one of the specified items is found in the collection.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="items">The items that must all be absent from the collection.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the collection is <c>null</c> or if <paramref name="items"/> is <c>null</c>.
+    /// </remarks>
+    public CollectionOperationsManager<T> NotContainAny(Reason? reason, params T[] items)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainAny))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotContainAnyValidator<T>.New(PrincipalChain, items))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", items.Select(BaseFormatter.Format))
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAny)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        items.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAny)} operation failed because the items parameter cannot be null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the collection does not contain all of the specified items simultaneously.
+    /// </summary>
+    /// <param name="items">The items that must not all be present in the collection.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotContainAll(params T[] items)
+    {
+        return NotContainAll(null, items);
+    }
+
+    /// <summary>
+    /// Asserts that the collection does not contain all of the specified items simultaneously.
+    /// At least one of the specified items must be absent from the collection.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="items">The items that must not all be present simultaneously.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the collection is <c>null</c> or if <paramref name="items"/> is <c>null</c>.
+    /// </remarks>
+    public CollectionOperationsManager<T> NotContainAll(Reason? reason, params T[] items)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainAll))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotContainAllValidator<T>.New(PrincipalChain, items))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", items.Select(BaseFormatter.Format))
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAll)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        items.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainAll)} operation failed because the items parameter cannot be null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that every element in the collection is also present in the specified superset.
     /// </summary>
     /// <param name="superset">The collection that must contain all elements of the tested collection.</param>

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainAllValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainAllValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection does not contain all of the specified items simultaneously.
+/// Passes if at least one of the expected items is missing from the collection.
+/// </summary>
+internal class CollectionNotContainAllValidator<T>(
+    PrincipalChain<IEnumerable<T>> chain,
+    params T[] expected
+) : IValidator
+{
+    public static CollectionNotContainAllValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        params T[] expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!expected.All(e => value.Contains(e)))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting collection was expected to not contain all of [{0}], but all were found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainAnyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainAnyValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection does not contain any of the specified items.
+/// Fails if even one of the expected items is found in the collection.
+/// </summary>
+internal class CollectionNotContainAnyValidator<T>(
+    PrincipalChain<IEnumerable<T>> chain,
+    params T[] expected
+) : IValidator
+{
+    public static CollectionNotContainAnyValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        params T[] expected
+    ) => new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (!expected.Any(e => value.Contains(e)))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting collection was expected to not contain any of [{0}], but at least one was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -370,6 +370,8 @@ Manager: `CollectionOperationsManager<T>`
 | `ContainSingle(Func<T, bool>)` | Exactly one element matching predicate |
 | `ContainAll(params T[])` | Contains all elements |
 | `ContainAny(params T[])` | Contains at least one |
+| `NotContainAny(params T[])` | Does not contain any of the specified items |
+| `NotContainAll(params T[])` | Does not contain all specified items simultaneously |
 | `ContainInOrder(params T[])` | Contains in specific order |
 | `HaveElementAt(int, T)` | Element at index |
 | `BeSubsetOf(IEnumerable)` | All elements in superset |
@@ -402,7 +404,7 @@ Manager: `CollectionOperationsManager<T>`
 
 Manager: `ArrayOperationsManager<T>`
 
-All Collection operations plus (including equivalence: `BeEquivalentTo`, `NotBeEquivalentTo`, `BeSequenceEqualTo`, `NotBeSequenceEqualTo`):
+All Collection operations plus (including equivalence: `BeEquivalentTo`, `NotBeEquivalentTo`, `BeSequenceEqualTo`, `NotBeSequenceEqualTo`, `NotContainAny`, `NotContainAll`):
 
 | Method | Description |
 |--------|-------------|


### PR DESCRIPTION
  Add two new collection validation operations as counterparts to ContainAny/ContainAll:

  - NotContainAny(params T[]): validates that none of the specified items are present in the collection. Fails if even one is found.
  - NotContainAll(params T[]): validates that not all specified items are present simultaneously. Passes if at least one is missing.

  New files:
  - 2 validators: CollectionNotContainAnyValidator<T>, CollectionNotContainAllValidator<T>
  - 1 test file: CollectionNotContainAnyAllTests.cs (84 tests covering all 6 pilares + chaining + null edge cases)

  Changes:
  - Operations.cs: Add NotContainAny and NotContainAll entries to Operations.Collection enum
  - CollectionOperationsManager: Add 4 methods (dual-overload pattern with params T[] delegating to Reason?, params T[])
  - ArrayOperationsManager: Add 4 methods reusing Collection validators
  - API.md: Update Collection and Array documentation tables