### PR TITLE
Add uint and nullable uint type support with validation operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -395,6 +395,69 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="uint"/> values.
+    /// </summary>
+    public enum UInt
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="uint?"/> (nullable uint) values.
+    /// </summary>
+    public enum NullableUInt
+    {
+        [EnumStringValue("havevalueuint")]
+        HaveValue,
+
+        [EnumStringValue("nothavevalueuint")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="short"/> values.
     /// </summary>
     public enum Short

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableUIntOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableUIntOperationsManager.cs
@@ -1,0 +1,618 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>uint?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>uint</c> is unsigned (0-4,294,967,295).
+/// </summary>
+public class NullableUIntOperationsManager
+    : BaseNullableOperationsManager<NullableUIntOperationsManager, uint?>,
+        ITestManager<NullableUIntOperationsManager, uint?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<uint?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableUIntOperationsManager(uint? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<uint?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableUInt.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableUInt.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager Be(uint? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager NotBe(uint? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeGreaterThan(uint value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeGreaterThanOrEqualTo(uint value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(
+                NullableUIntBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeLessThan(uint value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeLessThanOrEqualTo(uint value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeInRange(uint min, uint max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager NotBeInRange(uint min, uint max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeOneOf(params uint[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager NotBeOneOf(params uint[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to test against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeDivisibleBy(uint divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableUIntOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUIntOperationsManager, uint?>
+            .New(this)
+            .WithOperation(NullableUIntBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/UIntOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/UIntOperationsManager.cs
@@ -1,0 +1,563 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>uint</c> values.
+/// Supports equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>uint</c> is unsigned (0-4,294,967,295).
+/// </summary>
+public class UIntOperationsManager : ITestManager<UIntOperationsManager, uint>
+{
+    /// <inheritdoc />
+    public PrincipalChain<uint> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public UIntOperationsManager(uint value, string caller)
+    {
+        PrincipalChain = PrincipalChain<uint>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager Be(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager NotBe(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeGreaterThan(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeGreaterThanOrEqualTo(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeLessThan(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeLessThanOrEqualTo(uint expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public UIntOperationsManager BeInRange(uint min, uint max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public UIntOperationsManager NotBeInRange(uint min, uint max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public UIntOperationsManager BeOneOf(Reason? reason = null, params uint[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public UIntOperationsManager NotBeOneOf(Reason? reason = null, params uint[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to check divisibility against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public UIntOperationsManager BeDivisibleBy(uint divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UIntOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UInt.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UIntOperationsManager, uint>
+            .New(this)
+            .WithOperation(UIntBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -140,6 +140,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new SByteOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableUIntOperationsManager))
+        {
+            return (TManager)(object)new NullableUIntOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(UIntOperationsManager))
+        {
+            return (TManager)(object)new UIntOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(NullableShortOperationsManager))
         {
             return (TManager)(object)new NullableShortOperationsManager(null, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -483,6 +483,56 @@ public abstract partial class QualityBlueprint<T>
     ) => For<sbyte?, NullableSByteOperationsManager>(propertyExpression, config);
 
     /// <summary>
+    /// Defines a validation rule for a <see cref="uint"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access uint assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the uint property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="UIntOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<UIntOperationsManager> For(
+        Expression<Func<T, uint>> propertyExpression
+    ) => For<uint, UIntOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="uint"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the uint property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="UIntOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<UIntOperationsManager> For(
+        Expression<Func<T, uint>> propertyExpression,
+        RuleConfig config
+    ) => For<uint, UIntOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="uint"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable uint assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable uint property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableUIntOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableUIntOperationsManager> For(
+        Expression<Func<T, uint?>> propertyExpression
+    ) => For<uint?, NullableUIntOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="uint"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable uint property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableUIntOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableUIntOperationsManager> For(
+        Expression<Func<T, uint?>> propertyExpression,
+        RuleConfig config
+    ) => For<uint?, NullableUIntOperationsManager>(propertyExpression, config);
+
+    /// <summary>
     /// Defines a validation rule for a <see cref="short"/> property of the model.
     /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access short assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -910,6 +910,42 @@ public abstract partial class QualityBlueprint<T>
         RuleConfig config
     ) => ForTransform<sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
 
+    // uint -> uint transformation
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="uint"/> property.
+    /// </summary>
+    protected IPropertyProxy<UIntOperationsManager> ForTransform(
+        Expression<Func<T, uint>> propertyExpression,
+        Func<uint, uint> transform
+    ) => ForTransform<uint, UIntOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="uint"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<UIntOperationsManager> ForTransform(
+        Expression<Func<T, uint>> propertyExpression,
+        Func<uint, uint> transform,
+        RuleConfig config
+    ) => ForTransform<uint, UIntOperationsManager>(propertyExpression, transform, config);
+
+    // uint? -> uint? transformation
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="uint"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableUIntOperationsManager> ForTransform(
+        Expression<Func<T, uint?>> propertyExpression,
+        Func<uint?, uint?> transform
+    ) => ForTransform<uint?, NullableUIntOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="uint"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableUIntOperationsManager> ForTransform(
+        Expression<Func<T, uint?>> propertyExpression,
+        Func<uint?, uint?> transform,
+        RuleConfig config
+    ) => ForTransform<uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
+
     /// <summary>
     /// Registers a same-type transformation for a <see cref="short"/> property.
     /// </summary>
@@ -1500,6 +1536,42 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, sbyte?> transform,
         RuleConfig config
     ) => ForTransform<TProp, sbyte?, NullableSByteOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> uint
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="uint"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<UIntOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, uint> transform
+    ) => ForTransform<TProp, uint, UIntOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="uint"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<UIntOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, uint> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, uint, UIntOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> uint?
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="uint"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableUIntOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, uint?> transform
+    ) => ForTransform<TProp, uint?, NullableUIntOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="uint"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableUIntOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, uint?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
 
     /// <summary>
     /// Registers a property with a cross-type transformation to <see cref="short"/> applied before validation.

--- a/Distributed/JAAvila.FluentOperations/TestExtension.UInt.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.UInt.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Manager;
+
+namespace JAAvila.FluentOperations;
+
+public static partial class TestExtension
+{
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="uint"/> value.
+    /// </summary>
+    /// <param name="value">The uint value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="UIntOperationsManager"/> for chaining uint-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// uint count = 42u;
+    /// count.Test().BePositive().BeLessThan(100u);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static UIntOperationsManager Test(
+        this uint value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new UIntOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="uint"/> value.
+    /// </summary>
+    /// <param name="value">The nullable uint value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableUIntOperationsManager"/> for chaining nullable uint-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// uint? count = null;
+    /// count.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableUIntOperationsManager Test(
+        this uint? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableUIntOperationsManager(value, callerName);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableUIntBeDivisibleByValidator(PrincipalChain<uint?> chain, uint divisor)
+    : IValidator
+{
+    public static NullableUIntBeDivisibleByValidator New(
+        PrincipalChain<uint?> chain,
+        uint divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableUIntBeGreaterThanOrEqualToValidator(
+    PrincipalChain<uint?> chain,
+    uint comparison
+) : IValidator
+{
+    public static NullableUIntBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<uint?> chain,
+        uint comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is greater than the expected value.
+/// </summary>
+internal class NullableUIntBeGreaterThanValidator(PrincipalChain<uint?> chain, uint comparison)
+    : IValidator
+{
+    public static NullableUIntBeGreaterThanValidator New(
+        PrincipalChain<uint?> chain,
+        uint comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is within the specified inclusive range.
+/// </summary>
+internal class NullableUIntBeInRangeValidator(PrincipalChain<uint?> chain, uint min, uint max)
+    : IValidator
+{
+    public static NullableUIntBeInRangeValidator New(
+        PrincipalChain<uint?> chain,
+        uint min,
+        uint max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is less than or equal to the expected value.
+/// </summary>
+internal class NullableUIntBeLessThanOrEqualToValidator(
+    PrincipalChain<uint?> chain,
+    uint comparison
+) : IValidator
+{
+    public static NullableUIntBeLessThanOrEqualToValidator New(
+        PrincipalChain<uint?> chain,
+        uint comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is less than the expected value.
+/// </summary>
+internal class NullableUIntBeLessThanValidator(PrincipalChain<uint?> chain, uint comparison)
+    : IValidator
+{
+    public static NullableUIntBeLessThanValidator New(
+        PrincipalChain<uint?> chain,
+        uint comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is odd.
+/// </summary>
+internal class NullableUIntBeOddValidator(PrincipalChain<uint?> chain) : IValidator
+{
+    public static NullableUIntBeOddValidator New(PrincipalChain<uint?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is one of the specified allowed values.
+/// </summary>
+internal class NullableUIntBeOneOfValidator(PrincipalChain<uint?> chain, uint[] values)
+    : IValidator
+{
+    public static NullableUIntBeOneOfValidator New(PrincipalChain<uint?> chain, uint[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is strictly positive.
+/// </summary>
+internal class NullableUIntBePositiveValidator(PrincipalChain<uint?> chain) : IValidator
+{
+    public static NullableUIntBePositiveValidator New(PrincipalChain<uint?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value equals the expected value.
+/// </summary>
+internal class NullableUIntBeValidator(PrincipalChain<uint?> chain, uint? expected) : IValidator
+{
+    public static NullableUIntBeValidator New(PrincipalChain<uint?> chain, uint? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint has a value (is not null).
+/// </summary>
+internal class NullableUIntHaveValueValidator(PrincipalChain<uint?> chain) : IValidator
+{
+    public static NullableUIntHaveValueValidator New(PrincipalChain<uint?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is outside the specified inclusive range.
+/// </summary>
+internal class NullableUIntNotBeInRangeValidator(PrincipalChain<uint?> chain, uint min, uint max)
+    : IValidator
+{
+    public static NullableUIntNotBeInRangeValidator New(
+        PrincipalChain<uint?> chain,
+        uint min,
+        uint max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableUIntNotBeOneOfValidator(PrincipalChain<uint?> chain, uint[] values)
+    : IValidator
+{
+    public static NullableUIntNotBeOneOfValidator New(
+        PrincipalChain<uint?> chain,
+        uint[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint value does not equal the expected value.
+/// </summary>
+internal class NullableUIntNotBeValidator(PrincipalChain<uint?> chain, uint? expected) : IValidator
+{
+    public static NullableUIntNotBeValidator New(PrincipalChain<uint?> chain, uint? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUIntNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable uint does not have a value (is null).
+/// </summary>
+internal class NullableUIntNotHaveValueValidator(PrincipalChain<uint?> chain) : IValidator
+{
+    public static NullableUIntNotHaveValueValidator New(PrincipalChain<uint?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is evenly divisible by the specified divisor.
+/// </summary>
+internal class UIntBeDivisibleByValidator(PrincipalChain<uint> chain, uint divisor) : IValidator
+{
+    public static UIntBeDivisibleByValidator New(PrincipalChain<uint> chain, uint divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is even.
+/// </summary>
+internal class UIntBeEvenValidator(PrincipalChain<uint> chain) : IValidator
+{
+    public static UIntBeEvenValidator New(PrincipalChain<uint> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is greater than or equal to the expected value.
+/// </summary>
+internal class UIntBeGreaterThanOrEqualToValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntBeGreaterThanOrEqualToValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is greater than the expected value.
+/// </summary>
+internal class UIntBeGreaterThanValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntBeGreaterThanValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is within the specified inclusive range.
+/// </summary>
+internal class UIntBeInRangeValidator(PrincipalChain<uint> chain, uint min, uint max) : IValidator
+{
+    public static UIntBeInRangeValidator New(PrincipalChain<uint> chain, uint min, uint max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is less than or equal to the expected value.
+/// </summary>
+internal class UIntBeLessThanOrEqualToValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntBeLessThanOrEqualToValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is less than the expected value.
+/// </summary>
+internal class UIntBeLessThanValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntBeLessThanValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is odd.
+/// </summary>
+internal class UIntBeOddValidator(PrincipalChain<uint> chain) : IValidator
+{
+    public static UIntBeOddValidator New(PrincipalChain<uint> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is one of the specified allowed values.
+/// </summary>
+internal class UIntBeOneOfValidator(PrincipalChain<uint> chain, params uint[] expected) : IValidator
+{
+    public static UIntBeOneOfValidator New(PrincipalChain<uint> chain, params uint[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is strictly positive (greater than zero).
+/// </summary>
+internal class UIntBePositiveValidator(PrincipalChain<uint> chain) : IValidator
+{
+    public static UIntBePositiveValidator New(PrincipalChain<uint> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value equals the expected value.
+/// </summary>
+internal class UIntBeValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntBeValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is zero.
+/// </summary>
+internal class UIntBeZeroValidator(PrincipalChain<uint> chain) : IValidator
+{
+    public static UIntBeZeroValidator New(PrincipalChain<uint> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is outside the specified inclusive range.
+/// </summary>
+internal class UIntNotBeInRangeValidator(PrincipalChain<uint> chain, uint min, uint max)
+    : IValidator
+{
+    public static UIntNotBeInRangeValidator New(PrincipalChain<uint> chain, uint min, uint max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value is not one of the specified disallowed values.
+/// </summary>
+internal class UIntNotBeOneOfValidator(PrincipalChain<uint> chain, params uint[] expected) : IValidator
+{
+    public static UIntNotBeOneOfValidator New(PrincipalChain<uint> chain, params uint[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UIntNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the uint value does not equal the expected value.
+/// </summary>
+internal class UIntNotBeValidator(PrincipalChain<uint> chain, uint expected) : IValidator
+{
+    public static UIntNotBeValidator New(PrincipalChain<uint> chain, uint expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,6 +267,37 @@ Manager: `SByteOperationsManager` / `NullableSByteOperationsManager`
 
 ---
 
+### UInt Validations
+
+Manager: `UIntOperationsManager` / `NullableUIntOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(uint)` | Equals expected |
+| `NotBe(uint)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(uint)` | Greater than value |
+| `BeGreaterThanOrEqualTo(uint)` | Greater than or equal |
+| `BeLessThan(uint)` | Less than value |
+| `BeLessThanOrEqualTo(uint)` | Less than or equal |
+| `BeInRange(uint, uint)` | Within inclusive range |
+| `NotBeInRange(uint, uint)` | Outside range |
+| `BeOneOf(params uint[])` | In set of values |
+| `NotBeOneOf(params uint[])` | Not in set |
+| `BeDivisibleBy(uint)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** `BeNegative()` is not available for `uint` because it is an unsigned type (range 0-4,294,967,295).
+
+**Nullable uint (`uint?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All uint operations above (with FailIf null guards)
+
+---
+
 ### Short Validations
 
 Manager: `ShortOperationsManager` / `NullableShortOperationsManager`


### PR DESCRIPTION
  Add UIntOperationsManager (15 operations) and NullableUIntOperationsManager
  (17 operations) following the established unsigned numeric type pattern.
  BeNegative() is intentionally excluded as uint is unsigned (0-4,294,967,295).

  Operations: Be, NotBe, BePositive, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 32 validators: 15 UIntXxxValidator + 17 NullableUIntXxxValidator
  - 2 managers: UIntOperationsManager, NullableUIntOperationsManager
  - 1 extension: TestExtension.UInt.cs

  Changes:
  - Operations.cs: Add Operations.UInt (15 entries) and Operations.NullableUInt (2 entries) enums
  - PropertyProxy.cs: Register UIntOperationsManager and NullableUIntOperationsManager for Blueprint support
  - QualityBlueprint.For.cs: Add dedicated For() overloads for uint and uint? to prevent implicit long conversion from selecting LongOperationsManager
  - QualityBlueprint.ForTransform.cs: Add 8 ForTransform shortcuts (4 same-type + 4 cross-type) for uint and uint?
  - API.md: Add UInt Validations documentation section