### PR TITLE
Add Assert and AssertAsync methods to QualityBlueprint<T>

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
@@ -780,7 +780,7 @@ public class StringOperationsManager
                         manager.PrincipalChain.GetValue() is null,
                         Fail.New(
                             $"The {nameof(NotContain)} operation failed because the parent value was <null>. {{0}}.",
-                            $"It is recommended to run the {nameof(NotContain)} operation first to cover all possible scenarios"
+                            $"It is recommended to run the {nameof(NotBeNull)} operation first to cover all possible scenarios"
                         )
                     )
             )

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Linq.Expressions;
 using JAAvila.FluentOperations.Common;
 using JAAvila.FluentOperations.Contract;
@@ -678,6 +679,97 @@ public abstract partial class QualityBlueprint<T>
         }
 
         return report;
+    }
+
+    // --- Assert methods ------------------------------------------------
+
+    /// <summary>
+    /// Validates the specified instance against all rules defined in this blueprint
+    /// and throws if any Error-level failures are found.
+    /// Warning and Info failures do not cause an exception.
+    /// </summary>
+    /// <param name="instance">The model instance to validate.</param>
+    /// <exception cref="Exceptions.FluentOperationsException">
+    /// Thrown (or the active test framework's assertion exception) when validation produces Error-level failures
+    /// and no <see cref="AssertionScope"/> is active.
+    /// </exception>
+    /// <remarks>
+    /// When called inside an <see cref="AssertionScope"/>, failures are accumulated instead of thrown immediately.
+    /// Scenario detection works identically to <see cref="Check(T)"/>.
+    /// </remarks>
+    public void Assert(T instance)
+    {
+        var report = Check(instance);
+        if (report.IsValid) return;
+        Handler.ExceptionHandler.Handle(FormatAssertMessage(report));
+    }
+
+    /// <summary>
+    /// Validates the specified instance using only the rules that belong to <paramref name="activeScenario"/>
+    /// and throws if any Error-level failures are found.
+    /// </summary>
+    /// <param name="instance">The model instance to validate.</param>
+    /// <param name="activeScenario">The scenario type to activate, or <c>null</c> to run all non-scenario rules.</param>
+    /// <exception cref="Exceptions.FluentOperationsException">
+    /// Thrown (or the active test framework's assertion exception) when validation produces Error-level failures
+    /// and no <see cref="AssertionScope"/> is active.
+    /// </exception>
+    public void Assert(T instance, Type? activeScenario)
+    {
+        var report = Check(instance, activeScenario);
+        if (report.IsValid) return;
+        Handler.ExceptionHandler.Handle(FormatAssertMessage(report));
+    }
+
+    /// <summary>
+    /// Asynchronously validates the specified instance against all rules defined in this blueprint
+    /// and throws if any Error-level failures are found.
+    /// Use this overload when the blueprint contains async custom validators.
+    /// </summary>
+    /// <param name="instance">The model instance to validate.</param>
+    /// <exception cref="Exceptions.FluentOperationsException">
+    /// Thrown (or the active test framework's assertion exception) when validation produces Error-level failures
+    /// and no <see cref="AssertionScope"/> is active.
+    /// </exception>
+    /// <remarks>
+    /// When called inside an <see cref="AssertionScope"/>, failures are accumulated instead of thrown immediately.
+    /// Scenario detection works identically to <see cref="CheckAsync(T)"/>.
+    /// </remarks>
+    public async Task AssertAsync(T instance)
+    {
+        var report = await CheckAsync(instance);
+        if (report.IsValid) return;
+        Handler.ExceptionHandler.Handle(FormatAssertMessage(report));
+    }
+
+    /// <summary>
+    /// Asynchronously validates the specified instance using only the rules that belong to
+    /// <paramref name="activeScenario"/> and throws if any Error-level failures are found.
+    /// </summary>
+    /// <param name="instance">The model instance to validate.</param>
+    /// <param name="activeScenario">The scenario type to activate, or <c>null</c> to run all non-scenario rules.</param>
+    /// <exception cref="Exceptions.FluentOperationsException">
+    /// Thrown (or the active test framework's assertion exception) when validation produces Error-level failures
+    /// and no <see cref="AssertionScope"/> is active.
+    /// </exception>
+    public async Task AssertAsync(T instance, Type? activeScenario)
+    {
+        var report = await CheckAsync(instance, activeScenario);
+        if (report.IsValid) return;
+        Handler.ExceptionHandler.Handle(FormatAssertMessage(report));
+    }
+
+    /// <summary>
+    /// Builds a human-readable failure message from the Error-level failures in the report.
+    /// Each failure is formatted using <see cref="QualityFailure.ToString()"/> which includes
+    /// severity prefix, property name, message, and optional error code.
+    /// </summary>
+    private static string FormatAssertMessage(QualityReport report)
+    {
+        var errors = report.Errors;
+        var failures = errors.Select(f => $"  {f}");
+        return $"Blueprint validation failed with {errors.Count} error(s):\n"
+            + string.Join("\n", failures);
     }
 
     private static string GetPropertyName<TTarget>(Expression<Func<T, TTarget>> expression)


### PR DESCRIPTION
  Implement the test-to-production bridge that allows blueprints to be
  used as direct assertions in unit tests. Assert(T) and AssertAsync(T)
  internally call Check/CheckAsync and throw via ExceptionHandler.Handle()
  when Error-level failures are found.

  Key behaviors:
  - Only Severity.Error failures trigger exceptions (Warning/Info pass)
  - Respects active AssertionScope (failures accumulate instead of throwing)
  - Supports explicit scenario activation via Assert(T, Type?) overloads
  - FormatAssertMessage uses QualityFailure.ToString() for rich output

  Methods added to QualityBlueprint<T>:
  - Assert(T instance)
  - Assert(T instance, Type? activeScenario)
  - AssertAsync(T instance)
  - AssertAsync(T instance, Type? activeScenario)
  - FormatAssertMessage(QualityReport) [private]