### PR TITLE
Add ulong and nullable ulong support with validation operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -458,6 +458,69 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="ulong"/> values.
+    /// </summary>
+    public enum ULong
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="ulong?"/> (nullable ulong) values.
+    /// </summary>
+    public enum NullableULong
+    {
+        [EnumStringValue("havevalueulong")]
+        HaveValue,
+
+        [EnumStringValue("nothavevalueulong")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="short"/> values.
     /// </summary>
     public enum Short

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableULongOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableULongOperationsManager.cs
@@ -1,0 +1,618 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>ulong?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>ulong</c> is unsigned (0-18,446,744,073,709,551,615).
+/// </summary>
+public class NullableULongOperationsManager
+    : BaseNullableOperationsManager<NullableULongOperationsManager, ulong?>,
+        ITestManager<NullableULongOperationsManager, ulong?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<ulong?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableULongOperationsManager(ulong? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<ulong?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableULong.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableULong.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager Be(ulong? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager NotBe(ulong? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0UL, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeGreaterThan(ulong value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive lower bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeGreaterThanOrEqualTo(ulong value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(
+                NullableULongBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The exclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeLessThan(ulong value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">The inclusive upper bound.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeLessThanOrEqualTo(ulong value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeInRange(ulong min, ulong max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager NotBeInRange(ulong min, ulong max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeOneOf(params ulong[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    /// <param name="values">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager NotBeOneOf(params ulong[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to test against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeDivisibleBy(ulong divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0UL,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2UL, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public NullableULongOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableULongOperationsManager, ulong?>
+            .New(this)
+            .WithOperation(NullableULongBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/ULongOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ULongOperationsManager.cs
@@ -1,0 +1,563 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>ulong</c> values.
+/// Supports equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>ulong</c> is unsigned (0-18,446,744,073,709,551,615).
+/// </summary>
+public class ULongOperationsManager : ITestManager<ULongOperationsManager, ulong>
+{
+    /// <inheritdoc />
+    public PrincipalChain<ulong> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public ULongOperationsManager(ulong value, string caller)
+    {
+        PrincipalChain = PrincipalChain<ulong>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager Be(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager NotBe(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeGreaterThan(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeGreaterThanOrEqualTo(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeLessThan(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeLessThanOrEqualTo(ulong expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ULongOperationsManager BeInRange(ulong min, ulong max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The lower bound of the range (inclusive).</param>
+    /// <param name="max">The upper bound of the range (inclusive).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public ULongOperationsManager NotBeInRange(ulong min, ulong max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ULongOperationsManager BeOneOf(Reason? reason = null, params ulong[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public ULongOperationsManager NotBeOneOf(Reason? reason = null, params ulong[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <param name="divisor">The divisor to check divisibility against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public ULongOperationsManager BeDivisibleBy(ulong divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0UL,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ULongOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ULong.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ULongOperationsManager, ulong>
+            .New(this)
+            .WithOperation(ULongBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -150,6 +150,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new UIntOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableULongOperationsManager))
+        {
+            return (TManager)(object)new NullableULongOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(ULongOperationsManager))
+        {
+            return (TManager)(object)new ULongOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(NullableShortOperationsManager))
         {
             return (TManager)(object)new NullableShortOperationsManager(null, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -533,6 +533,56 @@ public abstract partial class QualityBlueprint<T>
     ) => For<uint?, NullableUIntOperationsManager>(propertyExpression, config);
 
     /// <summary>
+    /// Defines a validation rule for a <see cref="ulong"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access ulong assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the ulong property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="ULongOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ULongOperationsManager> For(
+        Expression<Func<T, ulong>> propertyExpression
+    ) => For<ulong, ULongOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="ulong"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the ulong property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="ULongOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<ULongOperationsManager> For(
+        Expression<Func<T, ulong>> propertyExpression,
+        RuleConfig config
+    ) => For<ulong, ULongOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="ulong"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable ulong assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable ulong property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableULongOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableULongOperationsManager> For(
+        Expression<Func<T, ulong?>> propertyExpression
+    ) => For<ulong?, NullableULongOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="ulong"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable ulong property to validate (e.g., <c>x =&gt; x.Count</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableULongOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableULongOperationsManager> For(
+        Expression<Func<T, ulong?>> propertyExpression,
+        RuleConfig config
+    ) => For<ulong?, NullableULongOperationsManager>(propertyExpression, config);
+
+    /// <summary>
     /// Defines a validation rule for a <see cref="short"/> property of the model.
     /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access short assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -946,6 +946,42 @@ public abstract partial class QualityBlueprint<T>
         RuleConfig config
     ) => ForTransform<uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
 
+    // ulong -> ulong transformation
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="ulong"/> property.
+    /// </summary>
+    protected IPropertyProxy<ULongOperationsManager> ForTransform(
+        Expression<Func<T, ulong>> propertyExpression,
+        Func<ulong, ulong> transform
+    ) => ForTransform<ulong, ULongOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="ulong"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ULongOperationsManager> ForTransform(
+        Expression<Func<T, ulong>> propertyExpression,
+        Func<ulong, ulong> transform,
+        RuleConfig config
+    ) => ForTransform<ulong, ULongOperationsManager>(propertyExpression, transform, config);
+
+    // ulong? -> ulong? transformation
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="ulong"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableULongOperationsManager> ForTransform(
+        Expression<Func<T, ulong?>> propertyExpression,
+        Func<ulong?, ulong?> transform
+    ) => ForTransform<ulong?, NullableULongOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="ulong"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableULongOperationsManager> ForTransform(
+        Expression<Func<T, ulong?>> propertyExpression,
+        Func<ulong?, ulong?> transform,
+        RuleConfig config
+    ) => ForTransform<ulong?, NullableULongOperationsManager>(propertyExpression, transform, config);
+
     /// <summary>
     /// Registers a same-type transformation for a <see cref="short"/> property.
     /// </summary>
@@ -1572,6 +1608,42 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, uint?> transform,
         RuleConfig config
     ) => ForTransform<TProp, uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> ulong
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="ulong"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<ULongOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ulong> transform
+    ) => ForTransform<TProp, ulong, ULongOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="ulong"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<ULongOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ulong> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, ulong, ULongOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> ulong?
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="ulong"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableULongOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ulong?> transform
+    ) => ForTransform<TProp, ulong?, NullableULongOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="ulong"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableULongOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ulong?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, ulong?, NullableULongOperationsManager>(propertyExpression, transform, config);
 
     /// <summary>
     /// Registers a property with a cross-type transformation to <see cref="short"/> applied before validation.

--- a/Distributed/JAAvila.FluentOperations/TestExtension.ULong.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.ULong.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Manager;
+
+namespace JAAvila.FluentOperations;
+
+public static partial class TestExtension
+{
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="ulong"/> value.
+    /// </summary>
+    /// <param name="value">The ulong value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="ULongOperationsManager"/> for chaining ulong-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// ulong count = 42UL;
+    /// count.Test().BePositive().BeLessThan(100UL);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static ULongOperationsManager Test(
+        this ulong value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new ULongOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="ulong"/> value.
+    /// </summary>
+    /// <param name="value">The nullable ulong value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableULongOperationsManager"/> for chaining nullable ulong-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// ulong? count = null;
+    /// count.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableULongOperationsManager Test(
+        this ulong? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableULongOperationsManager(value, callerName);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableULongBeDivisibleByValidator(PrincipalChain<ulong?> chain, ulong divisor)
+    : IValidator
+{
+    public static NullableULongBeDivisibleByValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableULongBeGreaterThanOrEqualToValidator(
+    PrincipalChain<ulong?> chain,
+    ulong comparison
+) : IValidator
+{
+    public static NullableULongBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is greater than the expected value.
+/// </summary>
+internal class NullableULongBeGreaterThanValidator(PrincipalChain<ulong?> chain, ulong comparison)
+    : IValidator
+{
+    public static NullableULongBeGreaterThanValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is within the specified inclusive range.
+/// </summary>
+internal class NullableULongBeInRangeValidator(PrincipalChain<ulong?> chain, ulong min, ulong max)
+    : IValidator
+{
+    public static NullableULongBeInRangeValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong min,
+        ulong max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is less than or equal to the expected value.
+/// </summary>
+internal class NullableULongBeLessThanOrEqualToValidator(
+    PrincipalChain<ulong?> chain,
+    ulong comparison
+) : IValidator
+{
+    public static NullableULongBeLessThanOrEqualToValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is less than the expected value.
+/// </summary>
+internal class NullableULongBeLessThanValidator(PrincipalChain<ulong?> chain, ulong comparison)
+    : IValidator
+{
+    public static NullableULongBeLessThanValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is odd.
+/// </summary>
+internal class NullableULongBeOddValidator(PrincipalChain<ulong?> chain) : IValidator
+{
+    public static NullableULongBeOddValidator New(PrincipalChain<ulong?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2UL != 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is one of the specified allowed values.
+/// </summary>
+internal class NullableULongBeOneOfValidator(PrincipalChain<ulong?> chain, ulong[] values)
+    : IValidator
+{
+    public static NullableULongBeOneOfValidator New(PrincipalChain<ulong?> chain, ulong[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is strictly positive.
+/// </summary>
+internal class NullableULongBePositiveValidator(PrincipalChain<ulong?> chain) : IValidator
+{
+    public static NullableULongBePositiveValidator New(PrincipalChain<ulong?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value equals the expected value.
+/// </summary>
+internal class NullableULongBeValidator(PrincipalChain<ulong?> chain, ulong? expected) : IValidator
+{
+    public static NullableULongBeValidator New(PrincipalChain<ulong?> chain, ulong? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong has a value (is not null).
+/// </summary>
+internal class NullableULongHaveValueValidator(PrincipalChain<ulong?> chain) : IValidator
+{
+    public static NullableULongHaveValueValidator New(PrincipalChain<ulong?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is outside the specified inclusive range.
+/// </summary>
+internal class NullableULongNotBeInRangeValidator(PrincipalChain<ulong?> chain, ulong min, ulong max)
+    : IValidator
+{
+    public static NullableULongNotBeInRangeValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong min,
+        ulong max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableULongNotBeOneOfValidator(PrincipalChain<ulong?> chain, ulong[] values)
+    : IValidator
+{
+    public static NullableULongNotBeOneOfValidator New(
+        PrincipalChain<ulong?> chain,
+        ulong[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong value does not equal the expected value.
+/// </summary>
+internal class NullableULongNotBeValidator(PrincipalChain<ulong?> chain, ulong? expected) : IValidator
+{
+    public static NullableULongNotBeValidator New(PrincipalChain<ulong?> chain, ulong? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableULongNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ulong does not have a value (is null).
+/// </summary>
+internal class NullableULongNotHaveValueValidator(PrincipalChain<ulong?> chain) : IValidator
+{
+    public static NullableULongNotHaveValueValidator New(PrincipalChain<ulong?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is evenly divisible by the specified divisor.
+/// </summary>
+internal class ULongBeDivisibleByValidator(PrincipalChain<ulong> chain, ulong divisor) : IValidator
+{
+    public static ULongBeDivisibleByValidator New(PrincipalChain<ulong> chain, ulong divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is even.
+/// </summary>
+internal class ULongBeEvenValidator(PrincipalChain<ulong> chain) : IValidator
+{
+    public static ULongBeEvenValidator New(PrincipalChain<ulong> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2UL == 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is greater than or equal to the expected value.
+/// </summary>
+internal class ULongBeGreaterThanOrEqualToValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongBeGreaterThanOrEqualToValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is greater than the expected value.
+/// </summary>
+internal class ULongBeGreaterThanValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongBeGreaterThanValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is within the specified inclusive range.
+/// </summary>
+internal class ULongBeInRangeValidator(PrincipalChain<ulong> chain, ulong min, ulong max) : IValidator
+{
+    public static ULongBeInRangeValidator New(PrincipalChain<ulong> chain, ulong min, ulong max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is less than or equal to the expected value.
+/// </summary>
+internal class ULongBeLessThanOrEqualToValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongBeLessThanOrEqualToValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is less than the expected value.
+/// </summary>
+internal class ULongBeLessThanValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongBeLessThanValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is odd.
+/// </summary>
+internal class ULongBeOddValidator(PrincipalChain<ulong> chain) : IValidator
+{
+    public static ULongBeOddValidator New(PrincipalChain<ulong> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2UL != 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is one of the specified allowed values.
+/// </summary>
+internal class ULongBeOneOfValidator(PrincipalChain<ulong> chain, params ulong[] expected) : IValidator
+{
+    public static ULongBeOneOfValidator New(PrincipalChain<ulong> chain, params ulong[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is strictly positive (greater than zero).
+/// </summary>
+internal class ULongBePositiveValidator(PrincipalChain<ulong> chain) : IValidator
+{
+    public static ULongBePositiveValidator New(PrincipalChain<ulong> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value equals the expected value.
+/// </summary>
+internal class ULongBeValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongBeValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is zero.
+/// </summary>
+internal class ULongBeZeroValidator(PrincipalChain<ulong> chain) : IValidator
+{
+    public static ULongBeZeroValidator New(PrincipalChain<ulong> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0UL)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is outside the specified inclusive range.
+/// </summary>
+internal class ULongNotBeInRangeValidator(PrincipalChain<ulong> chain, ulong min, ulong max)
+    : IValidator
+{
+    public static ULongNotBeInRangeValidator New(PrincipalChain<ulong> chain, ulong min, ulong max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value is not one of the specified disallowed values.
+/// </summary>
+internal class ULongNotBeOneOfValidator(PrincipalChain<ulong> chain, params ulong[] expected) : IValidator
+{
+    public static ULongNotBeOneOfValidator New(PrincipalChain<ulong> chain, params ulong[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ULongNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ulong value does not equal the expected value.
+/// </summary>
+internal class ULongNotBeValidator(PrincipalChain<ulong> chain, ulong expected) : IValidator
+{
+    public static ULongNotBeValidator New(PrincipalChain<ulong> chain, ulong expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -298,6 +298,37 @@ Manager: `UIntOperationsManager` / `NullableUIntOperationsManager`
 
 ---
 
+### ULong Validations
+
+Manager: `ULongOperationsManager` / `NullableULongOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(ulong)` | Equals expected |
+| `NotBe(ulong)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(ulong)` | Greater than value |
+| `BeGreaterThanOrEqualTo(ulong)` | Greater than or equal |
+| `BeLessThan(ulong)` | Less than value |
+| `BeLessThanOrEqualTo(ulong)` | Less than or equal |
+| `BeInRange(ulong, ulong)` | Within inclusive range |
+| `NotBeInRange(ulong, ulong)` | Outside range |
+| `BeOneOf(params ulong[])` | In set of values |
+| `NotBeOneOf(params ulong[])` | Not in set |
+| `BeDivisibleBy(ulong)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** `BeNegative()` is not available for `ulong` because it is an unsigned type (range 0-18,446,744,073,709,551,615).
+
+**Nullable ulong (`ulong?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All ulong operations above (with FailIf null guards)
+
+---
+
 ### Short Validations
 
 Manager: `ShortOperationsManager` / `NullableShortOperationsManager`


### PR DESCRIPTION
  Add ULongOperationsManager (15 operations) and NullableULongOperationsManager
  (17 operations) following the established unsigned numeric type pattern.
  BeNegative() is intentionally excluded as ulong is unsigned
  (0-18,446,744,073,709,551,615).

  Operations: Be, NotBe, BePositive, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 32 validators: 15 ULongXxxValidator + 17 NullableULongXxxValidator
  - 2 managers: ULongOperationsManager, NullableULongOperationsManager
  - 1 extension: TestExtension.ULong.cs

  Changes:
  - Operations.cs: Add Operations.ULong (15 entries) and Operations.NullableULong (2 entries) enums
  - PropertyProxy.cs: Register ULongOperationsManager and NullableULongOperationsManager for Blueprint support
  - QualityBlueprint.For.cs: Add dedicated For() overloads for ulong and ulong? to prevent implicit float/double conversion
  - QualityBlueprint.ForTransform.cs: Add 8 ForTransform shortcuts (4 same-type + 4 cross-type) for ulong and ulong?
  - API.md: Add ULong Validations documentation section