### PR TITLE
Add support for Short and NullableShort types with validation operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -395,6 +395,72 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="short"/> values.
+    /// </summary>
+    public enum Short
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("benegative")]
+        BeNegative,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="short?"/> (nullable short) values.
+    /// </summary>
+    public enum NullableShort
+    {
+        [EnumStringValue("havevalueshort")]
+        HaveValue,
+
+        [EnumStringValue("nothavevalueshort")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="char"/> values.
     /// </summary>
     public enum Char

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableShortOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableShortOperationsManager.cs
@@ -1,0 +1,654 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>short?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, sign, and membership validations.
+/// Unlike <c>ushort?</c>, <c>BeNegative()</c> is included because <c>short</c> is signed (-32768 to 32767).
+/// </summary>
+public class NullableShortOperationsManager
+    : BaseNullableOperationsManager<NullableShortOperationsManager, short?>,
+        ITestManager<NullableShortOperationsManager, short?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<short?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableShortOperationsManager(short? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<short?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableShort.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableShort.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager Be(short? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager NotBe(short? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeNegative(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeNegative))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeNegativeValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeGreaterThan(short value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeGreaterThanOrEqualTo(short value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(
+                NullableShortBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeLessThan(short value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeLessThanOrEqualTo(short value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeInRange(short min, short max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager NotBeInRange(short min, short max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeOneOf(params short[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager NotBeOneOf(params short[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to test against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeDivisibleBy(short divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableShortOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableShortOperationsManager, short?>
+            .New(this)
+            .WithOperation(NullableShortBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/ShortOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ShortOperationsManager.cs
@@ -1,0 +1,593 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>short</c> values.
+/// Supports equality, comparison, range, divisibility, parity, sign, and membership validations.
+/// Unlike <c>ushort</c>, <c>BeNegative()</c> is included because <c>short</c> is signed (-32768 to 32767).
+/// </summary>
+public class ShortOperationsManager : ITestManager<ShortOperationsManager, short>
+{
+    /// <inheritdoc />
+    public PrincipalChain<short> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public ShortOperationsManager(short value, string caller)
+    {
+        PrincipalChain = PrincipalChain<short>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager Be(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager NotBe(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly negative (less than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeNegative(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeNegative))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeNegativeValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeGreaterThan(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeGreaterThanOrEqualTo(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeLessThan(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeLessThanOrEqualTo(short expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ShortOperationsManager BeInRange(short min, short max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ShortOperationsManager NotBeInRange(short min, short max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ShortOperationsManager BeOneOf(Reason? reason = null, params short[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ShortOperationsManager NotBeOneOf(Reason? reason = null, params short[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to check divisibility against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public ShortOperationsManager BeDivisibleBy(short divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ShortOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Short.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ShortOperationsManager, short>
+            .New(this)
+            .WithOperation(ShortBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -140,6 +140,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new SByteOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableShortOperationsManager))
+        {
+            return (TManager)(object)new NullableShortOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(ShortOperationsManager))
+        {
+            return (TManager)(object)new ShortOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(NullableCharOperationsManager))
         {
             return (TManager)(object)new NullableCharOperationsManager(null, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -483,6 +483,56 @@ public abstract partial class QualityBlueprint<T>
     ) => For<sbyte?, NullableSByteOperationsManager>(propertyExpression, config);
 
     /// <summary>
+    /// Defines a validation rule for a <see cref="short"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access short assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the short property to validate (e.g., <c>x =&gt; x.Quantity</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="ShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ShortOperationsManager> For(
+        Expression<Func<T, short>> propertyExpression
+    ) => For<short, ShortOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="short"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the short property to validate (e.g., <c>x =&gt; x.Quantity</c>).
+    /// </param>
+    /// <param name="config">Configuration for severity, error code, custom message, or cascade mode.</param>
+    /// <returns>A property proxy that exposes <see cref="ShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ShortOperationsManager> For(
+        Expression<Func<T, short>> propertyExpression,
+        RuleConfig config
+    ) => For<short, ShortOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="short"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable short assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable short property to validate (e.g., <c>x =&gt; x.Quantity</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableShortOperationsManager> For(
+        Expression<Func<T, short?>> propertyExpression
+    ) => For<short?, NullableShortOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="short"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable short property to validate (e.g., <c>x =&gt; x.Quantity</c>).
+    /// </param>
+    /// <param name="config">Configuration for severity, error code, custom message, or cascade mode.</param>
+    /// <returns>A property proxy that exposes <see cref="NullableShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableShortOperationsManager> For(
+        Expression<Func<T, short?>> propertyExpression,
+        RuleConfig config
+    ) => For<short?, NullableShortOperationsManager>(propertyExpression, config);
+
+    /// <summary>
     /// Defines a validation rule for a <see cref="char"/> property of the model.
     /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access char assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -911,6 +911,40 @@ public abstract partial class QualityBlueprint<T>
     ) => ForTransform<sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
 
     /// <summary>
+    /// Registers a same-type transformation for a <see cref="short"/> property.
+    /// </summary>
+    protected IPropertyProxy<ShortOperationsManager> ForTransform(
+        Expression<Func<T, short>> propertyExpression,
+        Func<short, short> transform
+    ) => ForTransform<short, ShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="short"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ShortOperationsManager> ForTransform(
+        Expression<Func<T, short>> propertyExpression,
+        Func<short, short> transform,
+        RuleConfig config
+    ) => ForTransform<short, ShortOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="short"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableShortOperationsManager> ForTransform(
+        Expression<Func<T, short?>> propertyExpression,
+        Func<short?, short?> transform
+    ) => ForTransform<short?, NullableShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="short"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableShortOperationsManager> ForTransform(
+        Expression<Func<T, short?>> propertyExpression,
+        Func<short?, short?> transform,
+        RuleConfig config
+    ) => ForTransform<short?, NullableShortOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
     /// Registers a same-type transformation for a <see cref="char"/> property.
     /// </summary>
     protected IPropertyProxy<CharOperationsManager> ForTransform(
@@ -1466,6 +1500,40 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, sbyte?> transform,
         RuleConfig config
     ) => ForTransform<TProp, sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="short"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<ShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, short> transform
+    ) => ForTransform<TProp, short, ShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="short"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, short> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, short, ShortOperationsManager>(propertyExpression, transform, config);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="short"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, short?> transform
+    ) => ForTransform<TProp, short?, NullableShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="short"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, short?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, short?, NullableShortOperationsManager>(propertyExpression, transform, config);
 
     /// <summary>
     /// Registers a property with a cross-type transformation to <see cref="char"/> applied before validation.

--- a/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.Numeric.cs
@@ -336,6 +336,54 @@ public static partial class TestExtension
     }
 
     /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="short"/> value.
+    /// </summary>
+    /// <param name="value">The short value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="ShortOperationsManager"/> for chaining short-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// short temperature = -100;
+    /// temperature.Test().BeNegative().BeLessThan(0);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static ShortOperationsManager Test(
+        this short value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new ShortOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="short"/> value.
+    /// </summary>
+    /// <param name="value">The nullable short value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableShortOperationsManager"/> for chaining nullable short-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// short? offset = null;
+    /// offset.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableShortOperationsManager Test(
+        this short? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableShortOperationsManager(value, callerName);
+    }
+
+    /// <summary>
     /// Begins a fluent assertion chain for the specified <see cref="char"/> value.
     /// </summary>
     /// <param name="value">The char value to test.</param>

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableShortBeDivisibleByValidator(PrincipalChain<short?> chain, short divisor)
+    : IValidator
+{
+    public static NullableShortBeDivisibleByValidator New(
+        PrincipalChain<short?> chain,
+        short divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableShortBeGreaterThanOrEqualToValidator(
+    PrincipalChain<short?> chain,
+    short comparison
+) : IValidator
+{
+    public static NullableShortBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<short?> chain,
+        short comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is greater than the expected value.
+/// </summary>
+internal class NullableShortBeGreaterThanValidator(PrincipalChain<short?> chain, short comparison)
+    : IValidator
+{
+    public static NullableShortBeGreaterThanValidator New(
+        PrincipalChain<short?> chain,
+        short comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is within the specified inclusive range.
+/// </summary>
+internal class NullableShortBeInRangeValidator(PrincipalChain<short?> chain, short min, short max)
+    : IValidator
+{
+    public static NullableShortBeInRangeValidator New(
+        PrincipalChain<short?> chain,
+        short min,
+        short max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is less than or equal to the expected value.
+/// </summary>
+internal class NullableShortBeLessThanOrEqualToValidator(
+    PrincipalChain<short?> chain,
+    short comparison
+) : IValidator
+{
+    public static NullableShortBeLessThanOrEqualToValidator New(
+        PrincipalChain<short?> chain,
+        short comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is less than the expected value.
+/// </summary>
+internal class NullableShortBeLessThanValidator(PrincipalChain<short?> chain, short comparison)
+    : IValidator
+{
+    public static NullableShortBeLessThanValidator New(
+        PrincipalChain<short?> chain,
+        short comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeNegativeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeNegativeValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is strictly negative.
+/// </summary>
+internal class NullableShortBeNegativeValidator(PrincipalChain<short?> chain) : IValidator
+{
+    public static NullableShortBeNegativeValidator New(PrincipalChain<short?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be negative, but a non-negative value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is odd.
+/// </summary>
+internal class NullableShortBeOddValidator(PrincipalChain<short?> chain) : IValidator
+{
+    public static NullableShortBeOddValidator New(PrincipalChain<short?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is one of the specified allowed values.
+/// </summary>
+internal class NullableShortBeOneOfValidator(PrincipalChain<short?> chain, short[] values)
+    : IValidator
+{
+    public static NullableShortBeOneOfValidator New(PrincipalChain<short?> chain, short[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is strictly positive.
+/// </summary>
+internal class NullableShortBePositiveValidator(PrincipalChain<short?> chain) : IValidator
+{
+    public static NullableShortBePositiveValidator New(PrincipalChain<short?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value equals the expected value.
+/// </summary>
+internal class NullableShortBeValidator(PrincipalChain<short?> chain, short? expected) : IValidator
+{
+    public static NullableShortBeValidator New(PrincipalChain<short?> chain, short? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short has a value (is not null).
+/// </summary>
+internal class NullableShortHaveValueValidator(PrincipalChain<short?> chain) : IValidator
+{
+    public static NullableShortHaveValueValidator New(PrincipalChain<short?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is outside the specified inclusive range.
+/// </summary>
+internal class NullableShortNotBeInRangeValidator(PrincipalChain<short?> chain, short min, short max)
+    : IValidator
+{
+    public static NullableShortNotBeInRangeValidator New(
+        PrincipalChain<short?> chain,
+        short min,
+        short max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableShortNotBeOneOfValidator(PrincipalChain<short?> chain, short[] values)
+    : IValidator
+{
+    public static NullableShortNotBeOneOfValidator New(
+        PrincipalChain<short?> chain,
+        short[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short value does not equal the expected value.
+/// </summary>
+internal class NullableShortNotBeValidator(PrincipalChain<short?> chain, short? expected) : IValidator
+{
+    public static NullableShortNotBeValidator New(PrincipalChain<short?> chain, short? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableShortNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable short does not have a value (is null).
+/// </summary>
+internal class NullableShortNotHaveValueValidator(PrincipalChain<short?> chain) : IValidator
+{
+    public static NullableShortNotHaveValueValidator New(PrincipalChain<short?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is evenly divisible by the specified divisor.
+/// </summary>
+internal class ShortBeDivisibleByValidator(PrincipalChain<short> chain, short divisor) : IValidator
+{
+    public static ShortBeDivisibleByValidator New(PrincipalChain<short> chain, short divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is even.
+/// </summary>
+internal class ShortBeEvenValidator(PrincipalChain<short> chain) : IValidator
+{
+    public static ShortBeEvenValidator New(PrincipalChain<short> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is greater than or equal to the expected value.
+/// </summary>
+internal class ShortBeGreaterThanOrEqualToValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortBeGreaterThanOrEqualToValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is greater than the expected value.
+/// </summary>
+internal class ShortBeGreaterThanValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortBeGreaterThanValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is within the specified inclusive range.
+/// </summary>
+internal class ShortBeInRangeValidator(PrincipalChain<short> chain, short min, short max) : IValidator
+{
+    public static ShortBeInRangeValidator New(PrincipalChain<short> chain, short min, short max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is less than or equal to the expected value.
+/// </summary>
+internal class ShortBeLessThanOrEqualToValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortBeLessThanOrEqualToValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is less than the expected value.
+/// </summary>
+internal class ShortBeLessThanValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortBeLessThanValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeNegativeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeNegativeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is strictly negative (less than zero).
+/// </summary>
+internal class ShortBeNegativeValidator(PrincipalChain<short> chain) : IValidator
+{
+    public static ShortBeNegativeValidator New(PrincipalChain<short> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be negative, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is odd.
+/// </summary>
+internal class ShortBeOddValidator(PrincipalChain<short> chain) : IValidator
+{
+    public static ShortBeOddValidator New(PrincipalChain<short> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is one of the specified allowed values.
+/// </summary>
+internal class ShortBeOneOfValidator(PrincipalChain<short> chain, params short[] expected) : IValidator
+{
+    public static ShortBeOneOfValidator New(PrincipalChain<short> chain, params short[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is strictly positive (greater than zero).
+/// </summary>
+internal class ShortBePositiveValidator(PrincipalChain<short> chain) : IValidator
+{
+    public static ShortBePositiveValidator New(PrincipalChain<short> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value equals the expected value.
+/// </summary>
+internal class ShortBeValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortBeValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is zero.
+/// </summary>
+internal class ShortBeZeroValidator(PrincipalChain<short> chain) : IValidator
+{
+    public static ShortBeZeroValidator New(PrincipalChain<short> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is outside the specified inclusive range.
+/// </summary>
+internal class ShortNotBeInRangeValidator(PrincipalChain<short> chain, short min, short max)
+    : IValidator
+{
+    public static ShortNotBeInRangeValidator New(PrincipalChain<short> chain, short min, short max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value is not one of the specified disallowed values.
+/// </summary>
+internal class ShortNotBeOneOfValidator(PrincipalChain<short> chain, params short[] expected) : IValidator
+{
+    public static ShortNotBeOneOfValidator New(PrincipalChain<short> chain, params short[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ShortNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the short value does not equal the expected value.
+/// </summary>
+internal class ShortNotBeValidator(PrincipalChain<short> chain, short expected) : IValidator
+{
+    public static ShortNotBeValidator New(PrincipalChain<short> chain, short expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,6 +267,38 @@ Manager: `SByteOperationsManager` / `NullableSByteOperationsManager`
 
 ---
 
+### Short Validations
+
+Manager: `ShortOperationsManager` / `NullableShortOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(short)` | Equals expected |
+| `NotBe(short)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeNegative()` | Less than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(short)` | Greater than value |
+| `BeGreaterThanOrEqualTo(short)` | Greater than or equal |
+| `BeLessThan(short)` | Less than value |
+| `BeLessThanOrEqualTo(short)` | Less than or equal |
+| `BeInRange(short, short)` | Within inclusive range |
+| `NotBeInRange(short, short)` | Outside range |
+| `BeOneOf(params short[])` | In set of values |
+| `NotBeOneOf(params short[])` | Not in set |
+| `BeDivisibleBy(short)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** Unlike `ushort`, `BeNegative()` IS available for `short` because it is a signed type (range -32768 to 32767).
+
+**Nullable short (`short?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All short operations above (with FailIf null guards)
+
+---
+
 ### Char Validations
 
 Manager: `CharOperationsManager` / `NullableCharOperationsManager`


### PR DESCRIPTION
  Add ShortOperationsManager (16 operations) and NullableShortOperationsManager
  (18 operations) following the established signed numeric type pattern.
  Full parity with int/long/sbyte operations.

  Operations: Be, NotBe, BePositive, BeNegative, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 34 validators: 16 ShortXxxValidator + 18 NullableShortXxxValidator
  - 2 managers: ShortOperationsManager, NullableShortOperationsManager

  Changes:
  - Operations.cs: Add Operations.Short (16 entries) and Operations.NullableShort (2 entries) enums
  - TestExtension.Numeric.cs: Add short.Test() and short?.Test() extensions
  - PropertyProxy.cs: Register ShortOperationsManager and NullableShortOperationsManager for Blueprint support
  - QualityBlueprint.For.cs: Add dedicated For() overloads for short and short? to prevent implicit int conversion from selecting IntegerOperationsManager
  - QualityBlueprint.ForTransform.cs: Add 8 ForTransform shortcuts (4 same-type + 4 cross-type) for short and short?
  - API.md: Add Short Validations documentation section