### PR TITLE
Add NotContainNull and HaveCountBetween collection assertions

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -1511,6 +1511,12 @@ public struct Operations
 
         [EnumStringValue("notcontainequivalentof")]
         NotContainEquivalentOf,
+
+        [EnumStringValue("notcontainnull")]
+        NotContainNull,
+
+        [EnumStringValue("havecountbetween")]
+        HaveCountBetween,
     }
 
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -2883,6 +2883,110 @@ public class CollectionOperationsManager<T>
     }
 
     /// <summary>
+    /// Asserts that the collection contains no null elements.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the collection is <c>null</c>.
+    /// </remarks>
+    public CollectionOperationsManager<T> NotContainNull(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.NotContainNull))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionNotContainNullValidator<T>.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotContainNull)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the collection element count is within the specified inclusive range [<paramref name="min"/>, <paramref name="max"/>].
+    /// </summary>
+    /// <param name="min">The inclusive minimum element count. Must be non-negative.</param>
+    /// <param name="max">The inclusive maximum element count. Must be greater than or equal to <paramref name="min"/>.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// This operation fails immediately if the collection is <c>null</c>, if <paramref name="min"/> is negative,
+    /// or if <paramref name="max"/> is less than <paramref name="min"/>.
+    /// </remarks>
+    public CollectionOperationsManager<T> HaveCountBetween(int min, int max, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Collection.HaveCountBetween))
+        {
+            return this;
+        }
+
+        ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
+            .New(this)
+            .WithOperation(CollectionHaveCountBetweenValidator<T>.New(PrincipalChain, min, max))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.ResultValidation,
+                            min.ToString(),
+                            max.ToString(),
+                            PrincipalChain.GetValue()?.Count().ToString() ?? "null"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue().IsNull(),
+                        Fail.New(
+                            $"The {nameof(HaveCountBetween)} operation failed because the collection was null."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        min < 0,
+                        Fail.New(
+                            $"The {nameof(HaveCountBetween)} operation failed because the minimum count cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        max < min,
+                        Fail.New(
+                            $"The {nameof(HaveCountBetween)} operation failed because the maximum count ({max}) cannot be less than the minimum count ({min})."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Extracts a sub-value from the current collection using the given selector.
     /// Returns a connector that exposes the sub-value for further assertions.
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionHaveCountBetweenValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionHaveCountBetweenValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection element count is within the specified inclusive range [min, max].
+/// </summary>
+internal class CollectionHaveCountBetweenValidator<T>(
+    PrincipalChain<IEnumerable<T>> chain,
+    int min,
+    int max
+) : IValidator
+{
+    public static CollectionHaveCountBetweenValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain,
+        int min,
+        int max
+    ) => new(chain, min, max);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var count = chain.GetValue().Count();
+
+        if (count >= min && count <= max)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The resulting collection was expected to have between {0} and {1} element(s), but it had {2}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainNullValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionNotContainNullValidator.cs
@@ -1,0 +1,49 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the collection contains no null elements.
+/// Reports the count and indexes of null elements found.
+/// </summary>
+internal class CollectionNotContainNullValidator<T>(PrincipalChain<IEnumerable<T>> chain) : IValidator
+{
+    public static CollectionNotContainNullValidator<T> New(
+        PrincipalChain<IEnumerable<T>> chain
+    ) => new(chain);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+
+    public bool Validate()
+    {
+        var items = chain.GetValue();
+        var nullIndexes = new List<int>();
+        var index = 0;
+
+        foreach (var item in items)
+        {
+            if (item is null)
+            {
+                nullIndexes.Add(index);
+            }
+            index++;
+        }
+
+        if (nullIndexes.Count == 0)
+        {
+            return true;
+        }
+
+        var indexList = string.Join(", ", nullIndexes);
+        ResultValidation =
+            $"The collection was expected to contain no null elements, " +
+            $"but found {nullIndexes.Count} null element(s) at index(es): {indexList}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync()
+    {
+        return Task.FromResult(Validate());
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -599,6 +599,7 @@ Manager: `CollectionOperationsManager<T>`
 | `HaveCountLessThan(int)` | Fewer than N elements |
 | `HaveMinCount(int)` | At least N elements |
 | `HaveMaxCount(int)` | At most N elements |
+| `HaveCountBetween(int, int)` | Count is within [min, max] inclusive range |
 | `HaveLength(int)` | Exact length (element count) |
 | `HaveLengthGreaterThan(int)` | More than N elements |
 | `HaveLengthLessThan(int)` | Fewer than N elements |
@@ -606,6 +607,7 @@ Manager: `CollectionOperationsManager<T>`
 | `Contain(T, OccurrenceConstraint)` | Contains with occurrence |
 | `Contain(Func<T, bool>)` | Contains element matching predicate |
 | `NotContain(T)` | Does not contain |
+| `NotContainNull()` | No element is null (reports count and indexes of nulls found) |
 | `ContainSingle()` | Exactly one element |
 | `ContainSingle(Func<T, bool>)` | Exactly one element matching predicate |
 | `ContainAll(params T[])` | Contains all elements |


### PR DESCRIPTION
  Add two remaining collection assertion operations to close the
  nice-to-have API gaps identified in the competitive feature roadmap.

  NotContainNull():
  - Verifies collection contains no null elements
  - Reports count and indexes of null elements found in failure message
  - FailIf guard for null collection

  HaveCountBetween(int min, int max):
  - Verifies collection count is within [min, max] inclusive range
  - FailIf guards for null collection, negative min, and max < min
  - Uses format placeholders for min, max, and actual count in message

  Both operations follow the established ExecutionEngine pattern and
  support all 6 Pilares: Inline, Blueprint, Scenarios, AssertionScope,
  Transforms, and RuleConfig (Severity, ErrorCode, CustomMessage).