### PR TITLE
Add byte and nullable byte type support with validation operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -266,6 +266,69 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="byte"/> values.
+    /// </summary>
+    public enum Byte
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="byte?"/> (nullable byte) values.
+    /// </summary>
+    public enum NullableByte
+    {
+        [EnumStringValue("havevaluebyte")]
+        HaveValue,
+
+        [EnumStringValue("nothavevaluebyte")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="long"/> values.
     /// </summary>
     public enum Long

--- a/Distributed/JAAvila.FluentOperations/Manager/ByteOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ByteOperationsManager.cs
@@ -1,0 +1,563 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>byte</c> values.
+/// Supports equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>byte</c> is unsigned (0-255).
+/// </summary>
+public class ByteOperationsManager : ITestManager<ByteOperationsManager, byte>
+{
+    /// <inheritdoc />
+    public PrincipalChain<byte> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public ByteOperationsManager(byte value, string caller)
+    {
+        PrincipalChain = PrincipalChain<byte>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager Be(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager NotBe(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeGreaterThan(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeGreaterThanOrEqualTo(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeLessThan(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeLessThanOrEqualTo(byte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ByteOperationsManager BeInRange(byte min, byte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ByteOperationsManager NotBeInRange(byte min, byte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ByteOperationsManager BeOneOf(Reason? reason = null, params byte[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ByteOperationsManager NotBeOneOf(Reason? reason = null, params byte[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to check divisibility against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public ByteOperationsManager BeDivisibleBy(byte divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ByteOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ByteOperationsManager, byte>
+            .New(this)
+            .WithOperation(ByteBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableByteOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableByteOperationsManager.cs
@@ -1,0 +1,618 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>byte?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>byte</c> is unsigned (0-255).
+/// </summary>
+public class NullableByteOperationsManager
+    : BaseNullableOperationsManager<NullableByteOperationsManager, byte?>,
+        ITestManager<NullableByteOperationsManager, byte?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<byte?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableByteOperationsManager(byte? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<byte?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableByte.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableByte.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager Be(byte? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager NotBe(byte? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeGreaterThan(byte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeGreaterThanOrEqualTo(byte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(
+                NullableByteBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeLessThan(byte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeLessThanOrEqualTo(byte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeInRange(byte min, byte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager NotBeInRange(byte min, byte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeOneOf(params byte[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager NotBeOneOf(params byte[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to test against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeDivisibleBy(byte divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableByteOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Byte.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableByteOperationsManager, byte?>
+            .New(this)
+            .WithOperation(NullableByteBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -120,6 +120,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new FloatOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableByteOperationsManager))
+        {
+            return (TManager)(object)new NullableByteOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(ByteOperationsManager))
+        {
+            return (TManager)(object)new ByteOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(DateTimeOperationsManager))
         {
             return (TManager)(object)new DateTimeOperationsManager(default, propertyName);

--- a/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
@@ -238,4 +238,52 @@ public static partial class TestExtension
     {
         return new NullableFloatOperationsManager(value, callerName);
     }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="byte"/> value.
+    /// </summary>
+    /// <param name="value">The byte value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="ByteOperationsManager"/> for chaining byte-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// byte age = 25;
+    /// age.Test().BePositive().BeLessThan(128);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static ByteOperationsManager Test(
+        this byte value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new ByteOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="byte"/> value.
+    /// </summary>
+    /// <param name="value">The nullable byte value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableByteOperationsManager"/> for chaining nullable byte-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// byte? channel = null;
+    /// channel.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableByteOperationsManager Test(
+        this byte? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableByteOperationsManager(value, callerName);
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is evenly divisible by the specified divisor.
+/// </summary>
+internal class ByteBeDivisibleByValidator(PrincipalChain<byte> chain, byte divisor) : IValidator
+{
+    public static ByteBeDivisibleByValidator New(PrincipalChain<byte> chain, byte divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is even.
+/// </summary>
+internal class ByteBeEvenValidator(PrincipalChain<byte> chain) : IValidator
+{
+    public static ByteBeEvenValidator New(PrincipalChain<byte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is greater than or equal to the expected value.
+/// </summary>
+internal class ByteBeGreaterThanOrEqualToValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteBeGreaterThanOrEqualToValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is greater than the expected value.
+/// </summary>
+internal class ByteBeGreaterThanValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteBeGreaterThanValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is within the specified inclusive range.
+/// </summary>
+internal class ByteBeInRangeValidator(PrincipalChain<byte> chain, byte min, byte max) : IValidator
+{
+    public static ByteBeInRangeValidator New(PrincipalChain<byte> chain, byte min, byte max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is less than or equal to the expected value.
+/// </summary>
+internal class ByteBeLessThanOrEqualToValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteBeLessThanOrEqualToValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is less than the expected value.
+/// </summary>
+internal class ByteBeLessThanValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteBeLessThanValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is odd.
+/// </summary>
+internal class ByteBeOddValidator(PrincipalChain<byte> chain) : IValidator
+{
+    public static ByteBeOddValidator New(PrincipalChain<byte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is one of the specified allowed values.
+/// </summary>
+internal class ByteBeOneOfValidator(PrincipalChain<byte> chain, params byte[] expected) : IValidator
+{
+    public static ByteBeOneOfValidator New(PrincipalChain<byte> chain, params byte[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is strictly positive (greater than zero).
+/// </summary>
+internal class ByteBePositiveValidator(PrincipalChain<byte> chain) : IValidator
+{
+    public static ByteBePositiveValidator New(PrincipalChain<byte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value equals the expected value.
+/// </summary>
+internal class ByteBeValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteBeValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is zero.
+/// </summary>
+internal class ByteBeZeroValidator(PrincipalChain<byte> chain) : IValidator
+{
+    public static ByteBeZeroValidator New(PrincipalChain<byte> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is outside the specified inclusive range.
+/// </summary>
+internal class ByteNotBeInRangeValidator(PrincipalChain<byte> chain, byte min, byte max)
+    : IValidator
+{
+    public static ByteNotBeInRangeValidator New(PrincipalChain<byte> chain, byte min, byte max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value is not one of the specified disallowed values.
+/// </summary>
+internal class ByteNotBeOneOfValidator(PrincipalChain<byte> chain, params byte[] expected) : IValidator
+{
+    public static ByteNotBeOneOfValidator New(PrincipalChain<byte> chain, params byte[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ByteNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the byte value does not equal the expected value.
+/// </summary>
+internal class ByteNotBeValidator(PrincipalChain<byte> chain, byte expected) : IValidator
+{
+    public static ByteNotBeValidator New(PrincipalChain<byte> chain, byte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableByteBeDivisibleByValidator(PrincipalChain<byte?> chain, byte divisor)
+    : IValidator
+{
+    public static NullableByteBeDivisibleByValidator New(
+        PrincipalChain<byte?> chain,
+        byte divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableByteBeGreaterThanOrEqualToValidator(
+    PrincipalChain<byte?> chain,
+    byte comparison
+) : IValidator
+{
+    public static NullableByteBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<byte?> chain,
+        byte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is greater than the expected value.
+/// </summary>
+internal class NullableByteBeGreaterThanValidator(PrincipalChain<byte?> chain, byte comparison)
+    : IValidator
+{
+    public static NullableByteBeGreaterThanValidator New(
+        PrincipalChain<byte?> chain,
+        byte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is within the specified inclusive range.
+/// </summary>
+internal class NullableByteBeInRangeValidator(PrincipalChain<byte?> chain, byte min, byte max)
+    : IValidator
+{
+    public static NullableByteBeInRangeValidator New(
+        PrincipalChain<byte?> chain,
+        byte min,
+        byte max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is less than or equal to the expected value.
+/// </summary>
+internal class NullableByteBeLessThanOrEqualToValidator(
+    PrincipalChain<byte?> chain,
+    byte comparison
+) : IValidator
+{
+    public static NullableByteBeLessThanOrEqualToValidator New(
+        PrincipalChain<byte?> chain,
+        byte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is less than the expected value.
+/// </summary>
+internal class NullableByteBeLessThanValidator(PrincipalChain<byte?> chain, byte comparison)
+    : IValidator
+{
+    public static NullableByteBeLessThanValidator New(
+        PrincipalChain<byte?> chain,
+        byte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is odd.
+/// </summary>
+internal class NullableByteBeOddValidator(PrincipalChain<byte?> chain) : IValidator
+{
+    public static NullableByteBeOddValidator New(PrincipalChain<byte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is one of the specified allowed values.
+/// </summary>
+internal class NullableByteBeOneOfValidator(PrincipalChain<byte?> chain, byte[] values)
+    : IValidator
+{
+    public static NullableByteBeOneOfValidator New(PrincipalChain<byte?> chain, byte[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is strictly positive.
+/// </summary>
+internal class NullableByteBePositiveValidator(PrincipalChain<byte?> chain) : IValidator
+{
+    public static NullableByteBePositiveValidator New(PrincipalChain<byte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value equals the expected value.
+/// </summary>
+internal class NullableByteBeValidator(PrincipalChain<byte?> chain, byte? expected) : IValidator
+{
+    public static NullableByteBeValidator New(PrincipalChain<byte?> chain, byte? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte has a value (is not null).
+/// </summary>
+internal class NullableByteHaveValueValidator(PrincipalChain<byte?> chain) : IValidator
+{
+    public static NullableByteHaveValueValidator New(PrincipalChain<byte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is outside the specified inclusive range.
+/// </summary>
+internal class NullableByteNotBeInRangeValidator(PrincipalChain<byte?> chain, byte min, byte max)
+    : IValidator
+{
+    public static NullableByteNotBeInRangeValidator New(
+        PrincipalChain<byte?> chain,
+        byte min,
+        byte max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableByteNotBeOneOfValidator(PrincipalChain<byte?> chain, byte[] values)
+    : IValidator
+{
+    public static NullableByteNotBeOneOfValidator New(
+        PrincipalChain<byte?> chain,
+        byte[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte value does not equal the expected value.
+/// </summary>
+internal class NullableByteNotBeValidator(PrincipalChain<byte?> chain, byte? expected) : IValidator
+{
+    public static NullableByteNotBeValidator New(PrincipalChain<byte?> chain, byte? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableByteNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable byte does not have a value (is null).
+/// </summary>
+internal class NullableByteNotHaveValueValidator(PrincipalChain<byte?> chain) : IValidator
+{
+    public static NullableByteNotHaveValueValidator New(PrincipalChain<byte?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -203,6 +203,37 @@ Manager: `IntegerOperationsManager` / `NullableIntegerOperationsManager`
 
 ---
 
+### Byte Validations
+
+Manager: `ByteOperationsManager` / `NullableByteOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(byte)` | Equals expected |
+| `NotBe(byte)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(byte)` | Greater than value |
+| `BeGreaterThanOrEqualTo(byte)` | Greater than or equal |
+| `BeLessThan(byte)` | Less than value |
+| `BeLessThanOrEqualTo(byte)` | Less than or equal |
+| `BeInRange(byte, byte)` | Within inclusive range |
+| `NotBeInRange(byte, byte)` | Outside range |
+| `BeOneOf(params byte[])` | In set of values |
+| `NotBeOneOf(params byte[])` | Not in set |
+| `BeDivisibleBy(byte)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** `BeNegative()` is not available for `byte` because it is an unsigned type (range 0-255).
+
+**Nullable byte (`byte?`)** adds:
+- `HaveValue()` — has a non-null value
+- `NotHaveValue()` — is null
+- All byte operations above (with FailIf null guards)
+
+---
+
 ### Long Validations
 
 Manager: `LongOperationsManager` / `NullableLongOperationsManager`


### PR DESCRIPTION
  Add ByteOperationsManager (15 operations) and NullableByteOperationsManager
  (17 operations) following the established numeric type pattern. BeNegative()
  is intentionally excluded as byte is unsigned (0-255).

  Operations: Be, NotBe, BePositive, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 32 validators: 15 ByteXxxValidator + 17 NullableByteXxxValidator
  - 2 managers: ByteOperationsManager, NullableByteOperationsManager
  - 1 test file: ByteOperationsTests.cs (164 tests covering all 6 pilares)

  Changes:
  - Operations.cs: Add Operations.Byte (15 entries) and Operations.NullableByte (2 entries) enums
  - TestExtension.Numeric.cs: Add byte.Test() and byte?.Test() extensions
  - PropertyProxy.cs: Register ByteOperationsManager and NullableByteOperationsManager for Blueprint support
  - API.md: Add Byte Validations documentation section