### PR TITLE
Add sbyte and nullable sbyte type support with validation operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -329,6 +329,72 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="sbyte"/> values.
+    /// </summary>
+    public enum SByte
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("benegative")]
+        BeNegative,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="sbyte?"/> (nullable sbyte) values.
+    /// </summary>
+    public enum NullableSByte
+    {
+        [EnumStringValue("havevaluesbyte")]
+        HaveValue,
+
+        [EnumStringValue("nothavevaluesbyte")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="long"/> values.
     /// </summary>
     public enum Long

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableSByteOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableSByteOperationsManager.cs
@@ -1,0 +1,654 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>sbyte?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, sign, and membership validations.
+/// Unlike <c>byte?</c>, <c>BeNegative()</c> is included because <c>sbyte</c> is signed (-128 to 127).
+/// </summary>
+public class NullableSByteOperationsManager
+    : BaseNullableOperationsManager<NullableSByteOperationsManager, sbyte?>,
+        ITestManager<NullableSByteOperationsManager, sbyte?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<sbyte?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableSByteOperationsManager(sbyte? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<sbyte?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableSByte.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableSByte.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager Be(sbyte? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager NotBe(sbyte? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeNegative(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeNegative))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeNegativeValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeGreaterThan(sbyte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeGreaterThanOrEqualTo(sbyte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(
+                NullableSByteBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeLessThan(sbyte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeLessThanOrEqualTo(sbyte value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeInRange(sbyte min, sbyte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager NotBeInRange(sbyte min, sbyte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeOneOf(params sbyte[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager NotBeOneOf(params sbyte[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to test against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeDivisibleBy(sbyte divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableSByteOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableSByteOperationsManager, sbyte?>
+            .New(this)
+            .WithOperation(NullableSByteBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/SByteOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/SByteOperationsManager.cs
@@ -1,0 +1,593 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>sbyte</c> values.
+/// Supports equality, comparison, range, divisibility, parity, sign, and membership validations.
+/// Unlike <c>byte</c>, <c>BeNegative()</c> is included because <c>sbyte</c> is signed (-128 to 127).
+/// </summary>
+public class SByteOperationsManager : ITestManager<SByteOperationsManager, sbyte>
+{
+    /// <inheritdoc />
+    public PrincipalChain<sbyte> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public SByteOperationsManager(sbyte value, string caller)
+    {
+        PrincipalChain = PrincipalChain<sbyte>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager Be(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager NotBe(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly negative (less than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeNegative(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeNegative))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeNegativeValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeGreaterThan(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeGreaterThanOrEqualTo(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeLessThan(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeLessThanOrEqualTo(sbyte expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public SByteOperationsManager BeInRange(sbyte min, sbyte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public SByteOperationsManager NotBeInRange(sbyte min, sbyte max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public SByteOperationsManager BeOneOf(Reason? reason = null, params sbyte[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public SByteOperationsManager NotBeOneOf(Reason? reason = null, params sbyte[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to check divisibility against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public SByteOperationsManager BeDivisibleBy(sbyte divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public SByteOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.SByte.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<SByteOperationsManager, sbyte>
+            .New(this)
+            .WithOperation(SByteBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -130,6 +130,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new ByteOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableSByteOperationsManager))
+        {
+            return (TManager)(object)new NullableSByteOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(SByteOperationsManager))
+        {
+            return (TManager)(object)new SByteOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(DateTimeOperationsManager))
         {
             return (TManager)(object)new DateTimeOperationsManager(default, propertyName);

--- a/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
@@ -286,4 +286,52 @@ public static partial class TestExtension
     {
         return new NullableByteOperationsManager(value, callerName);
     }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="sbyte"/> value.
+    /// </summary>
+    /// <param name="value">The sbyte value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="SByteOperationsManager"/> for chaining sbyte-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// sbyte temperature = -10;
+    /// temperature.Test().BeNegative().BeLessThan(0);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static SByteOperationsManager Test(
+        this sbyte value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new SByteOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="sbyte"/> value.
+    /// </summary>
+    /// <param name="value">The nullable sbyte value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableSByteOperationsManager"/> for chaining nullable sbyte-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// sbyte? offset = null;
+    /// offset.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableSByteOperationsManager Test(
+        this sbyte? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableSByteOperationsManager(value, callerName);
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableSByteBeDivisibleByValidator(PrincipalChain<sbyte?> chain, sbyte divisor)
+    : IValidator
+{
+    public static NullableSByteBeDivisibleByValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableSByteBeGreaterThanOrEqualToValidator(
+    PrincipalChain<sbyte?> chain,
+    sbyte comparison
+) : IValidator
+{
+    public static NullableSByteBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is greater than the expected value.
+/// </summary>
+internal class NullableSByteBeGreaterThanValidator(PrincipalChain<sbyte?> chain, sbyte comparison)
+    : IValidator
+{
+    public static NullableSByteBeGreaterThanValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is within the specified inclusive range.
+/// </summary>
+internal class NullableSByteBeInRangeValidator(PrincipalChain<sbyte?> chain, sbyte min, sbyte max)
+    : IValidator
+{
+    public static NullableSByteBeInRangeValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte min,
+        sbyte max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is less than or equal to the expected value.
+/// </summary>
+internal class NullableSByteBeLessThanOrEqualToValidator(
+    PrincipalChain<sbyte?> chain,
+    sbyte comparison
+) : IValidator
+{
+    public static NullableSByteBeLessThanOrEqualToValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is less than the expected value.
+/// </summary>
+internal class NullableSByteBeLessThanValidator(PrincipalChain<sbyte?> chain, sbyte comparison)
+    : IValidator
+{
+    public static NullableSByteBeLessThanValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeNegativeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeNegativeValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is strictly negative.
+/// </summary>
+internal class NullableSByteBeNegativeValidator(PrincipalChain<sbyte?> chain) : IValidator
+{
+    public static NullableSByteBeNegativeValidator New(PrincipalChain<sbyte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be negative, but a non-negative value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is odd.
+/// </summary>
+internal class NullableSByteBeOddValidator(PrincipalChain<sbyte?> chain) : IValidator
+{
+    public static NullableSByteBeOddValidator New(PrincipalChain<sbyte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is one of the specified allowed values.
+/// </summary>
+internal class NullableSByteBeOneOfValidator(PrincipalChain<sbyte?> chain, sbyte[] values)
+    : IValidator
+{
+    public static NullableSByteBeOneOfValidator New(PrincipalChain<sbyte?> chain, sbyte[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is strictly positive.
+/// </summary>
+internal class NullableSByteBePositiveValidator(PrincipalChain<sbyte?> chain) : IValidator
+{
+    public static NullableSByteBePositiveValidator New(PrincipalChain<sbyte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value equals the expected value.
+/// </summary>
+internal class NullableSByteBeValidator(PrincipalChain<sbyte?> chain, sbyte? expected) : IValidator
+{
+    public static NullableSByteBeValidator New(PrincipalChain<sbyte?> chain, sbyte? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte has a value (is not null).
+/// </summary>
+internal class NullableSByteHaveValueValidator(PrincipalChain<sbyte?> chain) : IValidator
+{
+    public static NullableSByteHaveValueValidator New(PrincipalChain<sbyte?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is outside the specified inclusive range.
+/// </summary>
+internal class NullableSByteNotBeInRangeValidator(PrincipalChain<sbyte?> chain, sbyte min, sbyte max)
+    : IValidator
+{
+    public static NullableSByteNotBeInRangeValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte min,
+        sbyte max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableSByteNotBeOneOfValidator(PrincipalChain<sbyte?> chain, sbyte[] values)
+    : IValidator
+{
+    public static NullableSByteNotBeOneOfValidator New(
+        PrincipalChain<sbyte?> chain,
+        sbyte[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte value does not equal the expected value.
+/// </summary>
+internal class NullableSByteNotBeValidator(PrincipalChain<sbyte?> chain, sbyte? expected) : IValidator
+{
+    public static NullableSByteNotBeValidator New(PrincipalChain<sbyte?> chain, sbyte? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableSByteNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable sbyte does not have a value (is null).
+/// </summary>
+internal class NullableSByteNotHaveValueValidator(PrincipalChain<sbyte?> chain) : IValidator
+{
+    public static NullableSByteNotHaveValueValidator New(PrincipalChain<sbyte?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is evenly divisible by the specified divisor.
+/// </summary>
+internal class SByteBeDivisibleByValidator(PrincipalChain<sbyte> chain, sbyte divisor) : IValidator
+{
+    public static SByteBeDivisibleByValidator New(PrincipalChain<sbyte> chain, sbyte divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is even.
+/// </summary>
+internal class SByteBeEvenValidator(PrincipalChain<sbyte> chain) : IValidator
+{
+    public static SByteBeEvenValidator New(PrincipalChain<sbyte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is greater than or equal to the expected value.
+/// </summary>
+internal class SByteBeGreaterThanOrEqualToValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteBeGreaterThanOrEqualToValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is greater than the expected value.
+/// </summary>
+internal class SByteBeGreaterThanValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteBeGreaterThanValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is within the specified inclusive range.
+/// </summary>
+internal class SByteBeInRangeValidator(PrincipalChain<sbyte> chain, sbyte min, sbyte max) : IValidator
+{
+    public static SByteBeInRangeValidator New(PrincipalChain<sbyte> chain, sbyte min, sbyte max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is less than or equal to the expected value.
+/// </summary>
+internal class SByteBeLessThanOrEqualToValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteBeLessThanOrEqualToValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is less than the expected value.
+/// </summary>
+internal class SByteBeLessThanValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteBeLessThanValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeNegativeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeNegativeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is strictly negative (less than zero).
+/// </summary>
+internal class SByteBeNegativeValidator(PrincipalChain<sbyte> chain) : IValidator
+{
+    public static SByteBeNegativeValidator New(PrincipalChain<sbyte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be negative, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is odd.
+/// </summary>
+internal class SByteBeOddValidator(PrincipalChain<sbyte> chain) : IValidator
+{
+    public static SByteBeOddValidator New(PrincipalChain<sbyte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is one of the specified allowed values.
+/// </summary>
+internal class SByteBeOneOfValidator(PrincipalChain<sbyte> chain, params sbyte[] expected) : IValidator
+{
+    public static SByteBeOneOfValidator New(PrincipalChain<sbyte> chain, params sbyte[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is strictly positive (greater than zero).
+/// </summary>
+internal class SByteBePositiveValidator(PrincipalChain<sbyte> chain) : IValidator
+{
+    public static SByteBePositiveValidator New(PrincipalChain<sbyte> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value equals the expected value.
+/// </summary>
+internal class SByteBeValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteBeValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is zero.
+/// </summary>
+internal class SByteBeZeroValidator(PrincipalChain<sbyte> chain) : IValidator
+{
+    public static SByteBeZeroValidator New(PrincipalChain<sbyte> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is outside the specified inclusive range.
+/// </summary>
+internal class SByteNotBeInRangeValidator(PrincipalChain<sbyte> chain, sbyte min, sbyte max)
+    : IValidator
+{
+    public static SByteNotBeInRangeValidator New(PrincipalChain<sbyte> chain, sbyte min, sbyte max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value is not one of the specified disallowed values.
+/// </summary>
+internal class SByteNotBeOneOfValidator(PrincipalChain<sbyte> chain, params sbyte[] expected) : IValidator
+{
+    public static SByteNotBeOneOfValidator New(PrincipalChain<sbyte> chain, params sbyte[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/SByteNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the sbyte value does not equal the expected value.
+/// </summary>
+internal class SByteNotBeValidator(PrincipalChain<sbyte> chain, sbyte expected) : IValidator
+{
+    public static SByteNotBeValidator New(PrincipalChain<sbyte> chain, sbyte expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -234,6 +234,38 @@ Manager: `ByteOperationsManager` / `NullableByteOperationsManager`
 
 ---
 
+### SByte Validations
+
+Manager: `SByteOperationsManager` / `NullableSByteOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(sbyte)` | Equals expected |
+| `NotBe(sbyte)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeNegative()` | Less than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(sbyte)` | Greater than value |
+| `BeGreaterThanOrEqualTo(sbyte)` | Greater than or equal |
+| `BeLessThan(sbyte)` | Less than value |
+| `BeLessThanOrEqualTo(sbyte)` | Less than or equal |
+| `BeInRange(sbyte, sbyte)` | Within inclusive range |
+| `NotBeInRange(sbyte, sbyte)` | Outside range |
+| `BeOneOf(params sbyte[])` | In set of values |
+| `NotBeOneOf(params sbyte[])` | Not in set |
+| `BeDivisibleBy(sbyte)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** Unlike `byte`, `BeNegative()` IS available for `sbyte` because it is a signed type (range -128 to 127).
+
+**Nullable sbyte (`sbyte?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All sbyte operations above (with FailIf null guards)
+
+---
+
 ### Long Validations
 
 Manager: `LongOperationsManager` / `NullableLongOperationsManager`


### PR DESCRIPTION
  Add SByteOperationsManager (16 operations) and NullableSByteOperationsManager
  (18 operations) following the established numeric type pattern. Unlike byte,
  BeNegative() is included since sbyte is signed (-128 to 127).

  Operations: Be, NotBe, BePositive, BeNegative, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 34 validators: 16 SByteXxxValidator + 18 NullableSByteXxxValidator
  - 2 managers: SByteOperationsManager, NullableSByteOperationsManager
  - 1 test file: SByteOperationsTests.cs (183 tests covering all 6 pilares)

  Changes:
  - Operations.cs: Add Operations.SByte (16 entries) and Operations.NullableSByte (2 entries) enums
  - TestExtension.Numeric.cs: Add sbyte.Test() and sbyte?.Test() extensions
  - PropertyProxy.cs: Register SByteOperationsManager and NullableSByteOperationsManager for Blueprint support
  - API.md: Add SByte Validations documentation section