### PR TITLE
Implement RFC 7807 Problem Details for Validation Errors

### DIFF
--- a/Distributed/JAAvila.FluentOperations.AspNetCore/AspNetCoreBlueprintFilter.cs
+++ b/Distributed/JAAvila.FluentOperations.AspNetCore/AspNetCoreBlueprintFilter.cs
@@ -63,25 +63,7 @@ public class BlueprintValidationFilter : IActionFilter
                 continue;
             }
 
-            context.Result = new BadRequestObjectResult(
-                new
-                {
-                    Title = "Validation Failed",
-                    Status = 400,
-                    Errors = report
-                        .Failures.Select(
-                            f =>
-                                new
-                                {
-                                    Property = f.PropertyName,
-                                    f.Message,
-                                    f.AttemptedValue
-                                }
-                        )
-                        .ToList(),
-                    report.RulesEvaluated
-                }
-            );
+            context.Result = new BadRequestObjectResult(report.ToProblemDetails());
             return;
         }
     }
@@ -130,25 +112,7 @@ public class BlueprintValidationFilter<TModel, TBlueprint> : IActionFilter
                 continue;
             }
 
-            context.Result = new BadRequestObjectResult(
-                new
-                {
-                    Title = "Validation Failed",
-                    Status = 400,
-                    Errors = report
-                        .Failures.Select(
-                            f =>
-                                new
-                                {
-                                    Property = f.PropertyName,
-                                    f.Message,
-                                    f.AttemptedValue
-                                }
-                        )
-                        .ToList(),
-                    report.RulesEvaluated
-                }
-            );
+            context.Result = new BadRequestObjectResult(report.ToProblemDetails());
             return;
         }
     }

--- a/Distributed/JAAvila.FluentOperations.AspNetCore/QualityReportAspNetExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations.AspNetCore/QualityReportAspNetExtensions.cs
@@ -1,0 +1,53 @@
+using JAAvila.FluentOperations.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// ASP.NET Core-specific extension methods for <see cref="QualityReport"/>
+/// that produce RFC 7807 Problem Details responses.
+/// </summary>
+public static class QualityReportAspNetExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="QualityReport"/> to a <see cref="ValidationProblemDetails"/> instance
+    /// conforming to RFC 7807.
+    /// <para>
+    /// Only <see cref="Severity.Error"/>-level failures are included in the <c>Errors</c> dictionary.
+    /// Warning and Info failures are excluded.
+    /// </para>
+    /// </summary>
+    /// <param name="report">The quality report to convert.</param>
+    /// <param name="title">Optional title. Defaults to "Validation Failed".</param>
+    /// <param name="detail">Optional detailed explanation.</param>
+    /// <param name="statusCode">Optional HTTP status code. Defaults to 400.</param>
+    /// <returns>A ValidationProblemDetails instance with errors grouped by property name.</returns>
+    public static ValidationProblemDetails ToProblemDetails(
+        this QualityReport report,
+        string? title = null,
+        string? detail = null,
+        int? statusCode = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var errors = report.ToErrorDictionary();
+
+        var problemDetails = new ValidationProblemDetails
+        {
+            Title = title ?? "Validation Failed",
+            Status = statusCode ?? 400
+        };
+
+        foreach (var kvp in errors)
+        {
+            problemDetails.Errors[kvp.Key] = kvp.Value;
+        }
+
+        if (detail is not null)
+        {
+            problemDetails.Detail = detail;
+        }
+
+        return problemDetails;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Extensions/QualityReportExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations/Extensions/QualityReportExtensions.cs
@@ -1,0 +1,32 @@
+namespace JAAvila.FluentOperations.Model;
+
+/// <summary>
+/// Extension methods for <see cref="QualityReport"/> that provide RFC 7807-compatible output formats.
+/// </summary>
+public static class QualityReportExtensions
+{
+    /// <summary>
+    /// Converts the report into an error dictionary grouped by property name,
+    /// compatible with the Problem Details RFC 7807 <c>errors</c> structure.
+    /// <para>
+    /// Only <see cref="Severity.Error"/>-level failures are included.
+    /// Warning and Info failures are excluded from the output.
+    /// </para>
+    /// </summary>
+    /// <param name="report">The quality report to convert.</param>
+    /// <returns>
+    /// A dictionary where keys are property names and values are arrays of error messages
+    /// for that property. Returns an empty dictionary if there are no Error-level failures.
+    /// </returns>
+    public static IDictionary<string, string[]> ToErrorDictionary(this QualityReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        return report.Failures
+            .Where(f => f.Severity == Severity.Error)
+            .GroupBy(f => f.PropertyName)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(f => f.Message).ToArray());
+    }
+}


### PR DESCRIPTION
  Replace the anonymous object response format in BlueprintValidationFilter
  with standard ValidationProblemDetails, conforming to RFC 7807.

  Changes:
  - Add QualityReportExtensions.ToErrorDictionary() in core package that groups Error-level failures by property name into IDictionary<string, string[]>
  - Add QualityReportAspNetExtensions.ToProblemDetails() in AspNetCore package with optional title, detail, and statusCode parameters
  - Update both BlueprintValidationFilter and BlueprintValidationFilter<TModel, TBlueprint> to return report.ToProblemDetails() instead of anonymous objects

  BREAKING CHANGE: MVC filter response body changes from a flat array of
  error objects to the RFC 7807 dictionary format. The 
ulesEvaluated
  and ttemptedValue fields are no longer included in the response.