### PR TITLE
Add support for ushort and nullable ushort numeric types

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -458,6 +458,69 @@ public struct Operations
     }
 
     /// <summary>
+    /// Operations available for <see cref="ushort"/> values.
+    /// </summary>
+    public enum UShort
+    {
+        [EnumStringValue("be")]
+        Be,
+
+        [EnumStringValue("notbe")]
+        NotBe,
+
+        [EnumStringValue("bepositive")]
+        BePositive,
+
+        [EnumStringValue("bezero")]
+        BeZero,
+
+        [EnumStringValue("begreaterthan")]
+        BeGreaterThan,
+
+        [EnumStringValue("begreaterthanorequalto")]
+        BeGreaterThanOrEqualTo,
+
+        [EnumStringValue("belessthan")]
+        BeLessThan,
+
+        [EnumStringValue("belessthanorequalto")]
+        BeLessThanOrEqualTo,
+
+        [EnumStringValue("beinrange")]
+        BeInRange,
+
+        [EnumStringValue("notbeinrange")]
+        NotBeInRange,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
+
+        [EnumStringValue("bedivisibleby")]
+        BeDivisibleBy,
+
+        [EnumStringValue("beeven")]
+        BeEven,
+
+        [EnumStringValue("beodd")]
+        BeOdd,
+    }
+
+    /// <summary>
+    /// Operations available for <see cref="ushort?"/> (nullable ushort) values.
+    /// </summary>
+    public enum NullableUShort
+    {
+        [EnumStringValue("havevalueushort")]
+        HaveValue,
+
+        [EnumStringValue("nothavevalueushort")]
+        NotHaveValue,
+    }
+
+    /// <summary>
     /// Operations available for <see cref="ulong"/> values.
     /// </summary>
     public enum ULong

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableUShortOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableUShortOperationsManager.cs
@@ -1,0 +1,573 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>ushort?</c> values.
+/// Supports value presence, equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>ushort</c> is unsigned (0-65,535).
+/// </summary>
+public class NullableUShortOperationsManager
+    : BaseNullableOperationsManager<NullableUShortOperationsManager, ushort?>,
+        ITestManager<NullableUShortOperationsManager, ushort?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<ushort?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public NullableUShortOperationsManager(ushort? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<ushort?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value has a non-null value.
+    /// </summary>
+    public NullableUShortOperationsManager HaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableUShort.HaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the nullable value is <c>null</c> (does not have a value).
+    /// </summary>
+    public NullableUShortOperationsManager NotHaveValue(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableUShort.NotHaveValue))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortNotHaveValueValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    public NullableUShortOperationsManager Be(ushort? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue()),
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    public NullableUShortOperationsManager NotBe(ushort? expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than zero.
+    /// </summary>
+    public NullableUShortOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    public NullableUShortOperationsManager BeZero(Reason? reason = null)
+    {
+        return Be(0, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="value"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeGreaterThan(ushort value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeGreaterThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="value"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeGreaterThanOrEqualTo(ushort value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(
+                NullableUShortBeGreaterThanOrEqualToValidator.New(PrincipalChain, value)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="value"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeLessThan(ushort value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeLessThanValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="value"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeLessThanOrEqualTo(ushort value, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeLessThanOrEqualToValidator.New(PrincipalChain, value))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value falls within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    public NullableUShortOperationsManager BeInRange(ushort min, ushort max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value does not fall within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    public NullableUShortOperationsManager NotBeInRange(ushort min, ushort max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because min ({min}) is greater than max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified <paramref name="values"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeOneOf(params ushort[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not any of the specified <paramref name="values"/>.
+    /// </summary>
+    public NullableUShortOperationsManager NotBeOneOf(params ushort[] values)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortNotBeOneOfValidator.New(PrincipalChain, values))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        values.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    public NullableUShortOperationsManager BeDivisibleBy(ushort divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is an even number (divisible by 2).
+    /// </summary>
+    public NullableUShortOperationsManager BeEven(Reason? reason = null)
+    {
+        return BeDivisibleBy(2, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the value is an odd number (not divisible by 2).
+    /// </summary>
+    public NullableUShortOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableUShortOperationsManager, ushort?>
+            .New(this)
+            .WithOperation(NullableUShortBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOdd)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/UShortOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/UShortOperationsManager.cs
@@ -1,0 +1,530 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Formatters;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <c>ushort</c> values.
+/// Supports equality, comparison, range, divisibility, parity, and membership validations.
+/// Note: <c>BeNegative()</c> is intentionally excluded because <c>ushort</c> is unsigned (0-65,535).
+/// </summary>
+public class UShortOperationsManager : ITestManager<UShortOperationsManager, ushort>
+{
+    /// <inheritdoc />
+    public PrincipalChain<ushort> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public UShortOperationsManager(ushort value, string caller)
+    {
+        PrincipalChain = PrincipalChain<ushort>.Get(value, caller);
+        GlobalConfig.Initialize();
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected value to compare against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UShortOperationsManager Be(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.Be))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not equal to <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The value that should not match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UShortOperationsManager NotBe(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBe))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortNotBeValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation, BaseFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is strictly positive (greater than zero).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UShortOperationsManager BePositive(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BePositive))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBePositiveValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is equal to zero.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public UShortOperationsManager BeZero(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeZero))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeZeroValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than <paramref name="expected"/>.
+    /// </summary>
+    public UShortOperationsManager BeGreaterThan(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is greater than or equal to <paramref name="expected"/>.
+    /// </summary>
+    public UShortOperationsManager BeGreaterThanOrEqualTo(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeGreaterThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeGreaterThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than <paramref name="expected"/>.
+    /// </summary>
+    public UShortOperationsManager BeLessThan(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is less than or equal to <paramref name="expected"/>.
+    /// </summary>
+    public UShortOperationsManager BeLessThanOrEqualTo(ushort expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeLessThanOrEqualTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeLessThanOrEqualToValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is within the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public UShortOperationsManager BeInRange(ushort min, ushort max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is outside the inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <remarks>
+    /// Fails immediately if <paramref name="min"/> is greater than <paramref name="max"/> (inverted range).
+    /// </remarks>
+    public UShortOperationsManager NotBeInRange(ushort min, ushort max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBeInRange))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortNotBeInRangeValidator.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(min),
+                            BaseFormatter.Format(max),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min > max,
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the range is inverted: min ({min}) > max ({max})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is one of the specified allowed values.
+    /// </summary>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public UShortOperationsManager BeOneOf(Reason? reason = null, params ushort[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is not one of the specified disallowed values.
+    /// </summary>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty.
+    /// </remarks>
+    public UShortOperationsManager NotBeOneOf(Reason? reason = null, params ushort[] expected)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortNotBeOneOfValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => BaseFormatter.Format(e))),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is evenly divisible by <paramref name="divisor"/>.
+    /// </summary>
+    /// <remarks>
+    /// Fails immediately if <paramref name="divisor"/> is zero.
+    /// </remarks>
+    public UShortOperationsManager BeDivisibleBy(ushort divisor, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeDivisibleBy))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeDivisibleByValidator.New(PrincipalChain, divisor))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(divisor),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        divisor == 0,
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the divisor cannot be zero."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is even (divisible by 2).
+    /// </summary>
+    public UShortOperationsManager BeEven(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeEven))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeEvenValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is odd (not divisible by 2).
+    /// </summary>
+    public UShortOperationsManager BeOdd(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.UShort.BeOdd))
+        {
+            return this;
+        }
+
+        ExecutionEngine<UShortOperationsManager, ushort>
+            .New(this)
+            .WithOperation(UShortBeOddValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -160,6 +160,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new ULongOperationsManager(default, propertyName);
         }
 
+        if (typeof(TManager) == typeof(NullableUShortOperationsManager))
+        {
+            return (TManager)(object)new NullableUShortOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(UShortOperationsManager))
+        {
+            return (TManager)(object)new UShortOperationsManager(default, propertyName);
+        }
+
         if (typeof(TManager) == typeof(NullableShortOperationsManager))
         {
             return (TManager)(object)new NullableShortOperationsManager(null, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -533,6 +533,56 @@ public abstract partial class QualityBlueprint<T>
     ) => For<uint?, NullableUIntOperationsManager>(propertyExpression, config);
 
     /// <summary>
+    /// Defines a validation rule for a <see cref="ushort"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access ushort assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the ushort property to validate (e.g., <c>x =&gt; x.Port</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="UShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<UShortOperationsManager> For(
+        Expression<Func<T, ushort>> propertyExpression
+    ) => For<ushort, UShortOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="ushort"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the ushort property to validate (e.g., <c>x =&gt; x.Port</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="UShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<UShortOperationsManager> For(
+        Expression<Func<T, ushort>> propertyExpression,
+        RuleConfig config
+    ) => For<ushort, UShortOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="ushort"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access nullable ushort assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable ushort property to validate (e.g., <c>x =&gt; x.Port</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="NullableUShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableUShortOperationsManager> For(
+        Expression<Func<T, ushort?>> propertyExpression
+    ) => For<ushort?, NullableUShortOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a nullable <see cref="ushort"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the nullable ushort property to validate (e.g., <c>x =&gt; x.Port</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="NullableUShortOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<NullableUShortOperationsManager> For(
+        Expression<Func<T, ushort?>> propertyExpression,
+        RuleConfig config
+    ) => For<ushort?, NullableUShortOperationsManager>(propertyExpression, config);
+
+    /// <summary>
     /// Defines a validation rule for a <see cref="ulong"/> property of the model.
     /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access ulong assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -946,6 +946,42 @@ public abstract partial class QualityBlueprint<T>
         RuleConfig config
     ) => ForTransform<uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
 
+    // ushort -> ushort transformation
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="ushort"/> property.
+    /// </summary>
+    protected IPropertyProxy<UShortOperationsManager> ForTransform(
+        Expression<Func<T, ushort>> propertyExpression,
+        Func<ushort, ushort> transform
+    ) => ForTransform<ushort, UShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a <see cref="ushort"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<UShortOperationsManager> ForTransform(
+        Expression<Func<T, ushort>> propertyExpression,
+        Func<ushort, ushort> transform,
+        RuleConfig config
+    ) => ForTransform<ushort, UShortOperationsManager>(propertyExpression, transform, config);
+
+    // ushort? -> ushort? transformation
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="ushort"/> property.
+    /// </summary>
+    protected IPropertyProxy<NullableUShortOperationsManager> ForTransform(
+        Expression<Func<T, ushort?>> propertyExpression,
+        Func<ushort?, ushort?> transform
+    ) => ForTransform<ushort?, NullableUShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a same-type transformation for a nullable <see cref="ushort"/> property, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableUShortOperationsManager> ForTransform(
+        Expression<Func<T, ushort?>> propertyExpression,
+        Func<ushort?, ushort?> transform,
+        RuleConfig config
+    ) => ForTransform<ushort?, NullableUShortOperationsManager>(propertyExpression, transform, config);
+
     // ulong -> ulong transformation
     /// <summary>
     /// Registers a same-type transformation for a <see cref="ulong"/> property.
@@ -1608,6 +1644,42 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, uint?> transform,
         RuleConfig config
     ) => ForTransform<TProp, uint?, NullableUIntOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> ushort
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="ushort"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<UShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ushort> transform
+    ) => ForTransform<TProp, ushort, UShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="ushort"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<UShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ushort> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, ushort, UShortOperationsManager>(propertyExpression, transform, config);
+
+    // Cross-type -> ushort?
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="ushort"/> applied before validation.
+    /// </summary>
+    protected IPropertyProxy<NullableUShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ushort?> transform
+    ) => ForTransform<TProp, ushort?, NullableUShortOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to nullable <see cref="ushort"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    protected IPropertyProxy<NullableUShortOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, ushort?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, ushort?, NullableUShortOperationsManager>(propertyExpression, transform, config);
 
     // Cross-type -> ulong
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/TestExtension.UShort.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.UShort.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Manager;
+
+namespace JAAvila.FluentOperations;
+
+public static partial class TestExtension
+{
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="ushort"/> value.
+    /// </summary>
+    /// <param name="value">The ushort value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="UShortOperationsManager"/> for chaining ushort-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// ushort port = 8080;
+    /// port.Test().BePositive().BeLessThan(65535);
+    /// </code>
+    /// </example>
+    [Pure]
+    public static UShortOperationsManager Test(
+        this ushort value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new UShortOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified nullable <see cref="ushort"/> value.
+    /// </summary>
+    /// <param name="value">The nullable ushort value to test.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="NullableUShortOperationsManager"/> for chaining nullable ushort-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// ushort? port = null;
+    /// port.Test().NotHaveValue();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static NullableUShortOperationsManager Test(
+        this ushort? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new NullableUShortOperationsManager(value, callerName);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeDivisibleByValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is evenly divisible by the specified divisor.
+/// </summary>
+internal class NullableUShortBeDivisibleByValidator(PrincipalChain<ushort?> chain, ushort divisor)
+    : IValidator
+{
+    public static NullableUShortBeDivisibleByValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort divisor
+    ) => new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be divisible by the given divisor, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is greater than or equal to the expected value.
+/// </summary>
+internal class NullableUShortBeGreaterThanOrEqualToValidator(
+    PrincipalChain<ushort?> chain,
+    ushort comparison
+) : IValidator
+{
+    public static NullableUShortBeGreaterThanOrEqualToValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeGreaterThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is greater than the expected value.
+/// </summary>
+internal class NullableUShortBeGreaterThanValidator(PrincipalChain<ushort?> chain, ushort comparison)
+    : IValidator
+{
+    public static NullableUShortBeGreaterThanValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be greater than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is within the specified inclusive range.
+/// </summary>
+internal class NullableUShortBeInRangeValidator(PrincipalChain<ushort?> chain, ushort min, ushort max)
+    : IValidator
+{
+    public static NullableUShortBeInRangeValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort min,
+        ushort max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in the given range, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is less than or equal to the expected value.
+/// </summary>
+internal class NullableUShortBeLessThanOrEqualToValidator(
+    PrincipalChain<ushort?> chain,
+    ushort comparison
+) : IValidator
+{
+    public static NullableUShortBeLessThanOrEqualToValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value <= comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than or equal to the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeLessThanValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is less than the expected value.
+/// </summary>
+internal class NullableUShortBeLessThanValidator(PrincipalChain<ushort?> chain, ushort comparison)
+    : IValidator
+{
+    public static NullableUShortBeLessThanValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort comparison
+    ) => new(chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < comparison)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be less than the given value, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeOddValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is odd.
+/// </summary>
+internal class NullableUShortBeOddValidator(PrincipalChain<ushort?> chain) : IValidator
+{
+    public static NullableUShortBeOddValidator New(PrincipalChain<ushort?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be odd, but an even value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeOneOfValidator.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is one of the specified allowed values.
+/// </summary>
+internal class NullableUShortBeOneOfValidator(PrincipalChain<ushort?> chain, ushort[] values)
+    : IValidator
+{
+    public static NullableUShortBeOneOfValidator New(PrincipalChain<ushort?> chain, ushort[] values) =>
+        new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be one of the given values, but it was not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBePositiveValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is strictly positive.
+/// </summary>
+internal class NullableUShortBePositiveValidator(PrincipalChain<ushort?> chain) : IValidator
+{
+    public static NullableUShortBePositiveValidator New(PrincipalChain<ushort?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be positive, but a non-positive value was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value equals the expected value.
+/// </summary>
+internal class NullableUShortBeValidator(PrincipalChain<ushort?> chain, ushort? expected) : IValidator
+{
+    public static NullableUShortBeValidator New(PrincipalChain<ushort?> chain, ushort? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortHaveValueValidator.cs
@@ -1,0 +1,27 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort has a value (is not null).
+/// </summary>
+internal class NullableUShortHaveValueValidator(PrincipalChain<ushort?> chain) : IValidator
+{
+    public static NullableUShortHaveValueValidator New(PrincipalChain<ushort?> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is outside the specified inclusive range.
+/// </summary>
+internal class NullableUShortNotBeInRangeValidator(PrincipalChain<ushort?> chain, ushort min, ushort max)
+    : IValidator
+{
+    public static NullableUShortNotBeInRangeValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort min,
+        ushort max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be in the given range, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeOneOfValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value is not one of the specified disallowed values.
+/// </summary>
+internal class NullableUShortNotBeOneOfValidator(PrincipalChain<ushort?> chain, ushort[] values)
+    : IValidator
+{
+    public static NullableUShortNotBeOneOfValidator New(
+        PrincipalChain<ushort?> chain,
+        ushort[] values
+    ) => new(chain, values);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        if (!values.Contains(value))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected not to be one of the given values, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotBeValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort value does not equal the expected value.
+/// </summary>
+internal class NullableUShortNotBeValidator(PrincipalChain<ushort?> chain, ushort? expected) : IValidator
+{
+    public static NullableUShortNotBeValidator New(PrincipalChain<ushort?> chain, ushort? expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected not to be {0}, but it was.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotHaveValueValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableUShortNotHaveValueValidator.cs
@@ -1,0 +1,28 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable ushort does not have a value (is null).
+/// </summary>
+internal class NullableUShortNotHaveValueValidator(PrincipalChain<ushort?> chain) : IValidator
+{
+    public static NullableUShortNotHaveValueValidator New(PrincipalChain<ushort?> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue().HasValue)
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was expected not to have a value.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeDivisibleByValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeDivisibleByValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is evenly divisible by the specified divisor.
+/// </summary>
+internal class UShortBeDivisibleByValidator(PrincipalChain<ushort> chain, ushort divisor) : IValidator
+{
+    public static UShortBeDivisibleByValidator New(PrincipalChain<ushort> chain, ushort divisor) =>
+        new(chain, divisor);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % divisor == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be divisible by {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeEvenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeEvenValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is even.
+/// </summary>
+internal class UShortBeEvenValidator(PrincipalChain<ushort> chain) : IValidator
+{
+    public static UShortBeEvenValidator New(PrincipalChain<ushort> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be even, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeGreaterThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeGreaterThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is greater than or equal to the expected value.
+/// </summary>
+internal class UShortBeGreaterThanOrEqualToValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortBeGreaterThanOrEqualToValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() >= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeGreaterThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is greater than the expected value.
+/// </summary>
+internal class UShortBeGreaterThanValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortBeGreaterThanValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be greater than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeInRangeValidator.cs
@@ -1,0 +1,34 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is within the specified inclusive range.
+/// </summary>
+internal class UShortBeInRangeValidator(PrincipalChain<ushort> chain, ushort min, ushort max) : IValidator
+{
+    public static UShortBeInRangeValidator New(PrincipalChain<ushort> chain, ushort min, ushort max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value >= min && value <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeLessThanOrEqualToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeLessThanOrEqualToValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is less than or equal to the expected value.
+/// </summary>
+internal class UShortBeLessThanOrEqualToValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortBeLessThanOrEqualToValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() <= expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than or equal to {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeLessThanValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is less than the expected value.
+/// </summary>
+internal class UShortBeLessThanValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortBeLessThanValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() < expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be less than {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeOddValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeOddValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is odd.
+/// </summary>
+internal class UShortBeOddValidator(PrincipalChain<ushort> chain) : IValidator
+{
+    public static UShortBeOddValidator New(PrincipalChain<ushort> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() % 2 != 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be odd, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is one of the specified allowed values.
+/// </summary>
+internal class UShortBeOneOfValidator(PrincipalChain<ushort> chain, params ushort[] expected) : IValidator
+{
+    public static UShortBeOneOfValidator New(PrincipalChain<ushort> chain, params ushort[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBePositiveValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBePositiveValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is strictly positive (greater than zero).
+/// </summary>
+internal class UShortBePositiveValidator(PrincipalChain<ushort> chain) : IValidator
+{
+    public static UShortBePositiveValidator New(PrincipalChain<ushort> chain) =>
+        new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() > 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be positive, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value equals the expected value.
+/// </summary>
+internal class UShortBeValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortBeValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be {0}, but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortBeZeroValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortBeZeroValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is zero.
+/// </summary>
+internal class UShortBeZeroValidator(PrincipalChain<ushort> chain) : IValidator
+{
+    public static UShortBeZeroValidator New(PrincipalChain<ushort> chain) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() == 0)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to be zero, but {0} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeInRangeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeInRangeValidator.cs
@@ -1,0 +1,35 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is outside the specified inclusive range.
+/// </summary>
+internal class UShortNotBeInRangeValidator(PrincipalChain<ushort> chain, ushort min, ushort max)
+    : IValidator
+{
+    public static UShortNotBeInRangeValidator New(PrincipalChain<ushort> chain, ushort min, ushort max) =>
+        new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (value < min || value > max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be in range [{0}, {1}], but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeOneOfValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value is not one of the specified disallowed values.
+/// </summary>
+internal class UShortNotBeOneOfValidator(PrincipalChain<ushort> chain, params ushort[] expected) : IValidator
+{
+    public static UShortNotBeOneOfValidator New(PrincipalChain<ushort> chain, params ushort[] expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!expected.Contains(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/UShortNotBeValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the ushort value does not equal the expected value.
+/// </summary>
+internal class UShortNotBeValidator(PrincipalChain<ushort> chain, ushort expected) : IValidator
+{
+    public static UShortNotBeValidator New(PrincipalChain<ushort> chain, ushort expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue() != expected)
+        {
+            return true;
+        }
+
+        ResultValidation = "The resulting value was expected to not be {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -298,6 +298,37 @@ Manager: `UIntOperationsManager` / `NullableUIntOperationsManager`
 
 ---
 
+### UShort Validations
+
+Manager: `UShortOperationsManager` / `NullableUShortOperationsManager`
+
+| Operation | Description |
+|-----------|-------------|
+| `Be(ushort)` | Equals expected |
+| `NotBe(ushort)` | Does not equal |
+| `BePositive()` | Greater than zero |
+| `BeZero()` | Equals zero |
+| `BeGreaterThan(ushort)` | Greater than value |
+| `BeGreaterThanOrEqualTo(ushort)` | Greater than or equal |
+| `BeLessThan(ushort)` | Less than value |
+| `BeLessThanOrEqualTo(ushort)` | Less than or equal |
+| `BeInRange(ushort, ushort)` | Within inclusive range |
+| `NotBeInRange(ushort, ushort)` | Outside range |
+| `BeOneOf(params ushort[])` | In set of values |
+| `NotBeOneOf(params ushort[])` | Not in set |
+| `BeDivisibleBy(ushort)` | Divisible by value |
+| `BeEven()` | Divisible by 2 |
+| `BeOdd()` | Not divisible by 2 |
+
+> **Note:** `BeNegative()` is not available for `ushort` because it is an unsigned type (range 0-65,535).
+
+**Nullable ushort (`ushort?`)** adds:
+- `HaveValue()` -- has a non-null value
+- `NotHaveValue()` -- is null
+- All ushort operations above (with FailIf null guards)
+
+---
+
 ### ULong Validations
 
 Manager: `ULongOperationsManager` / `NullableULongOperationsManager`


### PR DESCRIPTION
  Add UShortOperationsManager (15 operations) and NullableUShortOperationsManager
  (17 operations) following the established unsigned numeric type pattern.
  BeNegative() is intentionally excluded as ushort is unsigned (0-65,535).

  This completes support for ALL .NET numeric primitive types: byte, sbyte,
  short, ushort, int, uint, long, ulong, char, float, double, decimal.

  Operations: Be, NotBe, BePositive, BeZero, BeGreaterThan,
  BeGreaterThanOrEqualTo, BeLessThan, BeLessThanOrEqualTo, BeInRange,
  NotBeInRange, BeOneOf, NotBeOneOf, BeDivisibleBy, BeEven, BeOdd.
  Nullable adds: HaveValue, NotHaveValue (+ all above with FailIf null guards).

  New files:
  - 32 validators: 15 UShortXxxValidator + 17 NullableUShortXxxValidator
  - 2 managers: UShortOperationsManager, NullableUShortOperationsManager
  - 1 extension: TestExtension.UShort.cs

  Changes:
  - Operations.cs: Add Operations.UShort (15 entries) and Operations.NullableUShort (2 entries) enums
  - PropertyProxy.cs: Register UShortOperationsManager and NullableUShortOperationsManager for Blueprint support
  - QualityBlueprint.For.cs: Add dedicated For() overloads for ushort and ushort? to prevent implicit int conversion from selecting IntegerOperationsManager
  - QualityBlueprint.ForTransform.cs: Add 8 ForTransform shortcuts (4 same-type + 4 cross-type) for ushort and ushort?
  - API.md: Add UShort Validations documentation section