### PR TITLE
Add character-level diff output for StartWith and EndWith operations

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/TemplatePart.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/TemplatePart.cs
@@ -18,4 +18,5 @@ internal struct TemplatePart
     public const string Transaction = "Transaction";
     public const string ErrorCode = "ErrorCode";
     public const string SeverityLevel = "Severity";
+    public const string Diff = "Diff";
 }

--- a/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
@@ -132,6 +132,9 @@ public class ConfigBuilder
         var builder = new ConfigBuilder();
         var sc = existing.GetStringConfigInternal();
         builder.String.MaxDisplayLength = sc.MaxDisplayLength;
+        builder.String.EnableStringDiff = sc.EnableStringDiff;
+        builder.String.StringDiffContextChars = sc.StringDiffContextChars;
+        builder.String.StringDiffMaxLength = sc.StringDiffMaxLength;
 
         var nc = existing.GetNumericConfigInternal();
         builder.Numeric.DecimalPlaces = nc.DecimalPlaces;
@@ -157,7 +160,13 @@ public class ConfigBuilder
     }
 
     internal StringConfig BuildStringConfig() =>
-        new() { MaxDisplayLength = Math.Max(String.MaxDisplayLength, 10) };
+        new()
+        {
+            MaxDisplayLength = Math.Max(String.MaxDisplayLength, 10),
+            EnableStringDiff = String.EnableStringDiff,
+            StringDiffContextChars = Math.Max(String.StringDiffContextChars, 5),
+            StringDiffMaxLength = Math.Max(String.StringDiffMaxLength, 50)
+        };
 
     internal NumericConfig BuildNumericConfig() =>
         new()
@@ -199,6 +208,24 @@ public class StringConfigBuilder
     /// Longer strings are truncated. Minimum effective value is 10.
     /// </summary>
     public int MaxDisplayLength { get; set; } = 30;
+
+    /// <summary>
+    /// When <c>true</c>, string diff output is appended to failure messages for StartWith and EndWith.
+    /// Default: <c>true</c>.
+    /// </summary>
+    public bool EnableStringDiff { get; set; } = true;
+
+    /// <summary>
+    /// Number of characters shown on each side of the first difference in the diff output.
+    /// Minimum effective value is 5. Default: 20.
+    /// </summary>
+    public int StringDiffContextChars { get; set; } = 20;
+
+    /// <summary>
+    /// Maximum string length for which diff output is generated.
+    /// Minimum effective value is 50. Default: 1000.
+    /// </summary>
+    public int StringDiffMaxLength { get; set; } = 1000;
 }
 
 /// <summary>

--- a/Distributed/JAAvila.FluentOperations/Config/StringConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/StringConfig.cs
@@ -10,4 +10,23 @@ public class StringConfig
     /// Default: 30. Minimum: 10.
     /// </summary>
     public int MaxDisplayLength { get; init; } = 30;
+
+    /// <summary>
+    /// When <c>true</c>, string diff output is appended to failure messages for StartWith and EndWith.
+    /// Default: <c>true</c>.
+    /// </summary>
+    public bool EnableStringDiff { get; init; } = true;
+
+    /// <summary>
+    /// Number of characters shown on each side of the first difference in the diff output.
+    /// Default: 20. Minimum: 5.
+    /// </summary>
+    public int StringDiffContextChars { get; init; } = 20;
+
+    /// <summary>
+    /// Maximum string length for which diff output is generated.
+    /// Strings longer than this receive a truncation notice instead of a full diff.
+    /// Default: 1000. Minimum: 50.
+    /// </summary>
+    public int StringDiffMaxLength { get; init; } = 1000;
 }

--- a/Distributed/JAAvila.FluentOperations/Formatters/StringDiffFormatter.cs
+++ b/Distributed/JAAvila.FluentOperations/Formatters/StringDiffFormatter.cs
@@ -1,0 +1,126 @@
+using JAAvila.FluentOperations.Config;
+
+namespace JAAvila.FluentOperations.Formatters;
+
+/// <summary>
+/// Formats a human-readable diff between two strings, highlighting the first point of divergence
+/// with context characters on each side and a caret pointer at the difference index.
+/// </summary>
+internal static class StringDiffFormatter
+{
+    /// <summary>
+    /// Formats a diff between <paramref name="expected"/> and <paramref name="actual"/>,
+    /// reading context and length limits from <see cref="GlobalConfig"/>.
+    /// Returns <c>null</c> when no diff should be shown.
+    /// </summary>
+    public static string? FormatDiff(string? expected, string? actual)
+    {
+        var config = GlobalConfig.GetStringConfig();
+        return FormatDiff(expected, actual, config.StringDiffContextChars, config.StringDiffMaxLength);
+    }
+
+    /// <summary>
+    /// Formats a diff between <paramref name="expected"/> and <paramref name="actual"/> using the
+    /// supplied <paramref name="contextChars"/> window and <paramref name="maxLength"/> cap.
+    /// Returns <c>null</c> when no diff should be shown (null inputs, equal strings, or truncation).
+    /// </summary>
+    public static string? FormatDiff(string? expected, string? actual, int contextChars = 20, int maxLength = 1000)
+    {
+        if (expected is null || actual is null)
+        {
+            return null;
+        }
+
+        if (string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (expected.Length > maxLength || actual.Length > maxLength)
+        {
+            return $"(strings too long to diff: expected length {expected.Length}, actual length {actual.Length}, max {maxLength})";
+        }
+
+        var diffIndex = FindFirstDifferenceIndex(expected, actual);
+
+        // Build context window
+        var start = Math.Max(0, diffIndex - contextChars);
+        var expectedEnd = Math.Min(expected.Length, diffIndex + contextChars);
+        var actualEnd = Math.Min(actual.Length, diffIndex + contextChars);
+
+        var expectedSnippet = SafeSubstring(expected, start, expectedEnd - start);
+        var actualSnippet = SafeSubstring(actual, start, actualEnd - start);
+
+        var prefixEllipsis = start > 0 ? "..." : string.Empty;
+        var expectedSuffixEllipsis = expectedEnd < expected.Length ? "..." : string.Empty;
+        var actualSuffixEllipsis = actualEnd < actual.Length ? "..." : string.Empty;
+
+        // Caret position relative to the snippet (offset by ellipsis width)
+        var caretOffset = diffIndex - start + prefixEllipsis.Length;
+        var caret = new string(' ', caretOffset) + "^";
+
+        var expectedWord = ExtractWordAround(expected, diffIndex);
+        var actualWord = ExtractWordAround(actual, diffIndex);
+
+        return
+            $"Difference at index {diffIndex}:" + Environment.NewLine +
+            $"  Expected : \"{prefixEllipsis}{expectedSnippet}{expectedSuffixEllipsis}\"" + Environment.NewLine +
+            $"  But found: \"{prefixEllipsis}{actualSnippet}{actualSuffixEllipsis}\"" + Environment.NewLine +
+            $"             {caret}" + Environment.NewLine +
+            $"  (expected \"{expectedWord}\" but found \"{actualWord}\" near index {diffIndex})";
+    }
+
+    #region PRIVATE HELPERS
+
+    private static int FindFirstDifferenceIndex(string a, string b)
+    {
+        var minLen = Math.Min(a.Length, b.Length);
+        for (var i = 0; i < minLen; i++)
+        {
+            if (a[i] != b[i])
+            {
+                return i;
+            }
+        }
+
+        return minLen;
+    }
+
+    private static string SafeSubstring(string value, int start, int length)
+    {
+        if (start >= value.Length)
+        {
+            return string.Empty;
+        }
+
+        var safeLength = Math.Min(length, value.Length - start);
+        return safeLength <= 0 ? string.Empty : value.Substring(start, safeLength);
+    }
+
+    private static string ExtractWordAround(string value, int index)
+    {
+        if (index >= value.Length)
+        {
+            return string.Empty;
+        }
+
+        // Walk back to start of word
+        var start = index;
+        while (start > 0 && !char.IsWhiteSpace(value[start - 1]))
+        {
+            start--;
+        }
+
+        // Walk forward to end of word
+        var end = index;
+        while (end < value.Length && !char.IsWhiteSpace(value[end]))
+        {
+            end++;
+        }
+
+        var word = value[start..end];
+        return word.Length > 20 ? word[..20] + "..." : word;
+    }
+
+    #endregion
+}

--- a/Distributed/JAAvila.FluentOperations/Handler/TemplateHandler.cs
+++ b/Distributed/JAAvila.FluentOperations/Handler/TemplateHandler.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Formatters;
 using JAAvila.FluentOperations.Model;
 
 // ReSharper disable once RedundantUsingDirective
@@ -176,6 +178,19 @@ internal class TemplateHandler
                     Template.New(severity.ToString())
                 )
             );
+        }
+        return this;
+    }
+
+    public TemplateHandler WithStringDiff(string? expected, string? actual)
+    {
+        var config = GlobalConfig.GetStringConfig();
+        if (!config.EnableStringDiff) return this;
+
+        var diff = StringDiffFormatter.FormatDiff(expected, actual, config.StringDiffContextChars, config.StringDiffMaxLength);
+        if (diff is not null)
+        {
+            _templates.Add(new KeyValuePair<string, Template>(TemplatePart.Diff, Template.New(diff)));
         }
         return this;
     }

--- a/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/StringOperationsManager.cs
@@ -2241,10 +2241,17 @@ public class StringOperationsManager
             .WithOperation(StringStartWithValidator.New(prefix, PrincipalChain))
             .WithTemplate(
                 (template, operation) =>
-                    template
+                {
+                    var actual = PrincipalChain.GetValue();
+                    var actualPrefix = actual is not null && actual.Length >= prefix.Length
+                        ? actual[..prefix.Length]
+                        : actual;
+                    return template
                         .WithSubject(PrincipalChain.GetSubject())
                         .WithResult(operation.ResultValidation, prefix)
-                        .WithReason(reason?.ToString())
+                        .WithStringDiff(prefix, actualPrefix)
+                        .WithReason(reason?.ToString());
+                }
             )
             .FailIf(
                 manager =>
@@ -2296,11 +2303,19 @@ public class StringOperationsManager
             .WithOperation(StringStartWithValidator.New(prefix, PrincipalChain, comparison))
             .WithTemplate(
                 (template, operation) =>
-                    template
+                {
+                    var actual = PrincipalChain.GetValue();
+                    var actualPrefix = actual is not null && actual.Length >= prefix.Length
+                        ? actual[..prefix.Length]
+                        : actual;
+                    var diff = comparison == StringComparison.Ordinal ? actualPrefix : null;
+                    return template
                         .WithSubject(PrincipalChain.GetSubject())
                         .WithValue(StringFormatter.Format(PrincipalChain.GetValueAsString()))
                         .WithResult(operation.ResultValidation, StringFormatter.Format(prefix))
-                        .WithReason(reason?.ToString())
+                        .WithStringDiff(prefix, diff)
+                        .WithReason(reason?.ToString());
+                }
             )
             .FailIf(
                 manager =>
@@ -2397,10 +2412,17 @@ public class StringOperationsManager
             .WithOperation(StringEndWithValidator.New(suffix, PrincipalChain))
             .WithTemplate(
                 (template, operation) =>
-                    template
+                {
+                    var actual = PrincipalChain.GetValue();
+                    var actualSuffix = actual is not null && actual.Length >= suffix.Length
+                        ? actual[^suffix.Length..]
+                        : actual;
+                    return template
                         .WithSubject(PrincipalChain.GetSubject())
                         .WithResult(operation.ResultValidation, suffix)
-                        .WithReason(reason?.ToString())
+                        .WithStringDiff(suffix, actualSuffix)
+                        .WithReason(reason?.ToString());
+                }
             )
             .FailIf(
                 manager =>
@@ -2452,11 +2474,19 @@ public class StringOperationsManager
             .WithOperation(StringEndWithValidator.New(suffix, PrincipalChain, comparison))
             .WithTemplate(
                 (template, operation) =>
-                    template
+                {
+                    var actual = PrincipalChain.GetValue();
+                    var actualSuffix = actual is not null && actual.Length >= suffix.Length
+                        ? actual[^suffix.Length..]
+                        : actual;
+                    var diff = comparison == StringComparison.Ordinal ? actualSuffix : null;
+                    return template
                         .WithSubject(PrincipalChain.GetSubject())
                         .WithValue(StringFormatter.Format(PrincipalChain.GetValueAsString()))
                         .WithResult(operation.ResultValidation, StringFormatter.Format(suffix))
-                        .WithReason(reason?.ToString())
+                        .WithStringDiff(suffix, diff)
+                        .WithReason(reason?.ToString());
+                }
             )
             .FailIf(
                 manager =>


### PR DESCRIPTION
  Introduce StringDiffFormatter that produces visual diff blocks showing
  exactly where two strings differ, with a caret pointer, context window,
  and descriptive word fragments.

  New infrastructure:
  - StringDiffFormatter: char-by-char diff with configurable context window (default 20 chars) and max length limit (default 1000 chars)
  - TemplateHandler.WithStringDiff(): appends diff block as TemplatePart.Diff
  - StringConfig: EnableStringDiff, StringDiffContextChars, StringDiffMaxLength

  Integration:
  - StartWith(prefix) and EndWith(suffix) now include diff output comparing the expected prefix/suffix against the actual prefix/suffix
  - Only Ordinal comparisons produce diff (culture-aware comparisons skip)
  - Be() unchanged (retains existing StringDifference format)
  - Contain() and NotBe() unchanged (diff not semantically applicable)

  Configurable via FluentOperationsConfig.Configure(c => c.String.EnableStringDiff = false)