### PR TITLE
Add Roslyn analyzer package with FO001 and FO003 diagnostics

### DIFF
--- a/Distributed/JAAvila.FluentOperations.Analyzers/Analyzers/DanglingTestChainAnalyzer.cs
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/Analyzers/DanglingTestChainAnalyzer.cs
@@ -1,0 +1,83 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace JAAvila.FluentOperations.Analyzers
+{
+    /// <summary>
+    /// FO001 — Reports a warning when <c>.Test()</c> is called as a standalone expression statement
+    /// without chaining an assertion operation. The manager result is discarded and no validation runs.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DanglingTestChainAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(DiagnosticIds.DanglingTestChain);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeExpressionStatement, SyntaxKind.ExpressionStatement);
+        }
+
+        private static void AnalyzeExpressionStatement(SyntaxNodeAnalysisContext context)
+        {
+            var expressionStatement = (ExpressionStatementSyntax)context.Node;
+
+            // The full statement must be an invocation expression (not a member-access chain)
+            if (expressionStatement.Expression is not InvocationExpressionSyntax invocation)
+            {
+                return;
+            }
+
+            // The invocation must be a member access: <expr>.Test()
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            {
+                return;
+            }
+
+            // The method name must be "Test"
+            if (memberAccess.Name.Identifier.Text != "Test")
+            {
+                return;
+            }
+
+            // Resolve the method symbol to confirm it returns a FluentOperations manager
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+            
+            if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+            {
+                return;
+            }
+
+            // Check the return type is in the JAAvila.FluentOperations.Manager namespace
+            // and its name ends with "OperationsManager"
+            var returnType = methodSymbol.ReturnType;
+            
+            if (returnType is null)
+            {
+                return;
+            }
+
+            var namespaceName = returnType.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            var typeName = returnType.Name;
+
+            if (!namespaceName.StartsWith("JAAvila.FluentOperations.Manager", System.StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (!typeName.EndsWith("OperationsManager", System.StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            // The .Test() result is being discarded — report FO001
+            context.ReportDiagnostic(
+                Diagnostic.Create(DiagnosticIds.DanglingTestChain, memberAccess.Name.GetLocation()));
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Analyzers/Analyzers/DefineWithoutUsingAnalyzer.cs
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/Analyzers/DefineWithoutUsingAnalyzer.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace JAAvila.FluentOperations.Analyzers
+{
+    /// <summary>
+    /// FO003 — Reports a warning when <c>Define()</c> is called inside a QualityBlueprint
+    /// without being wrapped in a <c>using</c> statement.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class DefineWithoutUsingAnalyzer : DiagnosticAnalyzer
+    {
+        private const string QualityBlueprintTypeName = "QualityBlueprint";
+        private const string QualityBlueprintFullName = "JAAvila.FluentOperations.QualityBlueprint";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(DiagnosticIds.DefineWithoutUsing);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+
+            // Must be a simple name invocation "Define()" or member access "this.Define()"
+            var methodName = invocation.Expression switch
+                             {
+                                 SimpleNameSyntax simple => simple.Identifier.Text,
+                                 MemberAccessExpressionSyntax ma => ma.Name.Identifier.Text,
+                                 _ => null
+                             };
+
+            if (methodName != "Define")
+            {
+                return;
+            }
+
+            // Must have 0 arguments
+            if (invocation.ArgumentList.Arguments.Count != 0)
+            {
+                return;
+            }
+
+            // Resolve the method symbol
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+            
+            if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+            {
+                return;
+            }
+
+            // The method must be defined in a type that inherits from QualityBlueprint<T>
+            if (!IsDefinedInQualityBlueprint(methodSymbol.ContainingType))
+            {
+                return;
+            }
+
+            // Check if this invocation is already wrapped in a using statement
+            if (IsWrappedInUsing(invocation))
+            {
+                return;
+            }
+
+            // Define() is not inside a using — report FO003
+            context.ReportDiagnostic(
+                Diagnostic.Create(DiagnosticIds.DefineWithoutUsing, invocation.GetLocation()));
+        }
+
+        /// <summary>
+        /// Walks the inheritance chain of <paramref name="type"/> to determine if it
+        /// inherits from <c>QualityBlueprint&lt;T&gt;</c>.
+        /// </summary>
+        private static bool IsDefinedInQualityBlueprint(INamedTypeSymbol? type)
+        {
+            var current = type;
+            
+            while (current != null)
+            {
+                var fullName = current.ConstructedFrom?.ToDisplayString() ?? current.ToDisplayString();
+
+                // Match "JAAvila.FluentOperations.QualityBlueprint<T>" or unbound "QualityBlueprint"
+                if (fullName.StartsWith(QualityBlueprintFullName, System.StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                // Fallback: match by simple name in case the namespace is aliased
+                if (current.Name == QualityBlueprintTypeName)
+                {
+                    return true;
+                }
+
+                current = current.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> if the invocation node is wrapped by any of the three
+        /// supported using forms:
+        /// <list type="bullet">
+        ///   <item><c>using (Define()) { }</c></item>
+        ///   <item><c>using (var x = Define()) { }</c></item>
+        ///   <item><c>using var x = Define();</c></item>
+        /// </list>
+        /// </summary>
+        private static bool IsWrappedInUsing(InvocationExpressionSyntax invocation)
+        {
+            var parent = invocation.Parent;
+
+            // Form 1: using (Define()) { }
+            // The invocation is the resource expression of a UsingStatementSyntax
+            if (parent is UsingStatementSyntax)
+            {
+                return true;
+            }
+
+            // Form 2: using (var x = Define()) { }
+            // invocation → EqualsValueClauseSyntax → VariableDeclaratorSyntax
+            //            → VariableDeclarationSyntax → UsingStatementSyntax
+            if (parent is EqualsValueClauseSyntax equalsClause)
+            {
+                if (equalsClause.Parent is VariableDeclaratorSyntax declarator &&
+                    declarator.Parent is VariableDeclarationSyntax declaration &&
+                    declaration.Parent is UsingStatementSyntax)
+                {
+                    return true;
+                }
+
+                // Form 3: using var x = Define();
+                // invocation → EqualsValueClauseSyntax → VariableDeclaratorSyntax
+                //            → VariableDeclarationSyntax → LocalDeclarationStatementSyntax (with UsingKeyword)
+                if (equalsClause.Parent is VariableDeclaratorSyntax declarator2 &&
+                    declarator2.Parent is VariableDeclarationSyntax declaration2 &&
+                    declaration2.Parent is LocalDeclarationStatementSyntax localDecl &&
+                    localDecl.UsingKeyword.IsKind(SyntaxKind.UsingKeyword))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Analyzers/CodeFixes/DefineWithoutUsingCodeFix.cs
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/CodeFixes/DefineWithoutUsingCodeFix.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace JAAvila.FluentOperations.Analyzers
+{
+    /// <summary>
+    /// Code fix for FO003: wraps a bare <c>Define()</c> call in <c>using (Define()) { ... }</c>,
+    /// moving all subsequent sibling statements inside the new using block.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(DefineWithoutUsingCodeFix))]
+    [Shared]
+    public sealed class DefineWithoutUsingCodeFix : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(DiagnosticIds.DefineWithoutUsing.Id);
+
+        public override FixAllProvider GetFixAllProvider() =>
+            WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            
+            if (root is null)
+            {
+                return;
+            }
+
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+            // Find the InvocationExpressionSyntax for Define()
+            var invocation = root.FindNode(diagnosticSpan)
+                                 .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            
+            if (invocation is null)
+            {
+                return;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Wrap Define() in using statement",
+                    createChangedDocument: ct => WrapInUsingAsync(context.Document, invocation, ct),
+                    equivalenceKey: "FO003_WrapInUsing"),
+                diagnostic);
+        }
+
+        private static async Task<Document> WrapInUsingAsync(
+            Document document,
+            InvocationExpressionSyntax defineInvocation,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            
+            if (root is null)
+            {
+                return document;
+            }
+
+            // The bare Define() call sits inside an ExpressionStatementSyntax
+            var exprStatement = defineInvocation.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+            
+            if (exprStatement is null)
+            {
+                return document;
+            }
+
+            // The statement must live directly inside a block (e.g., constructor body)
+            if (exprStatement.Parent is not BlockSyntax block)
+            {
+                return document;
+            }
+
+            var statements = block.Statements;
+            var defineIndex = statements.IndexOf(exprStatement);
+            
+            if (defineIndex < 0)
+            {
+                return document;
+            }
+
+            // All statements that come AFTER Define() in the same block move inside the using body
+            var innerStatements = new List<StatementSyntax>();
+            
+            for (var i = defineIndex + 1; i < statements.Count; i++)
+            {
+                innerStatements.Add(statements[i].WithoutLeadingTrivia());
+            }
+
+            // Build: using (Define()) { <innerStatements> }
+            var usingBody = SyntaxFactory.Block(
+                SyntaxFactory.List(innerStatements));
+
+            var usingStatement = SyntaxFactory.UsingStatement(
+                declaration: null,
+                expression: defineInvocation.WithoutTrivia(),
+                statement: usingBody)
+                .WithAdditionalAnnotations(Formatter.Annotation)
+                .WithLeadingTrivia(exprStatement.GetLeadingTrivia());
+
+            // Remove the original Define() statement and all statements that moved inside
+            var statementsToRemove = new HashSet<StatementSyntax> { exprStatement };
+            
+            for (var i = defineIndex + 1; i < statements.Count; i++)
+            {
+                statementsToRemove.Add(statements[i]);
+            }
+
+            var newStatements = statements
+                .Where(s => !statementsToRemove.Contains(s))
+                .ToList();
+
+            newStatements.Add(usingStatement);
+
+            var newBlock = block.WithStatements(SyntaxFactory.List(newStatements));
+            var newRoot = root.ReplaceNode(block, newBlock);
+
+            return document.WithSyntaxRoot(newRoot);
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Analyzers/DiagnosticIds.cs
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/DiagnosticIds.cs
@@ -1,0 +1,25 @@
+using Microsoft.CodeAnalysis;
+
+namespace JAAvila.FluentOperations.Analyzers
+{
+    internal static class DiagnosticIds
+    {
+        internal static readonly DiagnosticDescriptor DanglingTestChain = new DiagnosticDescriptor(
+            id: "FO001",
+            title: "Dangling .Test() chain",
+            messageFormat: "'.Test()' is called but no assertion operation is chained. The result is discarded and no validation occurs.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Calling '.Test()' without chaining an assertion operation (e.g., '.NotBeNull()', '.BePositive()') discards the result and performs no validation.");
+
+        internal static readonly DiagnosticDescriptor DefineWithoutUsing = new DiagnosticDescriptor(
+            id: "FO003",
+            title: "Define() called without using",
+            messageFormat: "'Define()' must be wrapped in a 'using' statement to ensure the rule-capture scope is disposed correctly.",
+            category: "Usage",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "Calling 'Define()' in a QualityBlueprint constructor without wrapping it in a 'using' statement leaves the capture context open, which may cause rules to be captured into the wrong blueprint.");
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Analyzers/JAAvila.FluentOperations.Analyzers.csproj
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/JAAvila.FluentOperations.Analyzers.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoWarn>RS2008;RS1032</NoWarn>
+    <PackageIcon>icon.png</PackageIcon>
+    <Authors>JAAvila</Authors>
+    <Description>Roslyn analyzers for JAAvila.FluentOperations. Detects dangling .Test() chains and Define() calls not wrapped in a using statement.</Description>
+    <PackageId>JAAvila.FluentOperations.Analyzers</PackageId>
+    <PackageTags>FluentOperations;Analyzer;Roslyn;Diagnostics</PackageTags>
+    <PackageProjectUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Copyright>Copyright (C) $([System.DateTime]::Now.Year) JAAvila</Copyright>
+    <MinVerTagPrefix>analyzers-</MinVerTagPrefix>
+    <DevelopmentDependency>true</DevelopmentDependency>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Pack the analyzer DLL into analyzers/dotnet/cs — NOT into lib/ -->
+    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="../../icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <Target Name="SetAssemblyVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/Distributed/JAAvila.FluentOperations.Analyzers/README.md
+++ b/Distributed/JAAvila.FluentOperations.Analyzers/README.md
@@ -1,0 +1,75 @@
+# JAAvila.FluentOperations.Analyzers
+
+Roslyn analyzers for [JAAvila.FluentOperations](https://github.com/JAAvila-Of/JAAvila.FluentOperations).
+
+This package provides compile-time diagnostics that detect common misuse patterns of the FluentOperations API.
+
+## Installation
+
+```
+dotnet add package JAAvila.FluentOperations.Analyzers
+```
+
+The package is a development-only dependency (`DevelopmentDependency = true`). It adds no runtime assemblies to your project.
+
+## Diagnostics
+
+### FO001 — Dangling `.Test()` chain (Warning)
+
+Reported when `.Test()` is called as a standalone statement without chaining any assertion operation. The manager result is discarded and no validation is performed.
+
+**Incorrect:**
+```csharp
+email.Test(); // FO001 — no assertion chained
+```
+
+**Correct:**
+```csharp
+email.Test().NotBeNull().BeEmail();
+```
+
+---
+
+### FO003 — `Define()` without `using` (Warning)
+
+Reported when `Define()` is called inside a `QualityBlueprint<T>` constructor without wrapping it in a `using` statement. Without `using`, the rule-capture scope is never disposed, which can cause rules to leak into subsequently constructed blueprints.
+
+A **code fix** is available: select *Wrap Define() in using statement* to automatically refactor the code.
+
+**Incorrect:**
+```csharp
+public class UserBlueprint : QualityBlueprint<User>
+{
+    public UserBlueprint()
+    {
+        Define(); // FO003 — not wrapped in using
+        For(x => x.Email).Test().NotBeNull();
+    }
+}
+```
+
+**Correct:**
+```csharp
+public class UserBlueprint : QualityBlueprint<User>
+{
+    public UserBlueprint()
+    {
+        using (Define())
+        {
+            For(x => x.Email).Test().NotBeNull();
+        }
+    }
+}
+```
+
+The following `using` forms are all recognized as valid:
+
+```csharp
+using (Define()) { ... }                    // parenthesized using
+using (var scope = Define()) { ... }        // with variable
+using var scope = Define();                 // declaration using (C# 8+)
+```
+
+## License
+
+Apache-2.0

--- a/JAAvila.FluentOperations.sln
+++ b/JAAvila.FluentOperations.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Me
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.MinimalApi", "Distributed\JAAvila.FluentOperations.MinimalApi\JAAvila.FluentOperations.MinimalApi.csproj", "{35A4BEB5-3B2D-465C-96B9-D044E250E1E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Analyzers", "Distributed\JAAvila.FluentOperations.Analyzers\JAAvila.FluentOperations.Analyzers.csproj", "{F110E7AD-E8D9-45CC-AB0D-763B61475D26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,18 @@ Global
 		{35A4BEB5-3B2D-465C-96B9-D044E250E1E2}.Release|x64.Build.0 = Release|Any CPU
 		{35A4BEB5-3B2D-465C-96B9-D044E250E1E2}.Release|x86.ActiveCfg = Release|Any CPU
 		{35A4BEB5-3B2D-465C-96B9-D044E250E1E2}.Release|x86.Build.0 = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|x64.Build.0 = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Debug|x86.Build.0 = Debug|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|x64.ActiveCfg = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|x64.Build.0 = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|x86.ActiveCfg = Release|Any CPU
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,5 +106,6 @@ Global
 		{05D5C54F-44E0-4193-9F7C-F7CDCB58C685} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{AD2F74A8-8CB7-493D-85E5-30E4205B2D4F} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{35A4BEB5-3B2D-465C-96B9-D044E250E1E2} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
+		{F110E7AD-E8D9-45CC-AB0D-763B61475D26} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
  Introduce JAAvila.FluentOperations.Analyzers, a separate NuGet package
  targeting netstandard2.0 that provides compile-time detection of common
  FluentOperations usage mistakes.

  Diagnostics:
  - FO001 (Warning): Dangling .Test() chain — detects when .Test() is called as a standalone expression without chaining any assertion. Semantically verifies the return type is an OperationsManager from the FluentOperations.Manager namespace (future-proof for new managers)
  - FO003 (Warning): Define() without using — detects when Define() in a QualityBlueprint subclass is not wrapped in a using statement. Covers all three valid forms: using (Define()), using (var x = Define()), and using var x = Define()

  CodeFix:
  - FO003 fix: automatically wraps bare Define() in using (Define()) { } and moves subsequent sibling statements inside the using block

  Packaging:
  - DLL placed exclusively in analyzers/dotnet/cs/ (not lib/)
  - IncludeBuildOutput=false prevents runtime dependency
  - MinVer tag prefix: analyzers-
  - FO002 (nullable without HaveValue guard) deferred to v2