### PR TITLE
Add ContainEquivalentOf and NotContainEquivalentOf operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -1505,6 +1505,12 @@ public struct Operations
 
         [EnumStringValue("extractsinglematch")]
         ExtractSingleMatch,
+
+        [EnumStringValue("containequivalentof")]
+        ContainEquivalentOf,
+
+        [EnumStringValue("notcontainequivalentof")]
+        NotContainEquivalentOf,
     }
 
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -2660,6 +2660,192 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
         return this;
     }
 
+    // =========================================================================
+    // ContainEquivalentOf
+    // =========================================================================
+
+    /// <summary>
+    /// Asserts that the array contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using deep property-by-property comparison with default options.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Reason? reason = null
+    )
+    {
+        return ContainEquivalentOf(expected, ComparisonOptions.Default, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the array contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using comparison options configured via the <paramref name="configure"/> builder.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="configure">A lambda that configures the comparison options.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Action<ComparisonOptionsBuilder> configure,
+        Reason? reason = null
+    )
+    {
+        var builder = new ComparisonOptionsBuilder();
+        configure(builder);
+        return ContainEquivalentOf(expected, builder.Build(), reason);
+    }
+
+    /// <summary>
+    /// Asserts that the array contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using the specified <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="options">Options controlling the comparison behaviour.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        ComparisonOptions options,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.ContainEquivalentOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                CollectionContainEquivalentOfValidator<T, TExpected>.New(
+                    PrincipalChain,
+                    expected,
+                    options
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(ContainEquivalentOf)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    // =========================================================================
+    // NotContainEquivalentOf
+    // =========================================================================
+
+    /// <summary>
+    /// Asserts that no element in the array is structurally equivalent
+    /// to <paramref name="expected"/> using deep property-by-property comparison with default options.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Reason? reason = null
+    )
+    {
+        return NotContainEquivalentOf(expected, ComparisonOptions.Default, reason);
+    }
+
+    /// <summary>
+    /// Asserts that no element in the array is structurally equivalent
+    /// to <paramref name="expected"/> using comparison options configured via the <paramref name="configure"/> builder.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="configure">A lambda that configures the comparison options.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Action<ComparisonOptionsBuilder> configure,
+        Reason? reason = null
+    )
+    {
+        var builder = new ComparisonOptionsBuilder();
+        configure(builder);
+        return NotContainEquivalentOf(expected, builder.Build(), reason);
+    }
+
+    /// <summary>
+    /// Asserts that no element in the array is structurally equivalent
+    /// to <paramref name="expected"/> using the specified <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="options">Options controlling the comparison behaviour.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public ArrayOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        ComparisonOptions options,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainEquivalentOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                CollectionNotContainEquivalentOfValidator<T, TExpected>.New(
+                    PrincipalChain,
+                    expected,
+                    options
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainEquivalentOf)} operation failed because the array was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
     /// <summary>
     /// Extracts a sub-value from the current array using the given selector.
     /// Returns a connector that exposes the sub-value for further assertions.

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -2692,6 +2692,196 @@ public class CollectionOperationsManager<T>
         return this;
     }
 
+    // =========================================================================
+    // ContainEquivalentOf
+    // =========================================================================
+
+    /// <summary>
+    /// Asserts that the collection contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using deep property-by-property comparison with default options.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Comparison is expected-driven: only properties present on <typeparamref name="TExpected"/>
+    /// are compared. This enables partial matching with anonymous types or DTOs.
+    /// </remarks>
+    public CollectionOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Reason? reason = null
+    )
+    {
+        return ContainEquivalentOf(expected, ComparisonOptions.Default, reason);
+    }
+
+    /// <summary>
+    /// Asserts that the collection contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using comparison options configured via the <paramref name="configure"/> builder.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="configure">A lambda that configures the comparison options.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Action<ComparisonOptionsBuilder> configure,
+        Reason? reason = null
+    )
+    {
+        var builder = new ComparisonOptionsBuilder();
+        configure(builder);
+        return ContainEquivalentOf(expected, builder.Build(), reason);
+    }
+
+    /// <summary>
+    /// Asserts that the collection contains at least one element that is structurally equivalent
+    /// to <paramref name="expected"/> using the specified <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="options">Options controlling the comparison behaviour.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> ContainEquivalentOf<TExpected>(
+        TExpected expected,
+        ComparisonOptions options,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.ContainEquivalentOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                CollectionContainEquivalentOfValidator<T, TExpected>.New(
+                    PrincipalChain,
+                    expected,
+                    options
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(ContainEquivalentOf)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    // =========================================================================
+    // NotContainEquivalentOf
+    // =========================================================================
+
+    /// <summary>
+    /// Asserts that no element in the collection is structurally equivalent
+    /// to <paramref name="expected"/> using deep property-by-property comparison with default options.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Reason? reason = null
+    )
+    {
+        return NotContainEquivalentOf(expected, ComparisonOptions.Default, reason);
+    }
+
+    /// <summary>
+    /// Asserts that no element in the collection is structurally equivalent
+    /// to <paramref name="expected"/> using comparison options configured via the <paramref name="configure"/> builder.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="configure">A lambda that configures the comparison options.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        Action<ComparisonOptionsBuilder> configure,
+        Reason? reason = null
+    )
+    {
+        var builder = new ComparisonOptionsBuilder();
+        configure(builder);
+        return NotContainEquivalentOf(expected, builder.Build(), reason);
+    }
+
+    /// <summary>
+    /// Asserts that no element in the collection is structurally equivalent
+    /// to <paramref name="expected"/> using the specified <paramref name="options"/>.
+    /// </summary>
+    /// <typeparam name="TExpected">The type of the expected template object.</typeparam>
+    /// <param name="expected">The template object to compare against each element.</param>
+    /// <param name="options">Options controlling the comparison behaviour.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public CollectionOperationsManager<T> NotContainEquivalentOf<TExpected>(
+        TExpected expected,
+        ComparisonOptions options,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainEquivalentOf))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(
+                CollectionNotContainEquivalentOfValidator<T, TExpected>.New(
+                    PrincipalChain,
+                    expected,
+                    options
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expected)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainEquivalentOf)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
     /// <summary>
     /// Extracts a sub-value from the current collection using the given selector.
     /// Returns a connector that exposes the sub-value for further assertions.

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionContainEquivalentOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionContainEquivalentOfValidator.cs
@@ -1,0 +1,52 @@
+using JAAvila.FluentOperations.Comparators;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that at least one element in the collection is structurally equivalent
+/// to the specified expected object, using deep property-by-property comparison.
+/// </summary>
+/// <remarks>
+/// Comparison is expected-driven: <see cref="ObjectComparator"/> iterates the properties
+/// of <paramref name="expected"/> and looks them up on each collection element.
+/// This enables partial matching with anonymous types or DTOs with fewer properties.
+/// </remarks>
+internal class CollectionContainEquivalentOfValidator<T, TExpected>(
+    PrincipalChain<IEnumerable<T>> chain,
+    TExpected expected,
+    ComparisonOptions options
+) : IValidator
+{
+    public static CollectionContainEquivalentOfValidator<T, TExpected> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        TExpected expected,
+        ComparisonOptions options
+    ) => new(chain, expected, options);
+
+    public string Expected { get; } = string.Empty;
+    public string ResultValidation { get; set; } = string.Empty;
+
+    public bool Validate()
+    {
+        var collection = chain.GetValue();
+        var items = collection.ToList();
+
+        foreach (var element in items)
+        {
+            // Swap: iterate expected's properties, resolve against element
+            var result = ObjectComparator.DeepCompare(expected, element, options);
+
+            if (result.AreEqual)
+            {
+                return true;
+            }
+        }
+
+        ResultValidation =
+            "The collection was expected to contain an element structurally equivalent to the specified object, but no matching element was found.\n{0}";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainEquivalentOfValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainEquivalentOfValidator.cs
@@ -1,0 +1,51 @@
+using JAAvila.FluentOperations.Comparators;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that no element in the collection is structurally equivalent
+/// to the specified expected object, using deep property-by-property comparison.
+/// </summary>
+/// <remarks>
+/// Comparison is expected-driven: <see cref="ObjectComparator"/> iterates the properties
+/// of <paramref name="expected"/> and looks them up on each collection element.
+/// </remarks>
+internal class CollectionNotContainEquivalentOfValidator<T, TExpected>(
+    PrincipalChain<IEnumerable<T>> chain,
+    TExpected expected,
+    ComparisonOptions options
+) : IValidator
+{
+    public static CollectionNotContainEquivalentOfValidator<T, TExpected> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        TExpected expected,
+        ComparisonOptions options
+    ) => new(chain, expected, options);
+
+    public string Expected { get; } = string.Empty;
+    public string ResultValidation { get; set; } = string.Empty;
+
+    public bool Validate()
+    {
+        var collection = chain.GetValue();
+        var items = collection.ToList();
+
+        foreach (var element in items)
+        {
+            // Swap: iterate expected's properties, resolve against element
+            var result = ObjectComparator.DeepCompare(expected, element, options);
+
+            if (result.AreEqual)
+            {
+                ResultValidation =
+                    "The collection was expected to NOT contain an element structurally equivalent to the specified object, but a matching element was found.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}


### PR DESCRIPTION
  Add structural equivalence containment checks to CollectionOperationsManager
  and ArrayOperationsManager with 3 overloads each: default ComparisonOptions,
  Action<ComparisonOptionsBuilder>, and static ComparisonOptions.

  Uses swapped comparison direction (expected→element) via ObjectComparator
  to enable partial matching with anonymous/subset types.

  - CollectionContainEquivalentOfValidator<T, TExpected> with dual generics
  - CollectionNotContainEquivalentOfValidator<T, TExpected> (negated)
  - 6 methods on CollectionOperationsManager (3 overloads × 2 operations)
  - 6 methods on ArrayOperationsManager (mirror)
  - 2 new entries in Operations.Collection enum