### PR TITLE
Add string operations and ICustomValidator integration

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -96,6 +96,9 @@ public struct Operations
         [EnumStringValue("notbenullorwhitespace")]
         NotBeNullOrWhiteSpace,
 
+        [EnumStringValue("notbenullorempty")]
+        NotBeNullOrEmpty,
+
         [EnumStringValue("havelength")]
         HaveLength,
 
@@ -177,6 +180,12 @@ public struct Operations
         [EnumStringValue("havelengthbetween")]
         HaveLengthBetween,
 
+        [EnumStringValue("havelengthgreaterthan")]
+        HaveLengthGreaterThan,
+
+        [EnumStringValue("havelengthlessthan")]
+        HaveLengthLessThan,
+
         [EnumStringValue("containonlydigits")]
         ContainOnlyDigits,
 
@@ -185,6 +194,9 @@ public struct Operations
 
         [EnumStringValue("containnowhitespace")]
         ContainNoWhitespace,
+
+        [EnumStringValue("notcontain")]
+        NotContain,
 
         [EnumStringValue("containall")]
         ContainAll,

--- a/Distributed/JAAvila.FluentOperations/Manager/BaseOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/BaseOperationsManager.cs
@@ -366,6 +366,99 @@ public abstract class BaseOperationsManager<TManager, TSubject>
         return Manager;
     }
 
+    /// <summary>
+    /// Asserts that the value passes the given <see cref="ICustomValidator{TSubject}"/>.
+    /// </summary>
+    /// <param name="customValidator">The custom validator to evaluate.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="customValidator"/> is <c>null</c>.
+    /// </remarks>
+    public TManager Evaluate(ICustomValidator<TSubject> customValidator, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.Evaluate))
+        {
+            return Manager;
+        }
+
+        ExecutionEngine<TManager, TSubject>
+            .New(Manager)
+            .WithOperation(
+                ReferenceEvaluateCustomValidator<TSubject>.New(
+                    Manager.PrincipalChain,
+                    customValidator
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(Manager.PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        customValidator is null,
+                        Fail.New(
+                            $"The {nameof(Evaluate)} operation failed because the custom validator was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return Manager;
+    }
+
+    /// <summary>
+    /// Asserts asynchronously that the value passes the given <see cref="IAsyncCustomValidator{TSubject}"/>.
+    /// </summary>
+    /// <param name="customValidator">The async custom validator to evaluate.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>A task that completes with the current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="customValidator"/> is <c>null</c>.
+    /// </remarks>
+    public async Task<TManager> EvaluateAsync(
+        IAsyncCustomValidator<TSubject> customValidator,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Common.Evaluate))
+        {
+            return Manager;
+        }
+
+        await ExecutionEngine<TManager, TSubject>
+            .New(Manager)
+            .WithOperation(
+                ReferenceEvaluateAsyncCustomValidator<TSubject>.New(
+                    Manager.PrincipalChain,
+                    customValidator
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(Manager.PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        customValidator is null,
+                        Fail.New(
+                            $"The {nameof(EvaluateAsync)} operation failed because the async custom validator was <null>."
+                        )
+                    )
+            )
+            .ExecuteAsync();
+
+        return Manager;
+    }
+
     #region PRIVATE METHODS
 
     private TManager ValidateNotBeCastToOperation(Reason? reason, Type? expectedType)

--- a/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
@@ -246,6 +246,34 @@ public class StringOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the string is not <c>null</c> and not empty (<c>""</c>).
+    /// </summary>
+    /// <param name="reason">An optional reason to provide context for the operation.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    public StringOperationsManager NotBeNullOrEmpty(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.NotBeNullOrEmpty))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringNotBeNullOrEmptyValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithValue(StringFormatter.Format(PrincipalChain.GetValueAsString()))
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the string is <c>null</c>, empty, or consists only of white-space characters.
     /// </summary>
     /// <param name="reason">An optional reason to provide context for the operation.</param>
@@ -646,6 +674,131 @@ public class StringOperationsManager
                         expected == "",
                         Fail.New(
                             $"The {nameof(Contain)} operation failed because expected was empty."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the string does not contain the specified substring (ordinal comparison).
+    /// </summary>
+    /// <param name="expected">The substring that should not appear in the string. Cannot be <c>null</c> or empty.</param>
+    /// <param name="reason">An optional reason to provide context for the operation.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the string is <c>null</c>, or if <paramref name="expected"/> is <c>null</c> or empty.
+    /// </remarks>
+    public StringOperationsManager NotContain(string expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.NotContain))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringNotContainValidator.New(expected, PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithValue(StringFormatter.Format(PrincipalChain.GetValueAsString()))
+                        .WithResult(operation.ResultValidation, StringFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because expected was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected == "",
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because expected was empty."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the string does not contain the specified substring using the given StringComparison.
+    /// </summary>
+    /// <param name="expected">The substring that should not appear in the string. Cannot be <c>null</c> or empty.</param>
+    /// <param name="comparison">The <see cref="StringComparison"/> mode to use.</param>
+    /// <param name="reason">An optional reason to provide context for the operation.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the string is <c>null</c>, or if <paramref name="expected"/> is <c>null</c> or empty.
+    /// </remarks>
+    public StringOperationsManager NotContain(
+        string expected,
+        StringComparison comparison,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.NotContain))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringNotContainValidator.New(expected, PrincipalChain, comparison))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithValue(StringFormatter.Format(PrincipalChain.GetValueAsString()))
+                        .WithResult(operation.ResultValidation, StringFormatter.Format(expected))
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotContain)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because expected was <null>."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected == "",
+                        Fail.New(
+                            $"The {nameof(NotContain)} operation failed because expected was empty."
                         )
                     )
             )
@@ -1951,6 +2104,114 @@ public class StringOperationsManager
                         min < 0 || max < 0 || min > max,
                         Fail.New(
                             $"The {nameof(HaveLengthBetween)} operation failed because the arguments are invalid: min={min}, max={max}."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the string length is strictly greater than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The exclusive lower bound for character count. Must be non-negative.</param>
+    /// <param name="reason">An optional reason to provide context for the operation.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the string is <c>null</c> or if <paramref name="expected"/> is negative.
+    /// </remarks>
+    public StringOperationsManager HaveLengthGreaterThan(int expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.HaveLengthGreaterThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringHaveLengthGreaterThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString(),
+                            PrincipalChain.GetValue()!.Length.ToString()
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveLengthGreaterThan)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected < 0,
+                        Fail.New(
+                            $"The {nameof(HaveLengthGreaterThan)} operation failed because the expected length cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the string length is strictly less than <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The exclusive upper bound for character count. Must be non-negative.</param>
+    /// <param name="reason">An optional reason to provide context for the operation.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the string is <c>null</c> or if <paramref name="expected"/> is negative.
+    /// </remarks>
+    public StringOperationsManager HaveLengthLessThan(int expected, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.HaveLengthLessThan))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringHaveLengthLessThanValidator.New(PrincipalChain, expected))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString(),
+                            PrincipalChain.GetValue()!.Length.ToString()
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveLengthLessThan)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected < 0,
+                        Fail.New(
+                            $"The {nameof(HaveLengthLessThan)} operation failed because the expected length cannot be negative."
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/Validators/ReferenceEvaluateAsyncCustomValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReferenceEvaluateAsyncCustomValidator.cs
@@ -1,0 +1,39 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Wraps an <see cref="IAsyncCustomValidator{T}"/> into the internal <see cref="IValidator"/> contract.
+/// </summary>
+internal class ReferenceEvaluateAsyncCustomValidator<TSubject>(
+    PrincipalChain<TSubject> chain,
+    IAsyncCustomValidator<TSubject> customValidator
+) : IValidator
+{
+    public static ReferenceEvaluateAsyncCustomValidator<TSubject> New(
+        PrincipalChain<TSubject> chain,
+        IAsyncCustomValidator<TSubject> customValidator
+    ) => new(chain, customValidator);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        // Synchronous fallback -- block on the async validator
+        return ValidateAsync().GetAwaiter().GetResult();
+    }
+
+    public async Task<bool> ValidateAsync()
+    {
+        var value = chain.GetValue();
+
+        if (await customValidator.IsValidAsync(value))
+        {
+            return true;
+        }
+
+        ResultValidation = customValidator.GetFailureMessage(value);
+        return false;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReferenceEvaluateCustomValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReferenceEvaluateCustomValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Wraps an <see cref="ICustomValidator{T}"/> into the internal <see cref="IValidator"/> contract.
+/// </summary>
+internal class ReferenceEvaluateCustomValidator<TSubject>(
+    PrincipalChain<TSubject> chain,
+    ICustomValidator<TSubject> customValidator
+) : IValidator
+{
+    public static ReferenceEvaluateCustomValidator<TSubject> New(
+        PrincipalChain<TSubject> chain,
+        ICustomValidator<TSubject> customValidator
+    ) => new(chain, customValidator);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (customValidator.IsValid(value))
+        {
+            return true;
+        }
+
+        ResultValidation = customValidator.GetFailureMessage(value);
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/StringHaveLengthGreaterThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringHaveLengthGreaterThanValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string length is strictly greater than the expected value.
+/// </summary>
+internal class StringHaveLengthGreaterThanValidator(PrincipalChain<string?> chain, int expected)
+    : IValidator
+{
+    public static StringHaveLengthGreaterThanValidator New(PrincipalChain<string?> chain, int expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue()!.Length > expected)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The value was expected to have a length greater than {0}, but the actual length was {1}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/StringHaveLengthLessThanValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringHaveLengthLessThanValidator.cs
@@ -1,0 +1,30 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string length is strictly less than the expected value.
+/// </summary>
+internal class StringHaveLengthLessThanValidator(PrincipalChain<string?> chain, int expected)
+    : IValidator
+{
+    public static StringHaveLengthLessThanValidator New(PrincipalChain<string?> chain, int expected) =>
+        new(chain, expected);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (chain.GetValue()!.Length < expected)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The value was expected to have a length less than {0}, but the actual length was {1}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/StringNotBeNullOrEmptyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringNotBeNullOrEmptyValidator.cs
@@ -1,0 +1,31 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string is not null and not empty.
+/// </summary>
+internal class StringNotBeNullOrEmptyValidator(PrincipalChain<string?> chain) : IValidator
+{
+    public static StringNotBeNullOrEmptyValidator New(PrincipalChain<string?> chain) =>
+        new(chain);
+
+    public string Expected => "Not be null or empty";
+    public string ResultValidation { get; set; } = string.Empty;
+
+    public bool Validate()
+    {
+        if (!string.IsNullOrEmpty(chain.GetValue()))
+        {
+            return true;
+        }
+
+        ResultValidation = "The subject was not expected to be null or empty.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/StringNotContainValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringNotContainValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string does not contain the expected substring.
+/// </summary>
+internal class StringNotContainValidator(
+    string expected,
+    PrincipalChain<string?> chain,
+    StringComparison comparison = StringComparison.Ordinal
+) : IValidator
+{
+    public static StringNotContainValidator New(string expected, PrincipalChain<string?> chain) =>
+        new(expected, chain);
+
+    public static StringNotContainValidator New(
+        string expected,
+        PrincipalChain<string?> chain,
+        StringComparison comparison) =>
+        new(expected, chain, comparison);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        if (!chain.GetValue()!.Contains(expected, comparison))
+        {
+            return true;
+        }
+
+        ResultValidation = "The value was expected to not contain {0}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}


### PR DESCRIPTION
  Add NotContain, NotBeNullOrEmpty, HaveLengthGreaterThan, and
  HaveLengthLessThan operations to StringOperationsManager with their
  corresponding validators and enum entries.

  Add Evaluate(ICustomValidator<T>) and EvaluateAsync(IAsyncCustomValidator<T>)
  overloads to BaseOperationsManager, bridging the existing validator
  interfaces with the .Test() inline assertion API.

  - StringNotContainValidator with StringComparison overload
  - StringNotBeNullOrEmptyValidator (handles null and empty internally)
  - StringHaveLengthGreaterThanValidator / StringHaveLengthLessThanValidator
  - ReferenceEvaluateCustomValidator<T> wrapping ICustomValidator<T>
  - ReferenceEvaluateAsyncCustomValidator<T> wrapping IAsyncCustomValidator<T>
  - 4 new entries in Operations.String enum
  - 6 new methods on StringOperationsManager
  - 2 new overloads on BaseOperationsManager