### PR TITLE
Add NotBeCloseTo and complete BeCloseTo for nullable DateTime

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -1169,6 +1169,9 @@ public struct Operations
 
         [EnumStringValue("becloseto")]
         BeCloseTo,
+
+        [EnumStringValue("notbecloseto")]
+        NotBeCloseTo,
     }
 
     /// <summary>
@@ -1313,6 +1316,12 @@ public struct Operations
 
         [EnumStringValue("nothavevalue")]
         NotHaveValue,
+
+        [EnumStringValue("beclosetodatetime")]
+        BeCloseTo,
+
+        [EnumStringValue("notbeclosetodatetime")]
+        NotBeCloseTo,
     }
 
     /// <summary>
@@ -1729,6 +1738,9 @@ public struct Operations
         [EnumStringValue("becloseto")]
         BeCloseTo,
 
+        [EnumStringValue("notbeclosetodatetimeoffset")]
+        NotBeCloseTo,
+
         [EnumStringValue("haveoffset")]
         HaveOffset,
 
@@ -1758,6 +1770,12 @@ public struct Operations
 
         [EnumStringValue("nothavevalue")]
         NotHaveValue,
+
+        [EnumStringValue("beclosetodatetimeoffset")]
+        BeCloseTo,
+
+        [EnumStringValue("notbeclosetodatetimeoffset")]
+        NotBeCloseTo,
     }
 
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/DateTimeOffsetOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DateTimeOffsetOperationsManager.cs
@@ -399,6 +399,67 @@ public class DateTimeOffsetOperationsManager
                         )
                         .WithReason(reason?.ToString())
             )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(BeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is NOT within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The date and time to compare against.</param>
+    /// <param name="tolerance">The minimum required difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public DateTimeOffsetOperationsManager NotBeCloseTo(
+        DateTimeOffset expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTimeOffset.NotBeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DateTimeOffsetOperationsManager, DateTimeOffset>
+            .New(this)
+            .WithOperation(
+                DateTimeOffsetNotBeCloseToValidator.New(PrincipalChain, expected, tolerance)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
             .Execute();
 
         return this;

--- a/Distributed/JAAvila.FluentOperations/Manager/DateTimeOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DateTimeOperationsManager.cs
@@ -770,6 +770,56 @@ public class DateTimeOperationsManager : ITestManager<DateTimeOperationsManager,
     }
 
     /// <summary>
+    /// Asserts that the value is NOT within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The date and time to compare against.</param>
+    /// <param name="tolerance">The minimum required difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public DateTimeOperationsManager NotBeCloseTo(
+        DateTime expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.DateTime.NotBeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DateTimeOperationsManager, DateTime>
+            .New(this)
+            .WithOperation(DateTimeNotBeCloseToValidator.New(PrincipalChain, expected, tolerance))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the runtime type of the value is exactly <typeparamref name="TType"/>.
     /// </summary>
     public DateTimeOperationsManager BeOfType<TType>(Reason? reason = null)

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOffsetOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOffsetOperationsManager.cs
@@ -248,6 +248,124 @@ public class NullableDateTimeOffsetOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the value is within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected date and time to compare against.</param>
+    /// <param name="tolerance">The maximum allowed difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard) or if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public NullableDateTimeOffsetOperationsManager BeCloseTo(
+        DateTimeOffset expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableDateTimeOffset.BeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOffsetOperationsManager, DateTimeOffset?>
+            .New(this)
+            .WithOperation(NullableDateTimeOffsetBeCloseToValidator.New(PrincipalChain, expected, tolerance))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeCloseTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(BeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is NOT within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The date and time to compare against.</param>
+    /// <param name="tolerance">The minimum required difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard) or if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public NullableDateTimeOffsetOperationsManager NotBeCloseTo(
+        DateTimeOffset expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableDateTimeOffset.NotBeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOffsetOperationsManager, DateTimeOffset?>
+            .New(this)
+            .WithOperation(NullableDateTimeOffsetNotBeCloseToValidator.New(PrincipalChain, expected, tolerance))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the runtime type of the value is exactly <typeparamref name="TType"/>.
     /// </summary>
     public NullableDateTimeOffsetOperationsManager BeOfType<TType>(Reason? reason = null)

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDateTimeOperationsManager.cs
@@ -248,6 +248,124 @@ public class NullableDateTimeOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the value is within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The expected date and time to compare against.</param>
+    /// <param name="tolerance">The maximum allowed difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard) or if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public NullableDateTimeOperationsManager BeCloseTo(
+        DateTime expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableDateTime.BeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOperationsManager, DateTime?>
+            .New(this)
+            .WithOperation(NullableDateTimeBeCloseToValidator.New(PrincipalChain, expected, tolerance))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeCloseTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(BeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the value is NOT within <paramref name="tolerance"/> of <paramref name="expected"/>.
+    /// </summary>
+    /// <param name="expected">The date and time to compare against.</param>
+    /// <param name="tolerance">The minimum required difference from the expected value.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard) or if <paramref name="tolerance"/> is negative.
+    /// </remarks>
+    public NullableDateTimeOperationsManager NotBeCloseTo(
+        DateTime expected,
+        TimeSpan tolerance,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.NullableDateTime.NotBeCloseTo))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDateTimeOperationsManager, DateTime?>
+            .New(this)
+            .WithOperation(NullableDateTimeNotBeCloseToValidator.New(PrincipalChain, expected, tolerance))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            expected.ToString("O"),
+                            BaseFormatter.Format(tolerance),
+                            BaseFormatter.Format(PrincipalChain.GetValue())
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        tolerance < TimeSpan.Zero,
+                        Fail.New(
+                            $"The {nameof(NotBeCloseTo)} operation failed because the tolerance cannot be negative."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the runtime type of the value is exactly <typeparamref name="TType"/>.
     /// </summary>
     public NullableDateTimeOperationsManager BeOfType<TType>(Reason? reason = null)

--- a/Distributed/JAAvila.FluentOperations/Validators/DateTimeNotBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DateTimeNotBeCloseToValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the datetime value is NOT close to the expected value within a specified precision.
+/// </summary>
+internal class DateTimeNotBeCloseToValidator(
+    PrincipalChain<DateTime> chain,
+    DateTime expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static DateTimeNotBeCloseToValidator New(
+        PrincipalChain<DateTime> chain,
+        DateTime expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value - expected).Ticks) > tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/DateTimeOffsetNotBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DateTimeOffsetNotBeCloseToValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the datetimeoffset value is NOT close to the expected value within a specified precision.
+/// </summary>
+internal class DateTimeOffsetNotBeCloseToValidator(
+    PrincipalChain<DateTimeOffset> chain,
+    DateTimeOffset expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static DateTimeOffsetNotBeCloseToValidator New(
+        PrincipalChain<DateTimeOffset> chain,
+        DateTimeOffset expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value - expected).Ticks) > tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeBeCloseToValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetime value is close to the expected value within a specified precision.
+/// </summary>
+internal class NullableDateTimeBeCloseToValidator(
+    PrincipalChain<DateTime?> chain,
+    DateTime expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static NullableDateTimeBeCloseToValidator New(
+        PrincipalChain<DateTime?> chain,
+        DateTime expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value!.Value - expected).Ticks) <= tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeNotBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeNotBeCloseToValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetime value is NOT close to the expected value within a specified precision.
+/// </summary>
+internal class NullableDateTimeNotBeCloseToValidator(
+    PrincipalChain<DateTime?> chain,
+    DateTime expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static NullableDateTimeNotBeCloseToValidator New(
+        PrincipalChain<DateTime?> chain,
+        DateTime expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value!.Value - expected).Ticks) > tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetBeCloseToValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetimeoffset value is close to the expected value within a specified precision.
+/// </summary>
+internal class NullableDateTimeOffsetBeCloseToValidator(
+    PrincipalChain<DateTimeOffset?> chain,
+    DateTimeOffset expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static NullableDateTimeOffsetBeCloseToValidator New(
+        PrincipalChain<DateTimeOffset?> chain,
+        DateTimeOffset expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value!.Value - expected).Ticks) <= tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetNotBeCloseToValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDateTimeOffsetNotBeCloseToValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable datetimeoffset value is NOT close to the expected value within a specified precision.
+/// </summary>
+internal class NullableDateTimeOffsetNotBeCloseToValidator(
+    PrincipalChain<DateTimeOffset?> chain,
+    DateTimeOffset expected,
+    TimeSpan tolerance
+) : IValidator
+{
+    public static NullableDateTimeOffsetNotBeCloseToValidator New(
+        PrincipalChain<DateTimeOffset?> chain,
+        DateTimeOffset expected,
+        TimeSpan tolerance
+    ) => new(chain, expected, tolerance);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        if (Math.Abs((value!.Value - expected).Ticks) > tolerance.Ticks)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting value was expected to not be close to {0} (tolerance: {1}), but {2} was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}


### PR DESCRIPTION
  Add NotBeCloseTo to all 4 DateTime-related managers and add missing
  BeCloseTo to NullableDateTimeOperationsManager and
  NullableDateTimeOffsetOperationsManager.

  Fix missing negative-tolerance FailIf guard on
  DateTimeOffsetOperationsManager.BeCloseTo (bugfix).

  - 6 new validators: NotBeCloseTo (DateTime, DateTimeOffset) + BeCloseTo/NotBeCloseTo for both nullable variants
  - 4 enum additions across NullableDateTime and NullableDateTimeOffset
  - NotBeCloseTo added to DateTimeOperationsManager and DateTimeOffsetOperationsManager
  - BeCloseTo + NotBeCloseTo added to both nullable managers with null + negative-tolerance FailIf guards