### PR TITLE
Fix NaN comparisons in double/float validators and add guards

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Manager/DoubleOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DoubleOperationsManager.cs
@@ -118,6 +118,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -148,6 +158,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -177,6 +197,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeZero)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -210,6 +240,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -241,6 +281,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -274,6 +324,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -305,6 +365,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -342,6 +412,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -388,6 +468,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -542,6 +632,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         .WithReason(reason?.ToString())
             )
             .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         divisor == 0.0 || double.IsNaN(divisor),
@@ -586,6 +686,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                         .WithReason(reason?.ToString())
             )
             .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(HavePrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         expectedDecimals < 0,
@@ -628,6 +738,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeRoundedTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -678,6 +798,16 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeApproximately)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>

--- a/Distributed/JAAvila.FluentOperations/Manager/FloatOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/FloatOperationsManager.cs
@@ -118,6 +118,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -148,6 +158,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -177,6 +197,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeZero)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -210,6 +240,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -241,6 +281,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -274,6 +324,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -305,6 +365,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .Execute();
 
@@ -342,6 +412,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -388,6 +468,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -542,6 +632,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         .WithReason(reason?.ToString())
             )
             .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         divisor is 0.0f or float.NaN,
@@ -586,6 +686,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                         .WithReason(reason?.ToString())
             )
             .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(HavePrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         expectedDecimals < 0,
@@ -628,6 +738,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeRoundedTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>
@@ -678,6 +798,16 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
                             BaseFormatter.Format(PrincipalChain.GetValue())
                         )
                         .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(BeApproximately)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
             )
             .FailIf(
                 _ =>

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDoubleOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDoubleOperationsManager.cs
@@ -179,6 +179,17 @@ public class NullableDoubleOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -215,6 +226,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeNegative)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -257,6 +279,17 @@ public class NullableDoubleOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeZero)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -294,6 +327,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeGreaterThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -340,6 +384,17 @@ public class NullableDoubleOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -377,6 +432,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeLessThan)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -420,6 +486,17 @@ public class NullableDoubleOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -459,6 +536,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -514,6 +602,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -664,6 +763,17 @@ public class NullableDoubleOperationsManager
                     )
             )
             .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         divisor == 0d,
@@ -717,6 +827,17 @@ public class NullableDoubleOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(HavePrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -755,6 +876,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeRoundedTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeRoundedTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -802,6 +934,17 @@ public class NullableDoubleOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeApproximately)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeApproximately)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableFloatOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableFloatOperationsManager.cs
@@ -179,6 +179,17 @@ public class NullableFloatOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BePositive)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -218,6 +229,17 @@ public class NullableFloatOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeNegative)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -254,6 +276,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeZero)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeZero)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -297,6 +330,17 @@ public class NullableFloatOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -334,6 +378,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeGreaterThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -377,6 +432,17 @@ public class NullableFloatOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeLessThan)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -414,6 +480,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeLessThanOrEqualTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeLessThanOrEqualTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -456,6 +533,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -507,6 +595,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(NotBeInRange)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(NotBeInRange)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -657,6 +756,17 @@ public class NullableFloatOperationsManager
                     )
             )
             .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeDivisibleBy)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
                 _ =>
                     (
                         divisor == 0f,
@@ -707,6 +817,17 @@ public class NullableFloatOperationsManager
                         )
                     )
             )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(HavePrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
             .Execute();
 
         return this;
@@ -745,6 +866,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeRoundedTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeRoundedTo)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )
@@ -792,6 +924,17 @@ public class NullableFloatOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(BeApproximately)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(BeApproximately)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/Validators/DoubleBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DoubleBeValidator.cs
@@ -15,7 +15,7 @@ internal class DoubleBeValidator(PrincipalChain<double> chain, double expected) 
 
     public bool Validate()
     {
-        if (chain.GetValue() == expected)
+        if (chain.GetValue().Equals(expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/DoubleNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DoubleNotBeValidator.cs
@@ -15,7 +15,7 @@ internal class DoubleNotBeValidator(PrincipalChain<double> chain, double expecte
 
     public bool Validate()
     {
-        if (chain.GetValue() != expected)
+        if (!chain.GetValue().Equals(expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/FloatBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/FloatBeValidator.cs
@@ -15,7 +15,7 @@ internal class FloatBeValidator(PrincipalChain<float> chain, float expected) : I
 
     public bool Validate()
     {
-        if (chain.GetValue() == expected)
+        if (chain.GetValue().Equals(expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/FloatNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/FloatNotBeValidator.cs
@@ -15,7 +15,7 @@ internal class FloatNotBeValidator(PrincipalChain<float> chain, float expected) 
 
     public bool Validate()
     {
-        if (chain.GetValue() != expected)
+        if (!chain.GetValue().Equals(expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleBeValidator.cs
@@ -18,7 +18,7 @@ internal class NullableDoubleBeValidator(PrincipalChain<double?> chain, double? 
     {
         var value = chain.GetValue();
 
-        if (value == expected)
+        if (Nullable.Equals(value, expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleNotBeValidator.cs
@@ -20,7 +20,7 @@ internal class NullableDoubleNotBeValidator(PrincipalChain<double?> chain, doubl
     {
         var value = chain.GetValue();
 
-        if (value != expected)
+        if (!Nullable.Equals(value, expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableFloatBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableFloatBeValidator.cs
@@ -17,7 +17,7 @@ internal class NullableFloatBeValidator(PrincipalChain<float?> chain, float? exp
     {
         var value = chain.GetValue();
 
-        if (value == expected)
+        if (Nullable.Equals(value, expected))
         {
             return true;
         }

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableFloatNotBeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableFloatNotBeValidator.cs
@@ -16,7 +16,7 @@ internal class NullableFloatNotBeValidator(PrincipalChain<float?> chain, float? 
 
     public bool Validate()
     {
-        if (chain.GetValue() != expected)
+        if (!Nullable.Equals(chain.GetValue(), expected))
         {
             return true;
         }


### PR DESCRIPTION
  Replace == / != operators with .Equals() / Nullable.Equals() in Be/NotBe
  validators for double, float, and their nullable variants so that
  NaN-vs-NaN equality is evaluated correctly (NaN.Equals(NaN) returns true,
  unlike the == operator which always returns false per IEEE 754).

  Add FailIf NaN precondition guards to 13 operations across 4 managers
  (DoubleOperationsManager, FloatOperationsManager, NullableDoubleOperationsManager,
  NullableFloatOperationsManager). Guarded operations: BePositive, BeNegative,
  BeZero, BeGreaterThan, BeGreaterThanOrEqualTo, BeLessThan,
  BeLessThanOrEqualTo, BeInRange, NotBeInRange, BeApproximately,
  BeDivisibleBy, HavePrecision, BeRoundedTo. The guard short-circuits with
  a descriptive message directing users to BeNaN/NotBeNaN.

  Category 1 — validator fixes (8 files):
  - DoubleBeValidator, DoubleNotBeValidator
  - FloatBeValidator, FloatNotBeValidator
  - NullableDoubleBeValidator, NullableDoubleNotBeValidator
  - NullableFloatBeValidator, NullableFloatNotBeValidator

  Category 2 — manager FailIf NaN guards (4 files, 52 guards):
  - DoubleOperationsManager (13 methods)
  - FloatOperationsManager (13 methods)
  - NullableDoubleOperationsManager (13 methods)
  - NullableFloatOperationsManager (13 methods)