### PR TITLE
Add Char and Nullable Char type support with classification operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -395,6 +395,84 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="char"/> values.
+    /// </summary>
+    public enum Char
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("beuppercase")]
+        BeUpperCase,
+
+        [EnumStringValue("belowercase")]
+        BeLowerCase,
+
+        [EnumStringValue("bedigit")]
+        BeDigit,
+
+        [EnumStringValue("beletter")]
+        BeLetter,
+
+        [EnumStringValue("beletterordigit")]
+        BeLetterOrDigit,
+
+        [EnumStringValue("bewhitespace")]
+        BeWhiteSpace,
+
+        [EnumStringValue("bepunctuation")]
+        BePunctuation,
+
+        [EnumStringValue("becontrol")]
+        BeControl,
+
+        [EnumStringValue("beascii")]
+        BeAscii,
+
+        [EnumStringValue("besurrogate")]
+        BeSurrogate,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="char?"/> (nullable char) values.
+    /// </summary>
+    public enum NullableChar
+    {
+        [EnumStringValue("havevaluechar")]
+        HaveValue,
+
+        [EnumStringValue("nothavevaluechar")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="long"/> values.
     /// </summary>
     public enum Long

--- a/Distributed/JAAvila.FluentOperations/Manager/CharOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CharOperationsManager.cs
@@ -1,0 +1,699 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>char</c> values.
+/// Supports equality, comparison, range, membership, and character classification validations.
+/// Character classification operations use <see cref="System.Char"/> static methods.
+/// </summary>
+public class CharOperationsManager : ITestManager<CharOperationsManager, char>
+{
+    /// <inheritdoc />
+    public PrincipalChain<char> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public CharOperationsManager(char value, string caller)
+    {
+        PrincipalChain = PrincipalChain<char>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager Be(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager NotBe(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeGreaterThan(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeGreaterThanOrEqualTo(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeLessThan(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeLessThanOrEqualTo(char expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public CharOperationsManager BeInRange(char min, char max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public CharOperationsManager NotBeInRange(char min, char max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public CharOperationsManager BeOneOf(Reason? reason = null, params char[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public CharOperationsManager NotBeOneOf(Reason? reason = null, params char[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is an uppercase letter (using <see cref="char.IsUpper"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeUpperCase(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeUpperCase))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeUpperCaseValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a lowercase letter (using <see cref="char.IsLower"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeLowerCase(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLowerCase))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeLowerCaseValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a digit (using <see cref="char.IsDigit"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeDigit(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeDigit))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeDigitValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a letter (using <see cref="char.IsLetter"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeLetter(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLetter))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeLetterValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a letter or digit (using <see cref="char.IsLetterOrDigit"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeLetterOrDigit(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLetterOrDigit))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeLetterOrDigitValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a white-space character (using <see cref="char.IsWhiteSpace"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeWhiteSpace(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeWhiteSpace))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeWhiteSpaceValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a punctuation character (using <see cref="char.IsPunctuation"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BePunctuation(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BePunctuation))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBePunctuationValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a control character (using <see cref="char.IsControl"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeControl(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeControl))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeControlValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is an ASCII character (value less than 128).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeAscii(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeAscii))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeAsciiValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a surrogate character (using <see cref="char.IsSurrogate"/>).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CharOperationsManager BeSurrogate(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeSurrogate))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CharOperationsManager, char>
+            .New(this)
+            .WithOperation(CharBeSurrogateValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableCharOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableCharOperationsManager.cs
@@ -1,0 +1,839 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>char?</c> values.
+/// Supports value presence, equality, comparison, range, membership, and character classification validations.
+/// </summary>
+public class NullableCharOperationsManager
+    : BaseNullableOperationsManager<NullableCharOperationsManager, char?>,
+        ITestManager<NullableCharOperationsManager, char?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<char?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableCharOperationsManager(char? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<char?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableChar.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableChar.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager Be(char? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager NotBe(char? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeGreaterThan(char value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeGreaterThanOrEqualTo(char value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(
+                NullableCharBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeLessThan(char value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeLessThanOrEqualTo(char value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeInRange(char min, char max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager NotBeInRange(char min, char max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeOneOf(params char[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager NotBeOneOf(params char[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is an uppercase letter.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeUpperCase(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeUpperCase))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeUpperCaseValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeUpperCase)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a lowercase letter.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeLowerCase(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLowerCase))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeLowerCaseValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLowerCase)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a digit.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeDigit(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeDigit))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeDigitValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDigit)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a letter.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeLetter(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLetter))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeLetterValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLetter)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a letter or digit.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeLetterOrDigit(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeLetterOrDigit))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeLetterOrDigitValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLetterOrDigit)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a white-space character.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeWhiteSpace(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeWhiteSpace))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeWhiteSpaceValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeWhiteSpace)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a punctuation character.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BePunctuation(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BePunctuation))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBePunctuationValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePunctuation)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a control character.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeControl(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeControl))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeControlValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeControl)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is an ASCII character (value less than 128).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeAscii(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeAscii))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeAsciiValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeAscii)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the character is a surrogate character.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableCharOperationsManager BeSurrogate(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Char.BeSurrogate))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableCharOperationsManager, char?>
+            .New(this)
+            .WithOperation(NullableCharBeSurrogateValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeSurrogate)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -140,6 +140,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new SByteOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableCharOperationsManager))
+        {
+            return (TManager)(object)new NullableCharOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(CharOperationsManager))
+        {
+            return (TManager)(object)new CharOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(DateTimeOperationsManager))
         {
             return (TManager)(object)new DateTimeOperationsManager(default, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -383,6 +383,156 @@ public abstract partial class QualityBlueprint<T>
     ) => For<float?, NullableFloatOperationsManager>(propertyExpression, config);
 
     /// <summary>
+    /// Defines a validation rule for a <see cref="byte"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access byte assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the byte property to validate (e.g., <c>x =&gt; x.Channel</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="ByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ByteOperationsManager> For(
+        Expression<Func<T, byte>> propertyExpression
+    ) => For<byte, ByteOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="byte"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the byte property to validate (e.g., <c>x =&gt; x.Channel</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="ByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ByteOperationsManager> For(
+        Expression<Func<T, byte>> propertyExpression,
+        RuleConfig config
+    ) => For<byte, ByteOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="byte"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable byte assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable byte property to validate (e.g., <c>x =&gt; x.Channel</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableByteOperationsManager> For(
+        Expression<Func<T, byte?>> propertyExpression
+    ) => For<byte?, NullableByteOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="byte"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable byte property to validate (e.g., <c>x =&gt; x.Channel</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableByteOperationsManager> For(
+        Expression<Func<T, byte?>> propertyExpression,
+        RuleConfig config
+    ) => For<byte?, NullableByteOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for an <see cref="sbyte"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access sbyte assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the sbyte property to validate (e.g., <c>x =&gt; x.Temperature</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="SByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<SByteOperationsManager> For(
+        Expression<Func<T, sbyte>> propertyExpression
+    ) => For<sbyte, SByteOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for an <see cref="sbyte"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the sbyte property to validate (e.g., <c>x =&gt; x.Temperature</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="SByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<SByteOperationsManager> For(
+        Expression<Func<T, sbyte>> propertyExpression,
+        RuleConfig config
+    ) => For<sbyte, SByteOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="sbyte"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable sbyte assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable sbyte property to validate (e.g., <c>x =&gt; x.Temperature</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableSByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableSByteOperationsManager> For(
+        Expression<Func<T, sbyte?>> propertyExpression
+    ) => For<sbyte?, NullableSByteOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="sbyte"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable sbyte property to validate (e.g., <c>x =&gt; x.Temperature</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableSByteOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableSByteOperationsManager> For(
+        Expression<Func<T, sbyte?>> propertyExpression,
+        RuleConfig config
+    ) => For<sbyte?, NullableSByteOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="char"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access char assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the char property to validate (e.g., <c>x =&gt; x.Grade</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="CharOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<CharOperationsManager> For(
+        Expression<Func<T, char>> propertyExpression
+    ) => For<char, CharOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="char"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the char property to validate (e.g., <c>x =&gt; x.Grade</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="CharOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<CharOperationsManager> For(
+        Expression<Func<T, char>> propertyExpression,
+        RuleConfig config
+    ) => For<char, CharOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="char"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable char assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable char property to validate (e.g., <c>x =&gt; x.Grade</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableCharOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableCharOperationsManager> For(
+        Expression<Func<T, char?>> propertyExpression
+    ) => For<char?, NullableCharOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="char"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable char property to validate (e.g., <c>x =&gt; x.Grade</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableCharOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableCharOperationsManager> For(
+        Expression<Func<T, char?>> propertyExpression,
+        RuleConfig config
+    ) => For<char?, NullableCharOperationsManager>(propertyExpression, config);
+
+    /// <summary>
     /// Defines a validation rule for a nullable <see cref="int"/> property of the model.
     /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable integer assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -840,6 +840,110 @@ public abstract partial class QualityBlueprint<T>
         RuleConfig config
     ) => ForTransform<Uri?, UriOperationsManager>(propertyExpression, transform, config);
 
+    // Same-type ForTransform shortcuts for byte, sbyte, char (+ nullables)
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="byte"/> property.
+    /// </summary>
+    protected IPropertyProxy<ByteOperationsManager> ForTransform(
+        Expression<Func<T, byte>> propertyExpression,
+        Func<byte, byte> transform
+    ) => ForTransform<byte, ByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="byte"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ByteOperationsManager> ForTransform(
+        Expression<Func<T, byte>> propertyExpression,
+        Func<byte, byte> transform,
+        RuleConfig config
+    ) => ForTransform<byte, ByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="byte"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableByteOperationsManager> ForTransform(
+        Expression<Func<T, byte?>> propertyExpression,
+        Func<byte?, byte?> transform
+    ) => ForTransform<byte?, NullableByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="byte"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableByteOperationsManager> ForTransform(
+        Expression<Func<T, byte?>> propertyExpression,
+        Func<byte?, byte?> transform,
+        RuleConfig config
+    ) => ForTransform<byte?, NullableByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for an <see cref="sbyte"/> property.
+    /// </summary>
+    protected IPropertyProxy<SByteOperationsManager> ForTransform(
+        Expression<Func<T, sbyte>> propertyExpression,
+        Func<sbyte, sbyte> transform
+    ) => ForTransform<sbyte, SByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for an <see cref="sbyte"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<SByteOperationsManager> ForTransform(
+        Expression<Func<T, sbyte>> propertyExpression,
+        Func<sbyte, sbyte> transform,
+        RuleConfig config
+    ) => ForTransform<sbyte, SByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="sbyte"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableSByteOperationsManager> ForTransform(
+        Expression<Func<T, sbyte?>> propertyExpression,
+        Func<sbyte?, sbyte?> transform
+    ) => ForTransform<sbyte?, NullableSByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="sbyte"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableSByteOperationsManager> ForTransform(
+        Expression<Func<T, sbyte?>> propertyExpression,
+        Func<sbyte?, sbyte?> transform,
+        RuleConfig config
+    ) => ForTransform<sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="char"/> property.
+    /// </summary>
+    protected IPropertyProxy<CharOperationsManager> ForTransform(
+        Expression<Func<T, char>> propertyExpression,
+        Func<char, char> transform
+    ) => ForTransform<char, CharOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="char"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<CharOperationsManager> ForTransform(
+        Expression<Func<T, char>> propertyExpression,
+        Func<char, char> transform,
+        RuleConfig config
+    ) => ForTransform<char, CharOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="char"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableCharOperationsManager> ForTransform(
+        Expression<Func<T, char?>> propertyExpression,
+        Func<char?, char?> transform
+    ) => ForTransform<char?, NullableCharOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="char"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableCharOperationsManager> ForTransform(
+        Expression<Func<T, char?>> propertyExpression,
+        Func<char?, char?> transform,
+        RuleConfig config
+    ) => ForTransform<char?, NullableCharOperationsManager>(propertyExpression, transform, config);
+
     // -------------------------------------------------------------------------
     // Cross-type ForTransform shortcuts (Phase 2: 15 target types x 2 = 30 methods)
     // The source type TProp is inferred from the property expression.
@@ -1292,4 +1396,108 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, ActionStats?> transform,
         RuleConfig config
     ) => ForTransform<TProp, ActionStats?, ActionStatsOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type ForTransform shortcuts for byte, sbyte, char (+ nullables)
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="byte"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<ByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, byte> transform
+    ) => ForTransform<TProp, byte, ByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="byte"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, byte> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, byte, ByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="byte"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, byte?> transform
+    ) => ForTransform<TProp, byte?, NullableByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="byte"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, byte?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, byte?, NullableByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="sbyte"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<SByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, sbyte> transform
+    ) => ForTransform<TProp, sbyte, SByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="sbyte"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<SByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, sbyte> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, sbyte, SByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="sbyte"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableSByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, sbyte?> transform
+    ) => ForTransform<TProp, sbyte?, NullableSByteOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="sbyte"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableSByteOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, sbyte?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="char"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<CharOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, char> transform
+    ) => ForTransform<TProp, char, CharOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="char"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<CharOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, char> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, char, CharOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="char"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableCharOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, char?> transform
+    ) => ForTransform<TProp, char?, NullableCharOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="char"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableCharOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, char?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, char?, NullableCharOperationsManager>(propertyExpression, transform, config);
 }

--- a/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
@@ -334,4 +334,52 @@ public static partial class TestExtension
     {
         return new NullableSByteOperationsManager(value, callerName);
     }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="char"/> value.
+    /// </summary>
+    /// <param name="value">The char value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="CharOperationsManager"/> for chaining char-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// char letter = 'A';
+    /// letter.Test().BeUpperCase().BeLetter();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static CharOperationsManager Test(
+        this char value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new CharOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="char"/> value.
+    /// </summary>
+    /// <param name="value">The nullable char value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableCharOperationsManager"/> for chaining nullable char-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// char? initial = null;
+    /// initial.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableCharOperationsManager Test(
+        this char? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableCharOperationsManager(value, callerName);
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeAsciiValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeAsciiValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is an ASCII character (value less than 128).
+/// </summary>
+internal class CharBeAsciiValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeAsciiValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < 128)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be an ASCII character (< 128), but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeControlValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeControlValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a control character.
+/// </summary>
+internal class CharBeControlValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeControlValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsControl(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a control character, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeDigitValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeDigitValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a digit character.
+/// </summary>
+internal class CharBeDigitValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeDigitValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsDigit(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a digit, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is greater than or equal to the expected value.
+/// </summary>
+internal class CharBeGreaterThanOrEqualToValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharBeGreaterThanOrEqualToValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is greater than the expected value.
+/// </summary>
+internal class CharBeGreaterThanValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharBeGreaterThanValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is within the specified inclusive range.
+/// </summary>
+internal class CharBeInRangeValidator(PrincipalChain<char> chain, char min, char max) : IValidator
+{
+    public static CharBeInRangeValidator New(PrincipalChain<char> chain, char min, char max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is less than or equal to the expected value.
+/// </summary>
+internal class CharBeLessThanOrEqualToValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharBeLessThanOrEqualToValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is less than the expected value.
+/// </summary>
+internal class CharBeLessThanValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharBeLessThanValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeLetterOrDigitValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeLetterOrDigitValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a letter or digit.
+/// </summary>
+internal class CharBeLetterOrDigitValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeLetterOrDigitValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsLetterOrDigit(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a letter or digit, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeLetterValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeLetterValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a letter.
+/// </summary>
+internal class CharBeLetterValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeLetterValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsLetter(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a letter, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeLowerCaseValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeLowerCaseValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a lowercase letter.
+/// </summary>
+internal class CharBeLowerCaseValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeLowerCaseValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsLower(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a lowercase letter, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is one of the specified allowed values.
+/// </summary>
+internal class CharBeOneOfValidator(PrincipalChain<char> chain, params char[] expected) : IValidator
+{
+    public static CharBeOneOfValidator New(PrincipalChain<char> chain, params char[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBePunctuationValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBePunctuationValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a punctuation character.
+/// </summary>
+internal class CharBePunctuationValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBePunctuationValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsPunctuation(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a punctuation character, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeSurrogateValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeSurrogateValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a surrogate character.
+/// </summary>
+internal class CharBeSurrogateValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeSurrogateValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsSurrogate(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a surrogate character, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeUpperCaseValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeUpperCaseValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is an uppercase letter.
+/// </summary>
+internal class CharBeUpperCaseValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeUpperCaseValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsUpper(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be an uppercase letter, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value equals the expected value.
+/// </summary>
+internal class CharBeValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharBeValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharBeWhiteSpaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharBeWhiteSpaceValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is a white-space character.
+/// </summary>
+internal class CharBeWhiteSpaceValidator(PrincipalChain<char> chain) : IValidator
+{
+    public static CharBeWhiteSpaceValidator New(PrincipalChain<char> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (char.IsWhiteSpace(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be a white-space character, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is outside the specified inclusive range.
+/// </summary>
+internal class CharNotBeInRangeValidator(PrincipalChain<char> chain, char min, char max)
+    : IValidator
+{
+    public static CharNotBeInRangeValidator New(PrincipalChain<char> chain, char min, char max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value is not one of the specified disallowed values.
+/// </summary>
+internal class CharNotBeOneOfValidator(PrincipalChain<char> chain, params char[] expected) : IValidator
+{
+    public static CharNotBeOneOfValidator New(PrincipalChain<char> chain, params char[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CharNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CharNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the char value does not equal the expected value.
+/// </summary>
+internal class CharNotBeValidator(PrincipalChain<char> chain, char expected) : IValidator
+{
+    public static CharNotBeValidator New(PrincipalChain<char> chain, char expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeAsciiValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeAsciiValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is an ASCII character (value less than 128).
+/// </summary>
+internal class NullableCharBeAsciiValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeAsciiValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && value.Value < 128)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be an ASCII character (< 128), but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeControlValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeControlValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a control character.
+/// </summary>
+internal class NullableCharBeControlValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeControlValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsControl(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a control character, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeDigitValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeDigitValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a digit character.
+/// </summary>
+internal class NullableCharBeDigitValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeDigitValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsDigit(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a digit, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableCharBeGreaterThanOrEqualToValidator(PrincipalChain<char?> chain, char comparison)
+    : IValidator
+{
+    public static NullableCharBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<char?> chain,
+        char comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is greater than the expected value.
+/// </summary>
+internal class NullableCharBeGreaterThanValidator(PrincipalChain<char?> chain, char comparison)
+    : IValidator
+{
+    public static NullableCharBeGreaterThanValidator New(
+        PrincipalChain<char?> chain,
+        char comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is within the specified inclusive range.
+/// </summary>
+internal class NullableCharBeInRangeValidator(PrincipalChain<char?> chain, char min, char max)
+    : IValidator
+{
+    public static NullableCharBeInRangeValidator New(
+        PrincipalChain<char?> chain,
+        char min,
+        char max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is less than or equal to the expected value.
+/// </summary>
+internal class NullableCharBeLessThanOrEqualToValidator(PrincipalChain<char?> chain, char comparison)
+    : IValidator
+{
+    public static NullableCharBeLessThanOrEqualToValidator New(
+        PrincipalChain<char?> chain,
+        char comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is less than the expected value.
+/// </summary>
+internal class NullableCharBeLessThanValidator(PrincipalChain<char?> chain, char comparison)
+    : IValidator
+{
+    public static NullableCharBeLessThanValidator New(
+        PrincipalChain<char?> chain,
+        char comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLetterOrDigitValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLetterOrDigitValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a letter or digit.
+/// </summary>
+internal class NullableCharBeLetterOrDigitValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeLetterOrDigitValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsLetterOrDigit(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a letter or digit, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLetterValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLetterValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a letter.
+/// </summary>
+internal class NullableCharBeLetterValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeLetterValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsLetter(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a letter, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLowerCaseValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeLowerCaseValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a lowercase letter.
+/// </summary>
+internal class NullableCharBeLowerCaseValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeLowerCaseValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsLower(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a lowercase letter, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is one of the specified allowed values.
+/// </summary>
+internal class NullableCharBeOneOfValidator(PrincipalChain<char?> chain, char[] values)
+    : IValidator
+{
+    public static NullableCharBeOneOfValidator New(PrincipalChain<char?> chain, char[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBePunctuationValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBePunctuationValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a punctuation character.
+/// </summary>
+internal class NullableCharBePunctuationValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBePunctuationValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsPunctuation(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a punctuation character, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeSurrogateValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeSurrogateValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a surrogate character.
+/// </summary>
+internal class NullableCharBeSurrogateValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeSurrogateValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsSurrogate(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a surrogate character, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeUpperCaseValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeUpperCaseValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is an uppercase letter.
+/// </summary>
+internal class NullableCharBeUpperCaseValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeUpperCaseValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsUpper(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be an uppercase letter, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value equals the expected value.
+/// </summary>
+internal class NullableCharBeValidator(PrincipalChain<char?> chain, char? expected) : IValidator
+{
+    public static NullableCharBeValidator New(PrincipalChain<char?> chain, char? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeWhiteSpaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharBeWhiteSpaceValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is a white-space character.
+/// </summary>
+internal class NullableCharBeWhiteSpaceValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharBeWhiteSpaceValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value.HasValue && char.IsWhiteSpace(value.Value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be a white-space character, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char has a value (is not null).
+/// </summary>
+internal class NullableCharHaveValueValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharHaveValueValidator New(PrincipalChain<char?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is outside the specified inclusive range.
+/// </summary>
+internal class NullableCharNotBeInRangeValidator(PrincipalChain<char?> chain, char min, char max)
+    : IValidator
+{
+    public static NullableCharNotBeInRangeValidator New(
+        PrincipalChain<char?> chain,
+        char min,
+        char max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableCharNotBeOneOfValidator(PrincipalChain<char?> chain, char[] values)
+    : IValidator
+{
+    public static NullableCharNotBeOneOfValidator New(
+        PrincipalChain<char?> chain,
+        char[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char value does not equal the expected value.
+/// </summary>
+internal class NullableCharNotBeValidator(PrincipalChain<char?> chain, char? expected) : IValidator
+{
+    public static NullableCharNotBeValidator New(PrincipalChain<char?> chain, char? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableCharNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable char does not have a value (is null).
+/// </summary>
+internal class NullableCharNotHaveValueValidator(PrincipalChain<char?> chain) : IValidator
+{
+    public static NullableCharNotHaveValueValidator New(PrincipalChain<char?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,7 @@ Complete API documentation for JAAvila.FluentOperations.
   - [Decimal](#decimal-validations)
   - [Double](#double-validations)
   - [Float](#float-validations)
+  - [Char](#char-validations)
   - [DateTime](#datetime-validations)
   - [DateOnly](#dateonly-validations)
   - [TimeOnly](#timeonly-validations)
@@ -263,6 +264,42 @@ Manager: `SByteOperationsManager` / `NullableSByteOperationsManager`
 - `HaveValue()` -- has a non-null value
 - `NotHaveValue()` -- is null
 - All sbyte operations above (with FailIf null guards)
+
+---
+
+### Char Validations
+
+Manager: `CharOperationsManager` / `NullableCharOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(char)` | Equals expected |
+| `NotBe(char)` | Does not equal |
+| `BeGreaterThan(char)` | Greater than value |
+| `BeGreaterThanOrEqualTo(char)` | Greater than or equal |
+| `BeLessThan(char)` | Less than value |
+| `BeLessThanOrEqualTo(char)` | Less than or equal |
+| `BeInRange(char, char)` | Within inclusive range |
+| `NotBeInRange(char, char)` | Outside range |
+| `BeOneOf(params char[])` | In set of values |
+| `NotBeOneOf(params char[])` | Not in set |
+| `BeUpperCase()` | Is uppercase letter (`char.IsUpper`) |
+| `BeLowerCase()` | Is lowercase letter (`char.IsLower`) |
+| `BeDigit()` | Is digit (`char.IsDigit`) |
+| `BeLetter()` | Is letter (`char.IsLetter`) |
+| `BeLetterOrDigit()` | Is letter or digit (`char.IsLetterOrDigit`) |
+| `BeWhiteSpace()` | Is white-space (`char.IsWhiteSpace`) |
+| `BePunctuation()` | Is punctuation (`char.IsPunctuation`) |
+| `BeControl()` | Is control character (`char.IsControl`) |
+| `BeAscii()` | Is ASCII (value < 128) |
+| `BeSurrogate()` | Is surrogate (`char.IsSurrogate`) |
+
+> **Note:** Character classification operations use `System.Char` static methods. Numeric-only operations (BePositive, BeNegative, BeZero, BeDivisibleBy, BeEven, BeOdd) are intentionally excluded because `char` represents characters, not numbers.
+
+**Nullable char (`char?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All char operations above (with FailIf null guards)
 
 ---
 


### PR DESCRIPTION
  Add CharOperationsManager (20 operations) and NullableCharOperationsManager
  (22 operations). Unlike numeric types, char gets 10 unique character
  classification operations instead of numeric-only operations (no BePositive,
  BeNegative, BeZero, BeDivisibleBy, BeEven, BeOdd).

  Operations:
  - Equality & comparison: Be, NotBe, BeGreaterThan, BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo
  - Range & membership: BeInRange, NotBeInRange, BeOneOf, NotBeOneOf
  - Character classification: BeUpperCase, BeLowerCase, BeDigit, BeLetter, BeLetterOrDigit, BeWhiteSpace, BePunctuation, BeControl, BeAscii, BeSurrogate
  - Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards)

  New files:
  - 42 validators: 20 CharXxxValidator + 22 NullableCharXxxValidator
  - 2 managers: CharOperationsManager, NullableCharOperationsManager

  Changes:
  - Operations.cs: Add Operations.Char (20 entries) and Operations.NullableChar (2 entries) enums
  - TestExtension.Numeric.cs: Add char.Test() and char?.Test() extensions
  - PropertyProxy.cs: Register CharOperationsManager and NullableCharOperationsManager for Blueprint support
  - QualityBlueprint.For.cs: Add dedicated For() overloads for char and char? to prevent implicit int conversion from selecting IntegerOperationsManager
  - QualityBlueprint.ForTransform.cs: Add 12 ForTransform shortcuts (6 same-type + 6 cross-type) for char and char? to eliminate explicit generic type parameters
  - API.md: Add Char Validations documentation section