### PR TITLE
Add BeOneOf and NotBeOneOf operations to StringOperationsManager

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -227,6 +227,12 @@ public struct Operations
 
         [EnumStringValue("beipv6")]
         BeIPv6,
+
+        [EnumStringValue("beoneof")]
+        BeOneOf,
+
+        [EnumStringValue("notbeoneof")]
+        NotBeOneOf,
     }
 
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
@@ -3253,4 +3253,232 @@ public class StringOperationsManager
 
         return this;
     }
+
+    // =========================================================================
+    // BeOneOf / NotBeOneOf
+    // =========================================================================
+
+    /// <summary>
+    /// Asserts that the string is one of the specified allowed values (ordinal comparison).
+    /// </summary>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager BeOneOf(params string?[] expected)
+    {
+        return BeOneOfCore(null, null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is one of the specified allowed values using the given string comparison mode.
+    /// </summary>
+    /// <param name="comparison">The <see cref="StringComparison"/> mode to use.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager BeOneOf(
+        StringComparison comparison,
+        params string?[] expected
+    )
+    {
+        return BeOneOfCore(comparison, null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is one of the specified allowed values (ordinal comparison).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager BeOneOf(Reason? reason, params string?[] expected)
+    {
+        return BeOneOfCore(null, reason, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is one of the specified allowed values using the given string comparison mode.
+    /// </summary>
+    /// <param name="comparison">The <see cref="StringComparison"/> mode to use.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of allowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager BeOneOf(
+        StringComparison comparison,
+        Reason? reason,
+        params string?[] expected
+    )
+    {
+        return BeOneOfCore(comparison, reason, expected);
+    }
+
+    private StringOperationsManager BeOneOfCore(
+        StringComparison? comparison,
+        Reason? reason,
+        string?[] expected
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.BeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringBeOneOfValidator.New(PrincipalChain, expected, comparison))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => e is null ? "<null>" : $"\"{e}\"")),
+                            PrincipalChain.GetValue() is null ? "<null>" : $"\"{PrincipalChain.GetValue()}\""
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeOneOf)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the string is not one of the specified disallowed values (ordinal comparison).
+    /// </summary>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager NotBeOneOf(params string?[] expected)
+    {
+        return NotBeOneOfCore(null, null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is not one of the specified disallowed values using the given string comparison mode.
+    /// </summary>
+    /// <param name="comparison">The <see cref="StringComparison"/> mode to use.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager NotBeOneOf(
+        StringComparison comparison,
+        params string?[] expected
+    )
+    {
+        return NotBeOneOfCore(comparison, null, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is not one of the specified disallowed values (ordinal comparison).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager NotBeOneOf(Reason? reason, params string?[] expected)
+    {
+        return NotBeOneOfCore(null, reason, expected);
+    }
+
+    /// <summary>
+    /// Asserts that the string is not one of the specified disallowed values using the given string comparison mode.
+    /// </summary>
+    /// <param name="comparison">The <see cref="StringComparison"/> mode to use.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="expected">The set of disallowed values.</param>
+    /// <returns>The current instance of <see cref="StringOperationsManager"/> for method chaining.</returns>
+    /// <remarks>
+    /// Fails immediately if <paramref name="expected"/> is null or empty, or if the string is <c>null</c>.
+    /// </remarks>
+    public StringOperationsManager NotBeOneOf(
+        StringComparison comparison,
+        Reason? reason,
+        params string?[] expected
+    )
+    {
+        return NotBeOneOfCore(comparison, reason, expected);
+    }
+
+    private StringOperationsManager NotBeOneOfCore(
+        StringComparison? comparison,
+        Reason? reason,
+        string?[] expected
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.String.NotBeOneOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<StringOperationsManager, string?>
+            .New(this)
+            .WithOperation(StringNotBeOneOfValidator.New(PrincipalChain, expected, comparison))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            string.Join(", ", expected.Select(e => e is null ? "<null>" : $"\"{e}\"")),
+                            PrincipalChain.GetValue() is null ? "<null>" : $"\"{PrincipalChain.GetValue()}\""
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expected is null || expected.Length == 0,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because you have not provided any values."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeOneOf)} operation failed because the parent value was <null>. {{0}}.",
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Validators/StringBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringBeOneOfValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string value is one of the specified allowed values.
+/// </summary>
+internal class StringBeOneOfValidator(
+    PrincipalChain<string?> chain,
+    string?[] expected,
+    StringComparison? comparison
+) : IValidator
+{
+    public static StringBeOneOfValidator New(
+        PrincipalChain<string?> chain,
+        string?[] expected,
+        StringComparison? comparison = null
+    ) => new(chain, expected, comparison);
+
+    public string Expected { get; } = string.Join(", ", expected.Select(e => e is null ? "<null>" : $"\"{e}\""));
+    public string ResultValidation { get; set; } = string.Empty;
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+        var comp = comparison ?? StringComparison.Ordinal;
+
+        if (expected.Any(e => string.Equals(value, e, comp)))
+        {
+            return true;
+        }
+
+        ResultValidation = comparison.HasValue
+            ? $"The resulting value was expected to be one of [{{0}}] using {comp}, but {{1}} was found."
+            : "The resulting value was expected to be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/StringNotBeOneOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/StringNotBeOneOfValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the string value is not one of the specified disallowed values.
+/// </summary>
+internal class StringNotBeOneOfValidator(
+    PrincipalChain<string?> chain,
+    string?[] expected,
+    StringComparison? comparison
+) : IValidator
+{
+    public static StringNotBeOneOfValidator New(
+        PrincipalChain<string?> chain,
+        string?[] expected,
+        StringComparison? comparison = null
+    ) => new(chain, expected, comparison);
+
+    public string Expected { get; } = string.Join(", ", expected.Select(e => e is null ? "<null>" : $"\"{e}\""));
+    public string ResultValidation { get; set; } = string.Empty;
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+        var comp = comparison ?? StringComparison.Ordinal;
+
+        if (!expected.Any(e => string.Equals(value, e, comp)))
+        {
+            return true;
+        }
+
+        ResultValidation = comparison.HasValue
+            ? $"The resulting value was expected to not be one of [{{0}}] using {comp}, but {{1}} was found."
+            : "The resulting value was expected to not be one of [{0}], but {1} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}


### PR DESCRIPTION
  Add 8 public overloads (4 per operation) with StringComparison support
  for case-insensitive matching, following the ContainAll/ContainAny
  multi-overload pattern with private Core delegation methods.

  - StringBeOneOfValidator using string.Equals with StringComparison
  - StringNotBeOneOfValidator (negated variant)
  - 4 overloads each: params-only, StringComparison, Reason, both
  - FailIf guards for null/empty expected array and null value
  - 2 new entries in Operations.String enum