### PR TITLE
Document CallerArgumentExpression behavior and add complex tests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,7 @@ Complete API documentation for JAAvila.FluentOperations.
 ## Table of Contents
 
 - [Test Extensions](#test-extensions)
+  - [Automatic Subject Capture](#automatic-subject-capture)
 - [Validation Operations by Type](#validation-operations-by-type)
   - [String](#string-validations)
   - [Boolean](#boolean-validations)
@@ -90,6 +91,50 @@ asyncAct.Test().NotThrowAsync();
 ```
 
 All methods support an optional `Reason? reason` parameter for custom failure context. All methods return the manager instance for chaining.
+
+### Automatic Subject Capture
+
+Every `.Test()` overload uses `[CallerArgumentExpression]` to automatically capture the expression being validated. This expression appears as the **Subject** in error messages, giving you clear context about what failed without needing to specify names manually.
+
+```csharp
+var order = new Order { Customer = new Customer { Email = "bad" } };
+
+// The error message will show: Subject: variable "order.Customer.Email"
+order.Customer.Email.Test().BeEmail();
+```
+
+The captured expression is classified into one of these categories:
+
+| Category | Example Expression | Subject in Message |
+|----------|-------------------|-------------------|
+| **Variable** | `userName` | `variable "userName"` |
+| **Variable** (nested) | `order.Customer.Email` | `variable "order.Customer.Email"` |
+| **Function** | `GetValue()` | `function "GetValue()"` |
+| **Expression** | `list[0]` | `expression "list[0]"` |
+| **Primitive** | `42`, `"hello"`, `true` | `primitive "42"` |
+
+#### Blueprint Mode
+
+Inside a `QualityBlueprint<T>`, the subject comes from the `For()` expression, not from `CallerArgumentExpression`. The property name is extracted from the lambda expression:
+
+```csharp
+// Subject will be "Email", not the full CallerArgumentExpression
+For(x => x.Email).Test().BeEmail();
+```
+
+This is reflected in `QualityFailure.PropertyName` as well.
+
+#### AssertionScope
+
+Inside an `AssertionScope`, each assertion retains its own captured subject. The accumulated failure messages each show their respective subject:
+
+```csharp
+using (var scope = new AssertionScope())
+{
+    order.Customer.Email.Test().BeEmail();   // Subject: variable "order.Customer.Email"
+    order.Total.Test().BePositive();          // Subject: variable "order.Total"
+}
+```
 
 ---
 


### PR DESCRIPTION
  Document the automatic subject capture behavior that is already
  implemented via [CallerArgumentExpression] in all .Test() overloads.
  Add integration tests verifying complex expression handling.

  Documentation (docs/API.md):
  - New 'Automatic Subject Capture' section with classification table (Variable, Function, Expression, Primitive)
  - Blueprint mode note: subject comes from For() lambda, not CAE
  - AssertionScope note: each assertion retains its own subject

  Tests (17 new in CallerArgumentExpressionComplexTests.cs):
  - Nested properties: order.Customer.Email captured as full path
  - Indexers: scores[0], order.Tags[0] classified as 'expression'
  - Method calls: GetEmail() classified as 'function'
  - Arithmetic: a + b captured as expression
  - AssertionScope: multiple subjects preserved independently
  - Blueprint mode: PropertyName from PropertyProxy, not CAE
  - Message structure: Subject+Result format verified