### PR TITLE
Add null-checking operations to Collection, Array, Dictionary, and ActionStats managers

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Manager/ActionStatsOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ActionStatsOperationsManager.cs
@@ -29,6 +29,63 @@ public class ActionStatsOperationsManager : ITestManager<ActionStatsOperationsMa
     }
 
     /// <summary>
+    /// Asserts that the ActionStats value is <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ActionStatsOperationsManager BeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ActionStatsOperationsManager, ActionStats?>
+            .New(this)
+            .WithOperation(ReferenceBeNullValidator<ActionStats?>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the ActionStats value is not <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ActionStatsOperationsManager NotBeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ActionStatsOperationsManager, ActionStats?>
+            .New(this)
+            .WithOperation(ReferenceNotBeNullValidator<ActionStats?>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the action completed within the specified maximum duration.
     /// </summary>
     /// <param name="maxDuration">The maximum allowed duration.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -34,6 +34,63 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
     }
 
     /// <summary>
+    /// Asserts that the array is <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> BeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceBeNullValidator<IEnumerable<T>>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the array is not <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotBeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceNotBeNullValidator<IEnumerable<T>>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the array is the same reference as <paramref name="expected"/>.
     /// </summary>
     /// <param name="expected">The expected array/collection reference.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -42,6 +42,63 @@ public class CollectionOperationsManager<T>
     }
 
     /// <summary>
+    /// Asserts that the collection is <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> BeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceBeNullValidator<IEnumerable<T>>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the collection is not <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotBeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(ReferenceNotBeNullValidator<IEnumerable<T>>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the collection is the same reference as <paramref name="expected"/>.
     /// </summary>
     /// <param name="expected">The expected collection reference.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/DictionaryOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DictionaryOperationsManager.cs
@@ -33,6 +33,67 @@ public class DictionaryOperationsManager<TKey, TValue>
     }
 
     /// <summary>
+    /// Asserts that the dictionary is <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> BeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.BeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(
+                ReferenceBeNullValidator<IDictionary<TKey, TValue>>.New(PrincipalChain)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the dictionary is not <c>null</c>.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public DictionaryOperationsManager<TKey, TValue> NotBeNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.NotBeNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DictionaryOperationsManager<TKey, TValue>, IDictionary<TKey, TValue>>
+            .New(this)
+            .WithOperation(
+                ReferenceNotBeNullValidator<IDictionary<TKey, TValue>>.New(PrincipalChain)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the dictionary is the same reference as <paramref name="expected"/>.
     /// </summary>
     /// <param name="expected">The expected dictionary reference.</param>

--- a/docs/API.md
+++ b/docs/API.md
@@ -576,6 +576,8 @@ Manager: `CollectionOperationsManager<T>`
 
 | Method | Description |
 |--------|-------------|
+| `BeNull()` | Value is null |
+| `NotBeNull()` | Value is not null |
 | `NotBeNullOrEmpty()` | Not null and has elements |
 | `BeEmpty()` | No elements |
 | `NotBeEmpty()` | Has elements |
@@ -633,6 +635,8 @@ All Collection operations plus (including equivalence: `BeEquivalentTo`, `NotBeE
 
 | Method | Description |
 |--------|-------------|
+| `BeNull()` | Value is null |
+| `NotBeNull()` | Value is not null |
 | `HaveLength(int)` | Exact array length |
 | `HaveLengthGreaterThan(int)` | More than N |
 | `HaveLengthLessThan(int)` | Fewer than N |
@@ -651,6 +655,8 @@ Manager: `DictionaryOperationsManager<TKey, TValue>`
 
 | Method | Description |
 |--------|-------------|
+| `BeNull()` | Value is null |
+| `NotBeNull()` | Value is not null |
 | `ContainKey(TKey)` | Has key |
 | `NotContainKey(TKey)` | Does not have key |
 | `ContainValue(TValue)` | Has value |
@@ -850,6 +856,8 @@ Manager: `ActionStatsOperationsManager`
 
 | Method | Description |
 |--------|-------------|
+| `BeNull()` | ActionStats value is null |
+| `NotBeNull()` | ActionStats value is not null |
 | `CompleteWithin(TimeSpan)` | Elapsed time <= max |
 | `CompleteWithinMilliseconds(double)` | Convenience overload |
 | `TakeLongerThan(TimeSpan)` | Elapsed time >= min |


### PR DESCRIPTION
  Expose null-checking operations on 4 managers that work with nullable
  reference types but previously lacked explicit null assertions.

  Added methods:
  - CollectionOperationsManager<T>: BeNull(), NotBeNull()
  - ArrayOperationsManager<T>: BeNull(), NotBeNull()
  - DictionaryOperationsManager<TKey, TValue>: BeNull(), NotBeNull()
  - ActionStatsOperationsManager: BeNull(), NotBeNull()

  Implementation reuses existing infrastructure with zero new files:
  - Validators: ReferenceBeNullValidator<TSubject>, ReferenceNotBeNullValidator<TSubject> (already generic)
  - Operations enum: Operations.Common.BeNull, Operations.Common.NotBeNull (already exist)

  Changes:
  - CollectionOperationsManager.cs: Add BeNull/NotBeNull methods
  - ArrayOperationsManager.cs: Add BeNull/NotBeNull methods
  - DictionaryOperationsManager.cs: Add BeNull/NotBeNull methods
  - ActionStatsOperationsManager.cs: Add BeNull/NotBeNull methods
  - API.md: Add BeNull/NotBeNull rows to Collection, Array, Dictionary, and ActionStats documentation tables