### PR TITLE
Expose explicit test framework configuration API and enhancements

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/TestFramework.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/TestFramework.cs
@@ -5,8 +5,18 @@ namespace JAAvila.FluentOperations.Common;
 /// <summary>
 /// Represents the available test frameworks recognized and supported within the FluentOperations.
 /// </summary>
-internal enum TestFramework
+public enum TestFramework
 {
+    /// <summary>
+    /// Automatic detection of the test framework from loaded assemblies.
+    /// </summary>
+    Auto,
+
+    /// <summary>
+    /// No test framework. All assertion failures throw FluentOperationsException directly.
+    /// </summary>
+    None,
+
     /// <summary>
     /// Represents the Machine.Specifications (MSpec) testing framework,
     /// which is a Behavior Driven Development (BDD) framework designed for .NET applications.

--- a/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using JAAvila.FluentOperations.Common;
 
 namespace JAAvila.FluentOperations.Config;
 
@@ -88,6 +89,11 @@ public static class FluentOperationsConfig
     /// Returns the current effective FormattingConfig.
     /// </summary>
     public static FormattingConfig GetFormattingConfig() => GlobalConfig.GetFormattingConfig();
+
+    /// <summary>
+    /// Returns the current effective TestFrameworkConfig.
+    /// </summary>
+    public static TestFrameworkConfig GetTestFrameworkConfig() => GlobalConfig.GetTestFrameworkConfig();
 }
 
 /// <summary>
@@ -116,6 +122,11 @@ public class ConfigBuilder
     /// </summary>
     public FormattingConfigBuilder Formatting { get; } = new();
 
+    /// <summary>
+    /// Configuration options for the test framework used to throw assertion exceptions.
+    /// </summary>
+    public TestFrameworkConfigBuilder TestFramework { get; } = new();
+
     internal static ConfigBuilder FromExisting(GlobalConfig existing)
     {
         var builder = new ConfigBuilder();
@@ -138,6 +149,9 @@ public class ConfigBuilder
         builder.Formatting.EmptyDisplay = fc.EmptyDisplay;
         builder.Formatting.MaxCollectionItems = fc.MaxCollectionItems;
         builder.Formatting.MaxDepth = fc.MaxDepth;
+
+        var tfc = existing.GetTestFrameworkConfigInternal();
+        builder.TestFramework.Framework = tfc.Framework;
 
         return builder;
     }
@@ -170,6 +184,9 @@ public class ConfigBuilder
             MaxCollectionItems = Math.Max(Formatting.MaxCollectionItems, 1),
             MaxDepth = Math.Max(Formatting.MaxDepth, 1)
         };
+
+    internal TestFrameworkConfig BuildTestFrameworkConfig() =>
+        new() { Framework = TestFramework.Framework };
 }
 
 /// <summary>
@@ -264,4 +281,16 @@ public class FormattingConfigBuilder
     /// Minimum effective value is 1. Defaults to <c>3</c>.
     /// </summary>
     public int MaxDepth { get; set; } = 3;
+}
+
+/// <summary>
+/// Mutable builder for TestFrameworkConfig.
+/// </summary>
+public class TestFrameworkConfigBuilder
+{
+    /// <summary>
+    /// The test framework to use for assertion exceptions.
+    /// Default: <see cref="TestFramework.Auto"/> (auto-detect from loaded assemblies).
+    /// </summary>
+    public TestFramework Framework { get; set; } = TestFramework.Auto;
 }

--- a/Distributed/JAAvila.FluentOperations/Config/GlobalConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/GlobalConfig.cs
@@ -26,13 +26,15 @@ internal class GlobalConfig
     private NumericConfig Numeric { get; init; } = new();
     private DateTimeConfig DateTime { get; init; } = new();
     private FormattingConfig Formatting { get; init; } = new();
+    private TestFrameworkConfig TestFramework { get; init; } = new();
 
     private static GlobalConfig Default => new()
     {
         String = new StringConfig { MaxDisplayLength = 30 },
         Numeric = new NumericConfig(),
         DateTime = new DateTimeConfig(),
-        Formatting = new FormattingConfig()
+        Formatting = new FormattingConfig(),
+        TestFramework = new TestFrameworkConfig()
     };
 
     /// <summary>
@@ -108,6 +110,7 @@ internal class GlobalConfig
     public static NumericConfig GetNumericConfig() => GetInstance().Numeric;
     public static DateTimeConfig GetDateTimeConfig() => GetInstance().DateTime;
     public static FormattingConfig GetFormattingConfig() => GetInstance().Formatting;
+    public static TestFrameworkConfig GetTestFrameworkConfig() => GetInstance().TestFramework;
 
     // --- Internal accessors for ConfigBuilder.FromExisting() ---
 
@@ -115,6 +118,7 @@ internal class GlobalConfig
     internal NumericConfig GetNumericConfigInternal() => Numeric;
     internal DateTimeConfig GetDateTimeConfigInternal() => DateTime;
     internal FormattingConfig GetFormattingConfigInternal() => Formatting;
+    internal TestFrameworkConfig GetTestFrameworkConfigInternal() => TestFramework;
 
     // --- Scope management (used by FluentOperationsConfig) ---
 
@@ -125,22 +129,38 @@ internal class GlobalConfig
 
     internal static void ApplyConfig(ConfigBuilder builder)
     {
+        var previousFramework = Instance.Value?.TestFramework.Framework;
+        var newTestFrameworkConfig = builder.BuildTestFrameworkConfig();
+
         Instance.Value = new GlobalConfig
         {
             String = builder.BuildStringConfig(),
             Numeric = builder.BuildNumericConfig(),
             DateTime = builder.BuildDateTimeConfig(),
-            Formatting = builder.BuildFormattingConfig()
+            Formatting = builder.BuildFormattingConfig(),
+            TestFramework = newTestFrameworkConfig
         };
+
+        if (previousFramework != newTestFrameworkConfig.Framework)
+        {
+            Handler.ExceptionHandler.InvalidateCache();
+        }
     }
 
     internal static void RestoreConfig(GlobalConfig previous)
     {
+        var currentFramework = Instance.Value?.TestFramework.Framework;
         Instance.Value = previous;
+
+        if (currentFramework != previous.TestFramework.Framework)
+        {
+            Handler.ExceptionHandler.InvalidateCache();
+        }
     }
 
     internal static void ResetConfig()
     {
         Instance.Value = null;
+        Handler.ExceptionHandler.InvalidateCache();
     }
 }

--- a/Distributed/JAAvila.FluentOperations/Config/TestFrameworkConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/TestFrameworkConfig.cs
@@ -1,0 +1,15 @@
+using JAAvila.FluentOperations.Common;
+
+namespace JAAvila.FluentOperations.Config;
+
+/// <summary>
+/// Configuration for the test framework used to throw assertion exceptions.
+/// </summary>
+public class TestFrameworkConfig
+{
+    /// <summary>
+    /// The test framework to use for assertion exceptions.
+    /// Default: <see cref="TestFramework.Auto"/> (auto-detect from loaded assemblies).
+    /// </summary>
+    public TestFramework Framework { get; init; } = TestFramework.Auto;
+}

--- a/Distributed/JAAvila.FluentOperations/Handler/ExceptionHandler.cs
+++ b/Distributed/JAAvila.FluentOperations/Handler/ExceptionHandler.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JAAvila.FluentOperations.Common;
 using JAAvila.FluentOperations.Exceptions;
 
 namespace JAAvila.FluentOperations.Handler;
@@ -6,55 +7,88 @@ namespace JAAvila.FluentOperations.Handler;
 /// <summary>
 /// Resolves the correct exception type for the active test framework (NUnit, xUnit, MSTest, etc.)
 /// and either throws it directly or routes the failure message into the active
-/// <see cref="TransactionalOperations"/> scope. The framework assembly and exception constructor
-/// are resolved once and cached via <see cref="Lazy{T}"/> for performance.
+/// <see cref="TransactionalOperations"/> scope. The resolved throwable factory is cached via
+/// volatile field + double-checked locking and can be invalidated when the framework config changes.
 /// </summary>
 internal class ExceptionHandler
 {
-    private static readonly Lazy<Assembly?> CachedTestFramework =
-        new(
-            () =>
+    private static volatile Func<string, Exception>? _cachedThrowable;
+    private static readonly object Lock = new();
+
+    /// <summary>
+    /// Invalidates the cached throwable factory so the next call to <see cref="Throwable"/>
+    /// re-resolves from the current <see cref="Config.GlobalConfig"/>.
+    /// </summary>
+    public static void InvalidateCache()
+    {
+        _cachedThrowable = null;
+    }
+
+    private static Func<string, Exception> Throwable
+    {
+        get
+        {
+            var cached = _cachedThrowable;
+            if (cached is not null) return cached;
+
+            lock (Lock)
             {
-                var tf = new TestFrameworkHandler();
-                return tf.GetFramework();
-            },
-            LazyThreadSafetyMode.ExecutionAndPublication
+                cached = _cachedThrowable;
+                if (cached is not null) return cached;
+
+                cached = ResolveThrowable();
+                _cachedThrowable = cached;
+                return cached;
+            }
+        }
+    }
+
+    private static Func<string, Exception> ResolveThrowable()
+    {
+        var config = Config.GlobalConfig.GetTestFrameworkConfig();
+
+        Assembly? framework = config.Framework switch
+        {
+            TestFramework.None => null,
+            TestFramework.Auto => new TestFrameworkHandler().GetFramework(),
+            _ => new TestFrameworkHandler().GetFrameworkForExplicit(config.Framework)
+        };
+
+        if (config.Framework == TestFramework.None || framework is null)
+        {
+            return message => new FluentOperationsException(message);
+        }
+
+        var enumFramework = TestFrameworkHandler.TestFrameworkAssemblyNames.FirstOrDefault(
+            x => x.ObjectValue.Equals(
+                framework.GetName().Name,
+                StringComparison.OrdinalIgnoreCase
+            )
         );
 
-    private static readonly Lazy<Func<string, Exception>> CachedThrowable =
-        new(
-            () =>
-            {
-                var framework = CachedTestFramework.Value;
+        if (enumFramework is null)
+        {
+            return message => new FluentOperationsException(message);
+        }
 
-                if (framework is null)
-                {
-                    return message => new FluentOperationsException(message);
-                }
-
-                var enumFramework = TestFrameworkHandler.TestFrameworkAssemblyNames.First(
-                    x =>
-                        x.ObjectValue.Equals(
-                            framework.GetName().Name,
-                            StringComparison.CurrentCultureIgnoreCase
-                        )
-                );
-                var exceptionNamespace = TestFrameworkHandler.TestFrameworkExceptionNamespace.First(
-                    x => x.Value == enumFramework.Value
-                );
-                var exceptionType = framework.GetType(exceptionNamespace.ObjectValue);
-
-                if (exceptionType is null)
-                {
-                    return message => new FluentOperationsException(message);
-                }
-
-                return message => (Exception)Activator.CreateInstance(exceptionType, message)!;
-            },
-            LazyThreadSafetyMode.ExecutionAndPublication
+        var exceptionNamespace = TestFrameworkHandler.TestFrameworkExceptionNamespace.FirstOrDefault(
+            x => x.Value == enumFramework.Value
         );
 
-    private static Func<string, Exception> Throwable => CachedThrowable.Value;
+        if (exceptionNamespace is null)
+        {
+            return message => new FluentOperationsException(message);
+        }
+
+        var exceptionType = framework.GetType(exceptionNamespace.ObjectValue);
+
+        if (exceptionType is null)
+        {
+            return message => new FluentOperationsException(message);
+        }
+
+        return message => (Exception)Activator.CreateInstance(exceptionType, message)!;
+    }
 
     /// <summary>
     /// Handles a validation failure described by <paramref name="template"/>.

--- a/Distributed/JAAvila.FluentOperations/Handler/TestFrameworkHandler.cs
+++ b/Distributed/JAAvila.FluentOperations/Handler/TestFrameworkHandler.cs
@@ -15,17 +15,37 @@ internal class TestFrameworkHandler
 {
     private static readonly Type Frameworks = typeof(TestFramework);
     public static List<EnumKeyValueData<int, string>> TestFrameworkAssemblyNames { get; } =
-        Frameworks.GetKeyValues<int, string>("assembly");
+        Frameworks.GetKeyValues<int, string>("assembly")
+            .Where(x => x.ObjectValue is not null)
+            .ToList();
 
     public static List<EnumKeyValueData<int, string>> TestFrameworkExceptionNamespace { get; } =
-        Frameworks.GetKeyValues<int, string>("exception");
+        Frameworks.GetKeyValues<int, string>("exception")
+            .Where(x => x.ObjectValue is not null)
+            .ToList();
 
     private List<EnumBooleanData<int>> TestFrameworkForceAssembly { get; } =
-        Frameworks.GetBooleanValues<int>();
+        Frameworks.GetBooleanValues<int>()
+            .Where(x => Frameworks.GetKeyValues<int, string>("assembly")
+                .Any(a => a.Value == x.Value && a.ObjectValue is not null))
+            .ToList();
 
     private Assembly? Framework => GetFrameworkAssemby();
 
     public Assembly? GetFramework() => Framework;
+
+    public Assembly? GetFrameworkForExplicit(Common.TestFramework framework)
+    {
+        var assemblyEntry = TestFrameworkAssemblyNames.FirstOrDefault(x => x.Value == (int)framework);
+        if (assemblyEntry is null) return null;
+
+        var assembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(x => string.Equals(x.GetName().Name, assemblyEntry.ObjectValue, StringComparison.OrdinalIgnoreCase));
+        if (assembly is not null) return assembly;
+
+        try { return Assembly.Load(new AssemblyName(assemblyEntry.ObjectValue)); }
+        catch { return null; }
+    }
 
     #region PRIVATE METHODS
 


### PR DESCRIPTION
  Make the TestFramework enum public and add Auto/None values, allowing
  users to explicitly control which test framework exception type is
  thrown on assertion failures.

  Key changes:
  - TestFramework enum: internal -> public, added Auto (default) and None (production mode, always throws FluentOperationsException)
  - New TestFrameworkConfig class and TestFrameworkConfigBuilder for FluentOperationsConfig.Configure(c => c.TestFramework.Framework = ...)
  - ExceptionHandler rewritten: replaced Lazy<T> cache with volatile + double-checked locking pattern, enabling re-configuration at any time
  - InvalidateCache() called from GlobalConfig on ApplyConfig, ResetConfig, and RestoreConfig when the framework setting changes
  - TestFrameworkHandler: defensive filtering for enum values without attributes, new GetFrameworkForExplicit() for explicit resolution
  - Scope() support: temporary framework override within using block