### PR TITLE
Replace reflection with IBlueprintValidator for AOT-safe filters

### DIFF
--- a/Distributed/JAAvila.FluentOperations.AspNetCore/AspNetCoreBlueprintFilter.cs
+++ b/Distributed/JAAvila.FluentOperations.AspNetCore/AspNetCoreBlueprintFilter.cs
@@ -1,3 +1,4 @@
+using JAAvila.FluentOperations.Contract;
 using JAAvila.FluentOperations.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -8,14 +9,19 @@ namespace JAAvila.FluentOperations.Integration;
 /// Action filter that automatically validates action parameters using Quality Blueprints.
 /// Apply to controllers or actions to enable automatic validation.
 /// </summary>
+/// <remarks>
+/// This filter is AOT-safe: it depends on <see cref="IBlueprintValidator"/> via DI
+/// and never uses <c>MakeGenericType</c> or <c>GetMethod</c> at runtime.
+/// Register blueprints with the DI helpers (e.g. <c>AddBlueprint&lt;T&gt;</c>) so that
+/// <see cref="IEnumerable{IBlueprintValidator}"/> is populated.
+/// </remarks>
 public class BlueprintValidationFilter : IActionFilter
 {
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IEnumerable<IBlueprintValidator> _validators;
 
-    public BlueprintValidationFilter(IServiceProvider serviceProvider)
+    public BlueprintValidationFilter(IEnumerable<IBlueprintValidator> validators)
     {
-        _serviceProvider =
-            serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _validators = validators ?? throw new ArgumentNullException(nameof(validators));
     }
 
     public void OnActionExecuting(ActionExecutingContext context)
@@ -27,36 +33,15 @@ public class BlueprintValidationFilter : IActionFilter
                 continue;
             }
 
-            object? blueprint = null;
-            Type? resolvedType = null;
-            var currentType = argument.Value.GetType();
+            var type = argument.Value.GetType();
+            var validator = FindValidator(type);
 
-            while (currentType != null && blueprint == null)
-            {
-                var blueprintType = typeof(QualityBlueprint<>).MakeGenericType(currentType);
-                blueprint = _serviceProvider.GetService(blueprintType);
-
-                if (blueprint != null)
-                {
-                    resolvedType = currentType;
-                }
-
-                currentType = currentType.BaseType;
-            }
-
-            if (blueprint == null || resolvedType == null)
+            if (validator == null)
             {
                 continue;
             }
 
-            var checkMethod = blueprint.GetType().GetMethod("Check", [resolvedType]);
-
-            if (checkMethod == null)
-            {
-                continue;
-            }
-
-            var report = (QualityReport)checkMethod.Invoke(blueprint, [argument.Value])!;
+            var report = validator.Validate(argument.Value);
 
             if (report.IsValid)
             {
@@ -69,6 +54,19 @@ public class BlueprintValidationFilter : IActionFilter
     }
 
     public void OnActionExecuted(ActionExecutedContext context) { }
+
+    private IBlueprintValidator? FindValidator(Type modelType)
+    {
+        foreach (var validator in _validators)
+        {
+            if (validator.CanValidate(modelType))
+            {
+                return validator;
+            }
+        }
+
+        return null;
+    }
 }
 
 /// <summary>

--- a/Distributed/JAAvila.FluentOperations.DependencyInjection/FluentOperationsDIExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations.DependencyInjection/FluentOperationsDIExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using JAAvila.FluentOperations.Contract;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace JAAvila.FluentOperations.Integration;
@@ -11,6 +12,8 @@ public static class FluentOperationsDIExtensions
     /// <summary>
     /// Registers a Quality Blueprint for dependency injection.
     /// Blueprints are registered as singletons since they're stateless and reusable.
+    /// Also registers the blueprint as <see cref="IBlueprintValidator"/> when applicable,
+    /// enabling AOT-safe resolution by <c>BlueprintValidationFilter</c> and <c>MediatRBlueprintBehavior</c>.
     /// </summary>
     /// <typeparam name="TBlueprint">The blueprint type to register</typeparam>
     /// <param name="services">The service collection</param>
@@ -18,11 +21,15 @@ public static class FluentOperationsDIExtensions
     public static IServiceCollection AddBlueprint<TBlueprint>(this IServiceCollection services)
         where TBlueprint : class
     {
-        return services.AddSingleton<TBlueprint>();
+        services.AddSingleton<TBlueprint>();
+        if (typeof(IBlueprintValidator).IsAssignableFrom(typeof(TBlueprint)))
+            services.AddSingleton<IBlueprintValidator>(sp => (IBlueprintValidator)sp.GetRequiredService<TBlueprint>());
+        return services;
     }
 
     /// <summary>
     /// Registers multiple blueprints at once.
+    /// Also registers each blueprint as <see cref="IBlueprintValidator"/> when applicable.
     /// </summary>
     /// <param name="services">The service collection</param>
     /// <param name="blueprintTypes">Array of blueprint types to register</param>
@@ -35,6 +42,8 @@ public static class FluentOperationsDIExtensions
         foreach (var type in blueprintTypes)
         {
             services.AddSingleton(type);
+            if (typeof(IBlueprintValidator).IsAssignableFrom(type))
+                services.AddSingleton(typeof(IBlueprintValidator), sp => (IBlueprintValidator)sp.GetRequiredService(type));
         }
 
         return services;
@@ -45,6 +54,7 @@ public static class FluentOperationsDIExtensions
     /// <see cref="QualityBlueprint{T}"/> and registers them as singletons.
     /// Each blueprint is registered both as its concrete type and as its
     /// <c>QualityBlueprint&lt;TModel&gt;</c> base type, enabling resolution by either type.
+    /// Also registers each blueprint as <see cref="IBlueprintValidator"/> for AOT-safe filter resolution.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="assembly">The assembly to scan for blueprint implementations.</param>
@@ -64,8 +74,7 @@ public static class FluentOperationsDIExtensions
     /// </para>
     /// <para>
     /// The dual registration (concrete + base generic) ensures compatibility with
-    /// <c>BlueprintValidationFilter</c> (ASP.NET Core) and <c>MediatRBlueprintBehavior</c>,
-    /// which resolve blueprints via <c>typeof(QualityBlueprint&lt;&gt;).MakeGenericType(modelType)</c>.
+    /// <c>BlueprintValidationFilter</c> (ASP.NET Core) and <c>MediatRBlueprintBehavior</c>.
     /// </para>
     /// </remarks>
     /// <example>
@@ -88,6 +97,7 @@ public static class FluentOperationsDIExtensions
     /// then registers them as singletons.
     /// Each blueprint is registered both as its concrete type and as its
     /// <c>QualityBlueprint&lt;TModel&gt;</c> base type, enabling resolution by either type.
+    /// Also registers each blueprint as <see cref="IBlueprintValidator"/> for AOT-safe filter resolution.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="assembly">The assembly to scan for blueprint implementations.</param>
@@ -145,13 +155,15 @@ public static class FluentOperationsDIExtensions
             services.AddSingleton(type);
 
             // Register as QualityBlueprint<TModel> for generic resolution
-            // (used by BlueprintValidationFilter and MediatRBlueprintBehavior)
             var baseType = GetBlueprintBaseType(type);
 
             if (baseType is not null)
             {
                 services.AddSingleton(baseType, sp => sp.GetRequiredService(type));
             }
+
+            // Register as IBlueprintValidator for AOT-safe filter/behavior resolution
+            services.AddSingleton(typeof(IBlueprintValidator), sp => (IBlueprintValidator)sp.GetRequiredService(type));
         }
 
         return services;

--- a/Distributed/JAAvila.FluentOperations.MediatR/MediatRBlueprintBehavior.cs
+++ b/Distributed/JAAvila.FluentOperations.MediatR/MediatRBlueprintBehavior.cs
@@ -1,3 +1,4 @@
+using JAAvila.FluentOperations.Contract;
 using JAAvila.FluentOperations.Exceptions;
 using JAAvila.FluentOperations.Model;
 using MediatR;
@@ -6,20 +7,25 @@ namespace JAAvila.FluentOperations.Integration;
 
 /// <summary>
 /// MediatR pipeline behavior that automatically validates requests using Quality Blueprints.
-/// Walks up the type hierarchy to find blueprints registered for base types,
-/// enabling scenarios where a Blueprint&lt;BaseModel&gt; validates a derived request type.
+/// Finds the first registered <see cref="IBlueprintValidator"/> that can validate
+/// <typeparamref name="TRequest"/> and runs it before the handler is invoked.
 /// </summary>
+/// <remarks>
+/// This behavior is AOT-safe: it depends on <see cref="IBlueprintValidator"/> via DI
+/// and never uses <c>MakeGenericType</c> or <c>GetMethod</c> at runtime.
+/// Register blueprints with the DI helpers (e.g. <c>AddBlueprint&lt;T&gt;</c>) so that
+/// <see cref="IEnumerable{IBlueprintValidator}"/> is populated.
+/// </remarks>
 /// <typeparam name="TRequest">The request type</typeparam>
 /// <typeparam name="TResponse">The response type</typeparam>
 public class MediatRBlueprintBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : notnull
 {
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IEnumerable<IBlueprintValidator> _validators;
 
-    public MediatRBlueprintBehavior(IServiceProvider serviceProvider)
+    public MediatRBlueprintBehavior(IEnumerable<IBlueprintValidator> validators)
     {
-        _serviceProvider =
-            serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _validators = validators ?? throw new ArgumentNullException(nameof(validators));
     }
 
     public async Task<TResponse> Handle(
@@ -28,36 +34,14 @@ public class MediatRBlueprintBehavior<TRequest, TResponse> : IPipelineBehavior<T
         CancellationToken cancellationToken
     )
     {
-        object? blueprint = null;
-        Type? resolvedType = null;
-        var currentType = typeof(TRequest);
+        var validator = FindValidator(typeof(TRequest));
 
-        while (currentType != null && blueprint == null)
-        {
-            var blueprintType = typeof(QualityBlueprint<>).MakeGenericType(currentType);
-            blueprint = _serviceProvider.GetService(blueprintType);
-
-            if (blueprint != null)
-            {
-                resolvedType = currentType;
-            }
-
-            currentType = currentType.BaseType;
-        }
-
-        if (blueprint == null || resolvedType == null)
+        if (validator == null)
         {
             return await next();
         }
 
-        var checkMethod = blueprint.GetType().GetMethod("CheckAsync", [resolvedType]);
-
-        if (checkMethod == null)
-        {
-            return await next();
-        }
-
-        var report = await (Task<QualityReport>)checkMethod.Invoke(blueprint, [request])!;
+        var report = await validator.ValidateAsync(request);
 
         if (!report.IsValid)
         {
@@ -68,6 +52,19 @@ public class MediatRBlueprintBehavior<TRequest, TResponse> : IPipelineBehavior<T
         }
 
         return await next();
+    }
+
+    private IBlueprintValidator? FindValidator(Type requestType)
+    {
+        foreach (var validator in _validators)
+        {
+            if (validator.CanValidate(requestType))
+            {
+                return validator;
+            }
+        }
+
+        return null;
     }
 }
 

--- a/Distributed/JAAvila.FluentOperations.MediatR/MediatRExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations.MediatR/MediatRExtensions.cs
@@ -1,3 +1,4 @@
+using JAAvila.FluentOperations.Contract;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -43,6 +44,7 @@ public static class MediatRExtensions
     /// Adds a blueprint behavior where the blueprint validates a base model type
     /// and the request is a derived type. Registers the generic behavior that
     /// walks the type hierarchy to find the matching blueprint.
+    /// Also registers the blueprint as <see cref="IBlueprintValidator"/> for AOT-safe resolution.
     /// </summary>
     /// <typeparam name="TRequest">The request type (derived from TModel)</typeparam>
     /// <typeparam name="TResponse">The response type</typeparam>
@@ -57,6 +59,7 @@ public static class MediatRExtensions
         where TBlueprint : QualityBlueprint<TModel>
     {
         services.AddSingleton<QualityBlueprint<TModel>, TBlueprint>();
+        services.AddSingleton<IBlueprintValidator>(sp => (IBlueprintValidator)sp.GetRequiredService<QualityBlueprint<TModel>>());
         services.AddTransient<IPipelineBehavior<TRequest, TResponse>, MediatRBlueprintBehavior<TRequest, TResponse>>();
         return services;
     }

--- a/Distributed/JAAvila.FluentOperations/Contract/IBlueprintValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Contract/IBlueprintValidator.cs
@@ -1,0 +1,46 @@
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Contract;
+
+/// <summary>
+/// AOT-safe contract for blueprint validators that allows non-generic code to
+/// resolve and invoke blueprints without reflection, <c>MakeGenericType</c>, or <c>GetMethod</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="QualityBlueprint{T}"/> implements this interface explicitly.
+/// Consumers such as <c>BlueprintValidationFilter</c> and <c>MediatRBlueprintBehavior</c>
+/// depend only on <see cref="IBlueprintValidator"/> and avoid all runtime reflection.
+/// </para>
+/// <para>
+/// Register implementations via the DI helpers (e.g. <c>AddBlueprint&lt;T&gt;</c>) so that
+/// <see cref="IEnumerable{IBlueprintValidator}"/> can be injected by the filters.
+/// </para>
+/// </remarks>
+public interface IBlueprintValidator
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when this validator can validate instances of
+    /// <paramref name="modelType"/> (i.e. <c>T</c> is assignable from <paramref name="modelType"/>).
+    /// </summary>
+    /// <param name="modelType">The runtime type of the object to be validated.</param>
+    bool CanValidate(Type modelType);
+
+    /// <summary>
+    /// Synchronously validates <paramref name="instance"/> and returns a <see cref="QualityReport"/>.
+    /// </summary>
+    /// <param name="instance">The model instance to validate. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="instance"/> is <see langword="null"/>.
+    /// </exception>
+    QualityReport Validate(object instance);
+
+    /// <summary>
+    /// Asynchronously validates <paramref name="instance"/> and returns a <see cref="QualityReport"/>.
+    /// </summary>
+    /// <param name="instance">The model instance to validate. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="instance"/> is <see langword="null"/>.
+    /// </exception>
+    Task<QualityReport> ValidateAsync(object instance);
+}

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
@@ -34,7 +34,7 @@ namespace JAAvila.FluentOperations;
 /// if (!report.IsValid) { /* handle failures */ }
 /// </code>
 /// </example>
-public abstract partial class QualityBlueprint<T>
+public abstract partial class QualityBlueprint<T> : IBlueprintValidator
     where T : notnull
 {
     private record RuleDefinition(
@@ -770,6 +770,24 @@ public abstract partial class QualityBlueprint<T>
         var failures = errors.Select(f => $"  {f}");
         return $"Blueprint validation failed with {errors.Count} error(s):\n"
             + string.Join("\n", failures);
+    }
+
+    bool IBlueprintValidator.CanValidate(Type modelType)
+    {
+        ArgumentNullException.ThrowIfNull(modelType);
+        return typeof(T).IsAssignableFrom(modelType);
+    }
+
+    QualityReport IBlueprintValidator.Validate(object instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        return Check((T)instance);
+    }
+
+    async Task<QualityReport> IBlueprintValidator.ValidateAsync(object instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        return await CheckAsync((T)instance);
     }
 
     private static string GetPropertyName<TTarget>(Expression<Func<T, TTarget>> expression)


### PR DESCRIPTION
  Introduce IBlueprintValidator non-generic interface implemented
  explicitly by QualityBlueprint<T>, enabling NativeAOT-compatible
  validation filters without MakeGenericType or reflection-based
  method invocation.

  Changes:
  - New IBlueprintValidator interface with CanValidate(Type), Validate(object), and ValidateAsync(object)
  - QualityBlueprint<T> implements IBlueprintValidator explicitly using IsAssignableFrom for type matching and direct cast to T
  - BlueprintValidationFilter (ASP.NET Core non-generic): constructor changed from IServiceProvider to IEnumerable<IBlueprintValidator>, eliminating MakeGenericType and GetMethod/Invoke reflection
  - MediatRBlueprintBehavior<TRequest, TResponse> (non-generic): same pattern, all reflection removed
  - FluentOperationsDIExtensions: triple registration (concrete type + QualityBlueprint<TModel> + IBlueprintValidator) in all AddBlueprint and AddBlueprints overloads
  - Strongly-typed filters unchanged (already AOT-safe)

  BREAKING CHANGE: BlueprintValidationFilter and MediatRBlueprintBehavior
  non-generic constructors now accept IEnumerable<IBlueprintValidator>
  instead of IServiceProvider. DI resolves this automatically; only
  manual instantiation in tests requires updating.