### PR TITLE
Add JSON Schema generation from QualityBlueprint definitions

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Extensions/BlueprintJsonSchemaExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations/Extensions/BlueprintJsonSchemaExtensions.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using JAAvila.FluentOperations.Schema;
+
+namespace JAAvila.FluentOperations;
+
+/// <summary>
+/// Provides JSON Schema generation extension methods for <see cref="QualityBlueprint{T}"/>.
+/// </summary>
+public static class BlueprintJsonSchemaExtensions
+{
+    /// <summary>
+    /// Generates a JSON Schema <see cref="JsonDocument"/> that describes the model type
+    /// <typeparamref name="T"/> and the validation constraints defined in the blueprint.
+    /// </summary>
+    /// <typeparam name="T">The model type validated by the blueprint.</typeparam>
+    /// <param name="blueprint">The blueprint to inspect.</param>
+    /// <param name="options">
+    /// Optional generation options. When <c>null</c>, <see cref="JsonSchemaOptions.Default"/> is used.
+    /// </param>
+    /// <returns>
+    /// A <see cref="JsonDocument"/> representing the JSON Schema. The caller is responsible
+    /// for disposing the returned document.
+    /// </returns>
+    public static JsonDocument ToJsonSchema<T>(
+        this QualityBlueprint<T> blueprint,
+        JsonSchemaOptions? options = null)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(blueprint);
+
+        var rules = blueprint.GetRuleDescriptors();
+        return JsonSchemaGenerator.Generate<T>(rules, options ?? JsonSchemaOptions.Default);
+    }
+
+    /// <summary>
+    /// Generates a JSON Schema string that describes the model type <typeparamref name="T"/>
+    /// and the validation constraints defined in the blueprint.
+    /// </summary>
+    /// <typeparam name="T">The model type validated by the blueprint.</typeparam>
+    /// <param name="blueprint">The blueprint to inspect.</param>
+    /// <param name="options">
+    /// Optional generation options. When <c>null</c>, <see cref="JsonSchemaOptions.Default"/> is used.
+    /// </param>
+    /// <returns>A JSON string representation of the schema.</returns>
+    public static string ToJsonSchemaString<T>(
+        this QualityBlueprint<T> blueprint,
+        JsonSchemaOptions? options = null)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(blueprint);
+
+        var resolvedOptions = options ?? JsonSchemaOptions.Default;
+
+        using var doc = blueprint.ToJsonSchema(resolvedOptions);
+        using var stream = new System.IO.MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = resolvedOptions.WriteIndented });
+        doc.WriteTo(writer);
+        writer.Flush();
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaDraft.cs
+++ b/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaDraft.cs
@@ -1,0 +1,20 @@
+namespace JAAvila.FluentOperations.Schema;
+
+/// <summary>
+/// Specifies the JSON Schema draft version used when generating schemas from
+/// <see cref="QualityBlueprint{T}"/> definitions.
+/// </summary>
+public enum JsonSchemaDraft
+{
+    /// <summary>
+    /// JSON Schema Draft 2020-12. This is the default and recommended version.
+    /// Uses the <c>https://json-schema.org/draft/2020-12/schema</c> meta-schema URI.
+    /// </summary>
+    Draft202012,
+
+    /// <summary>
+    /// JSON Schema Draft 7.
+    /// Uses the <c>http://json-schema.org/draft-07/schema#</c> meta-schema URI.
+    /// </summary>
+    Draft7,
+}

--- a/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaGenerator.cs
+++ b/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaGenerator.cs
@@ -1,0 +1,176 @@
+using System.IO;
+using System.Reflection;
+using System.Text.Json;
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Schema;
+
+/// <summary>
+/// Generates a JSON Schema document from a flat list of <see cref="BlueprintRuleInfo"/> descriptors
+/// and the public properties of the model type <typeparamref name="T"/>.
+/// </summary>
+internal static class JsonSchemaGenerator
+{
+    /// <summary>
+    /// Generates a <see cref="JsonDocument"/> representing the JSON Schema for model type
+    /// <typeparamref name="T"/>, overlaid with the validation constraints derived from
+    /// <paramref name="descriptors"/>.
+    /// </summary>
+    /// <typeparam name="T">The model type.</typeparam>
+    /// <param name="descriptors">
+    /// The list of rule descriptors returned by <c>QualityBlueprint&lt;T&gt;.GetRuleDescriptors()</c>.
+    /// </param>
+    /// <param name="options">Generation options.</param>
+    /// <returns>A <see cref="JsonDocument"/> that the caller is responsible for disposing.</returns>
+    internal static JsonDocument Generate<T>(
+        IReadOnlyList<BlueprintRuleInfo> descriptors,
+        JsonSchemaOptions options)
+        where T : notnull
+    {
+        var stream = new MemoryStream();
+        var writerOptions = new JsonWriterOptions { Indented = options.WriteIndented };
+
+        using (var writer = new Utf8JsonWriter(stream, writerOptions))
+        {
+            writer.WriteStartObject();
+
+            // $schema URI
+            var schemaUri = options.Draft == JsonSchemaDraft.Draft7
+                ? "http://json-schema.org/draft-07/schema#"
+                : "https://json-schema.org/draft/2020-12/schema";
+            writer.WriteString("$schema", schemaUri);
+
+            writer.WriteString("type", "object");
+
+            // Separate unconditional from scenario-scoped descriptors
+            var unconditional = descriptors.Where(d => d.Scenario is null).ToList();
+            var byScenario = descriptors
+                .Where(d => d.Scenario is not null)
+                .GroupBy(d => d.Scenario!)
+                .ToList();
+
+            // Write properties and required for unconditional rules
+            WritePropertiesBlock<T>(writer, unconditional, options, out var requiredProps);
+
+            if (requiredProps.Count > 0)
+            {
+                WriteRequiredArray(writer, requiredProps);
+            }
+
+            // Write allOf with if/then blocks for scenario-scoped rules (Draft 2020-12 only)
+            if (byScenario.Count > 0 && options.Draft == JsonSchemaDraft.Draft202012)
+            {
+                writer.WritePropertyName("allOf");
+                writer.WriteStartArray();
+
+                foreach (var scenarioGroup in byScenario)
+                {
+                    var scenarioType = scenarioGroup.Key;
+                    var scenarioRules = scenarioGroup.ToList();
+
+                    writer.WriteStartObject();
+
+                    // if: describes when the model implements the scenario interface
+                    // We use a convention: the presence of a discriminator property or
+                    // simply annotate with the interface name in a description.
+                    writer.WritePropertyName("if");
+                    writer.WriteStartObject();
+                    writer.WritePropertyName("description");
+                    writer.WriteStringValue($"Applies when model satisfies scenario: {scenarioType.Name}");
+                    writer.WriteEndObject();
+
+                    // then: the constraints that apply under this scenario
+                    writer.WritePropertyName("then");
+                    writer.WriteStartObject();
+                    WritePropertiesBlock<T>(writer, scenarioRules, options, out var scenarioRequired);
+                    if (scenarioRequired.Count > 0)
+                    {
+                        WriteRequiredArray(writer, scenarioRequired);
+                    }
+                    writer.WriteEndObject();
+
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndArray();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        stream.Seek(0, SeekOrigin.Begin);
+        return JsonDocument.Parse(stream);
+    }
+
+    /// <summary>
+    /// Writes a <c>properties</c> block for <typeparamref name="T"/> using the provided rules.
+    /// Populates <paramref name="requiredProperties"/> with property names that should appear
+    /// in the <c>required</c> array.
+    /// </summary>
+    private static void WritePropertiesBlock<T>(
+        Utf8JsonWriter writer,
+        IReadOnlyList<BlueprintRuleInfo> rules,
+        JsonSchemaOptions options,
+        out List<string> requiredProperties)
+        where T : notnull
+    {
+        requiredProperties = [];
+
+        var modelProperties = typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // Index rules by property name for fast lookup
+        var rulesByProperty = rules
+            .GroupBy(r => r.PropertyName)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<BlueprintRuleInfo>)g.ToList());
+
+        writer.WritePropertyName("properties");
+        writer.WriteStartObject();
+
+        foreach (var prop in modelProperties)
+        {
+            var camelName = ToCamelCase(prop.Name);
+
+            writer.WritePropertyName(camelName);
+            writer.WriteStartObject();
+
+            // Write type information from the CLR type
+            JsonSchemaTypeMapper.WriteTypeProperties(writer, prop.PropertyType);
+
+            // Write validation constraints from matching rules
+            // Try both camelCase (JSON convention) and PascalCase (C# property name)
+            if (rulesByProperty.TryGetValue(prop.Name, out var matchingRules)
+                || rulesByProperty.TryGetValue(camelName, out matchingRules))
+            {
+                var isRequired = JsonSchemaRuleMapper.WriteConstraints(writer, matchingRules, options);
+                if (isRequired)
+                {
+                    requiredProperties.Add(camelName);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteRequiredArray(Utf8JsonWriter writer, IReadOnlyList<string> required)
+    {
+        writer.WritePropertyName("required");
+        writer.WriteStartArray();
+        foreach (var name in required)
+        {
+            writer.WriteStringValue(name);
+        }
+        writer.WriteEndArray();
+    }
+
+    private static string ToCamelCase(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return name;
+
+        return char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaOptions.cs
+++ b/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaOptions.cs
@@ -1,0 +1,36 @@
+namespace JAAvila.FluentOperations.Schema;
+
+/// <summary>
+/// Controls the behaviour of the JSON Schema generator.
+/// </summary>
+public sealed class JsonSchemaOptions
+{
+    /// <summary>
+    /// The JSON Schema draft version to emit. Defaults to <see cref="JsonSchemaDraft.Draft202012"/>.
+    /// </summary>
+    public JsonSchemaDraft Draft { get; init; } = JsonSchemaDraft.Draft202012;
+
+    /// <summary>
+    /// When <c>true</c> (the default), validation rules that do not map to a standard JSON Schema
+    /// keyword are written as <c>x-fo-validation</c> extension properties.
+    /// Set to <c>false</c> to suppress all extension properties.
+    /// </summary>
+    public bool IncludeExtensions { get; init; } = true;
+
+    /// <summary>
+    /// When <c>true</c>, mapped rules (those that DO produce standard keywords) are also included
+    /// in the <c>x-fo-validation</c> extension array alongside their standard keyword counterpart.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool IncludeMetadataForMappedRules { get; init; } = false;
+
+    /// <summary>
+    /// When <c>true</c> (the default), the output JSON is formatted with indentation.
+    /// </summary>
+    public bool WriteIndented { get; init; } = true;
+
+    /// <summary>
+    /// A pre-built instance with all defaults applied.
+    /// </summary>
+    public static JsonSchemaOptions Default { get; } = new();
+}

--- a/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaRuleMapper.cs
+++ b/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaRuleMapper.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Schema;
+
+/// <summary>
+/// Maps <see cref="BlueprintRuleInfo"/> operation names to standard JSON Schema keywords,
+/// writing them directly to a <see cref="Utf8JsonWriter"/>.
+/// </summary>
+internal static class JsonSchemaRuleMapper
+{
+    /// <summary>
+    /// Writes JSON Schema constraint keywords derived from the supplied rules onto the
+    /// currently-open property object in the writer.
+    /// </summary>
+    /// <param name="writer">The JSON writer, positioned inside a property schema object.</param>
+    /// <param name="rules">All rules registered for the property being written.</param>
+    /// <param name="options">Generation options.</param>
+    /// <returns>
+    /// <c>true</c> if any of the rules imply the property should appear in the model's
+    /// <c>required</c> array; <c>false</c> otherwise.
+    /// </returns>
+    internal static bool WriteConstraints(
+        Utf8JsonWriter writer,
+        IReadOnlyList<BlueprintRuleInfo> rules,
+        JsonSchemaOptions options)
+    {
+        var isRequired = false;
+        var unmappedRules = new List<BlueprintRuleInfo>();
+        var mappedRuleNames = new List<string>();
+
+        foreach (var rule in rules)
+        {
+            var mapped = TryWriteStandardConstraint(writer, rule, ref isRequired);
+            if (mapped)
+            {
+                mappedRuleNames.Add(rule.OperationName);
+            }
+            else
+            {
+                unmappedRules.Add(rule);
+            }
+        }
+
+        if (options.IncludeExtensions)
+        {
+            WriteExtensions(writer, unmappedRules, options.IncludeMetadataForMappedRules
+                ? rules.Where(r => mappedRuleNames.Contains(r.OperationName)).ToList()
+                : []);
+        }
+
+        return isRequired;
+    }
+
+    /// <summary>
+    /// Attempts to write a standard JSON Schema keyword for the operation.
+    /// Returns <c>true</c> when a keyword was written, <c>false</c> when the operation
+    /// does not map to a standard keyword.
+    /// </summary>
+    private static bool TryWriteStandardConstraint(
+        Utf8JsonWriter writer,
+        BlueprintRuleInfo rule,
+        ref bool isRequired)
+    {
+        switch (rule.OperationName)
+        {
+            case "NotBeNull":
+                isRequired = true;
+                return true;
+
+            case "NotBeEmpty":
+                writer.WriteNumber("minLength", 1);
+                return true;
+
+            case "NotBeNullOrEmpty":
+                isRequired = true;
+                writer.WriteNumber("minLength", 1);
+                return true;
+
+            case "HaveMinLength":
+                if (rule.Parameters.TryGetValue("minLength", out var minLen))
+                    writer.WriteNumber("minLength", Convert.ToInt64(minLen));
+                return true;
+
+            case "HaveMaxLength":
+                if (rule.Parameters.TryGetValue("maxLength", out var maxLen))
+                    writer.WriteNumber("maxLength", Convert.ToInt64(maxLen));
+                return true;
+
+            case "HaveLength":
+                if (rule.Parameters.TryGetValue("value", out var len))
+                {
+                    var lenVal = Convert.ToInt64(len);
+                    writer.WriteNumber("minLength", lenVal);
+                    writer.WriteNumber("maxLength", lenVal);
+                }
+                return true;
+
+            case "HaveLengthBetween":
+                if (rule.Parameters.TryGetValue("min", out var lbMin))
+                    writer.WriteNumber("minLength", Convert.ToInt64(lbMin));
+                if (rule.Parameters.TryGetValue("max", out var lbMax))
+                    writer.WriteNumber("maxLength", Convert.ToInt64(lbMax));
+                return true;
+
+            case "Match":
+            case "MatchRegex":
+                if (rule.Parameters.TryGetValue("pattern", out var pattern))
+                    writer.WriteString("pattern", pattern.ToString());
+                return true;
+
+            case "BeEmail":
+                writer.WriteString("format", "email");
+                return true;
+
+            case "BeUrl":
+                writer.WriteString("format", "uri");
+                return true;
+
+            case "BeGuid":
+                writer.WriteString("format", "uuid");
+                return true;
+
+            case "BeIPAddress":
+            case "BeIPv4":
+                writer.WriteString("format", "ipv4");
+                return true;
+
+            case "BeIPv6":
+                writer.WriteString("format", "ipv6");
+                return true;
+
+            case "BeGreaterThan":
+                if (rule.Parameters.TryGetValue("value", out var gtValue))
+                    WriteNumberOrDecimal(writer, "exclusiveMinimum", gtValue);
+                return true;
+
+            case "BeLessThan":
+                if (rule.Parameters.TryGetValue("value", out var ltValue))
+                    WriteNumberOrDecimal(writer, "exclusiveMaximum", ltValue);
+                return true;
+
+            case "BeGreaterThanOrEqualTo":
+                if (rule.Parameters.TryGetValue("value", out var gteValue))
+                    WriteNumberOrDecimal(writer, "minimum", gteValue);
+                return true;
+
+            case "BeLessThanOrEqualTo":
+                if (rule.Parameters.TryGetValue("value", out var lteValue))
+                    WriteNumberOrDecimal(writer, "maximum", lteValue);
+                return true;
+
+            case "BeInRange":
+                if (rule.Parameters.TryGetValue("min", out var rangeMin))
+                    WriteNumberOrDecimal(writer, "minimum", rangeMin);
+                if (rule.Parameters.TryGetValue("max", out var rangeMax))
+                    WriteNumberOrDecimal(writer, "maximum", rangeMax);
+                return true;
+
+            case "BePositive":
+                writer.WriteNumber("exclusiveMinimum", 0);
+                return true;
+
+            case "BeNegative":
+                writer.WriteNumber("exclusiveMaximum", 0);
+                return true;
+
+            case "BeZero":
+                writer.WriteNumber("const", 0);
+                return true;
+
+            case "BeOneOf":
+                if (rule.Parameters.TryGetValue("values", out var oneOfValues))
+                {
+                    writer.WritePropertyName("enum");
+                    writer.WriteStartArray();
+                    if (oneOfValues is System.Collections.IEnumerable enumValues)
+                    {
+                        foreach (var v in enumValues)
+                        {
+                            WriteJsonValue(writer, v);
+                        }
+                    }
+                    writer.WriteEndArray();
+                }
+                return true;
+
+            case "BeTrue":
+                writer.WriteBoolean("const", true);
+                return true;
+
+            case "BeFalse":
+                writer.WriteBoolean("const", false);
+                return true;
+
+            case "Be":
+                // Boolean Be: maps to const when the expected value is a known bool
+                if (rule.Parameters.TryGetValue("value", out var beValue) && beValue is bool boolConst)
+                {
+                    writer.WriteBoolean("const", boolConst);
+                    return true;
+                }
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    private static void WriteExtensions(
+        Utf8JsonWriter writer,
+        IReadOnlyList<BlueprintRuleInfo> unmappedRules,
+        IEnumerable<BlueprintRuleInfo> mappedRules)
+    {
+        var allExtensionRules = unmappedRules.Concat(mappedRules).ToList();
+        if (allExtensionRules.Count == 0)
+            return;
+
+        writer.WritePropertyName("x-fo-validation");
+        writer.WriteStartArray();
+
+        foreach (var rule in allExtensionRules)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("operation", rule.OperationName);
+
+            if (rule.Parameters.Count > 0)
+            {
+                writer.WritePropertyName("parameters");
+                writer.WriteStartObject();
+                foreach (var (key, value) in rule.Parameters)
+                {
+                    writer.WritePropertyName(key);
+                    WriteJsonValue(writer, value);
+                }
+                writer.WriteEndObject();
+            }
+
+            if (rule.Severity != Model.Severity.Error)
+            {
+                writer.WriteString("severity", rule.Severity.ToString());
+            }
+
+            if (rule.ErrorCode is not null)
+            {
+                writer.WriteString("errorCode", rule.ErrorCode);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteNumberOrDecimal(Utf8JsonWriter writer, string propertyName, object value)
+    {
+        writer.WritePropertyName(propertyName);
+        switch (value)
+        {
+            case int i: writer.WriteNumberValue(i); break;
+            case long l: writer.WriteNumberValue(l); break;
+            case float f: writer.WriteNumberValue(f); break;
+            case double d: writer.WriteNumberValue(d); break;
+            case decimal dec: writer.WriteNumberValue(dec); break;
+            case short s: writer.WriteNumberValue(s); break;
+            case byte b: writer.WriteNumberValue(b); break;
+            case uint ui: writer.WriteNumberValue(ui); break;
+            case ulong ul: writer.WriteNumberValue(ul); break;
+            default: writer.WriteNumberValue(Convert.ToDouble(value)); break;
+        }
+    }
+
+    private static void WriteJsonValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null: writer.WriteNullValue(); break;
+            case bool boolVal: writer.WriteBooleanValue(boolVal); break;
+            case int i: writer.WriteNumberValue(i); break;
+            case long l: writer.WriteNumberValue(l); break;
+            case float f: writer.WriteNumberValue(f); break;
+            case double d: writer.WriteNumberValue(d); break;
+            case decimal dec: writer.WriteNumberValue(dec); break;
+            case short s: writer.WriteNumberValue(s); break;
+            case byte b: writer.WriteNumberValue(b); break;
+            case uint ui: writer.WriteNumberValue(ui); break;
+            case ulong ul: writer.WriteNumberValue(ul); break;
+            case string str: writer.WriteStringValue(str); break;
+            default: writer.WriteStringValue(value.ToString()); break;
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaTypeMapper.cs
+++ b/Distributed/JAAvila.FluentOperations/Schema/JsonSchemaTypeMapper.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+
+namespace JAAvila.FluentOperations.Schema;
+
+/// <summary>
+/// Maps .NET CLR types to their JSON Schema <c>type</c> and <c>format</c> equivalents.
+/// Writes directly to a <see cref="Utf8JsonWriter"/> to avoid intermediate allocations.
+/// </summary>
+internal static class JsonSchemaTypeMapper
+{
+    /// <summary>
+    /// Writes the <c>type</c> (and optionally <c>format</c>) properties for the given CLR type.
+    /// For nullable value types, writes a two-element type array: <c>["type","null"]</c>.
+    /// For collection types, writes <c>type: "array"</c> and an <c>items</c> object with the
+    /// element type. For unknown types, writes <c>type: "object"</c>.
+    /// </summary>
+    /// <param name="writer">The JSON writer to write into. Must be positioned inside an object.</param>
+    /// <param name="type">The CLR type to map.</param>
+    internal static void WriteTypeProperties(Utf8JsonWriter writer, Type type)
+    {
+        // Unwrap Nullable<T>
+        var underlying = Nullable.GetUnderlyingType(type);
+        if (underlying is not null)
+        {
+            WriteNullableTypeProperties(writer, underlying);
+            return;
+        }
+
+        // Collection types (IEnumerable<T> but not string)
+        if (type != typeof(string) && TryGetCollectionElementType(type, out var elementType))
+        {
+            writer.WriteString("type", "array");
+            writer.WritePropertyName("items");
+            writer.WriteStartObject();
+            WriteTypeProperties(writer, elementType!);
+            writer.WriteEndObject();
+            return;
+        }
+
+        WriteSimpleTypeProperties(writer, type);
+    }
+
+    private static void WriteNullableTypeProperties(Utf8JsonWriter writer, Type underlyingType)
+    {
+        // Collect what the type would be without null
+        var (jsonType, format) = GetTypeAndFormat(underlyingType);
+
+        writer.WritePropertyName("type");
+        writer.WriteStartArray();
+        writer.WriteStringValue(jsonType);
+        writer.WriteStringValue("null");
+        writer.WriteEndArray();
+
+        if (format is not null)
+        {
+            writer.WriteString("format", format);
+        }
+
+        // Enum values
+        if (underlyingType.IsEnum)
+        {
+            WriteEnumValues(writer, underlyingType);
+        }
+    }
+
+    private static void WriteSimpleTypeProperties(Utf8JsonWriter writer, Type type)
+    {
+        var (jsonType, format) = GetTypeAndFormat(type);
+
+        writer.WriteString("type", jsonType);
+
+        if (format is not null)
+        {
+            writer.WriteString("format", format);
+        }
+
+        if (type.IsEnum)
+        {
+            WriteEnumValues(writer, type);
+        }
+    }
+
+    /// <summary>
+    /// Returns the JSON Schema type string and optional format string for a CLR type.
+    /// Does not handle Nullable&lt;T&gt; or collections — those are handled by the callers.
+    /// </summary>
+    private static (string JsonType, string? Format) GetTypeAndFormat(Type type)
+    {
+        if (type == typeof(string)) return ("string", null);
+        if (type == typeof(bool)) return ("boolean", null);
+        if (type == typeof(int)) return ("integer", "int32");
+        if (type == typeof(long)) return ("integer", "int64");
+        if (type == typeof(float)) return ("number", "float");
+        if (type == typeof(double)) return ("number", "double");
+        if (type == typeof(decimal)) return ("number", "decimal");
+        if (type == typeof(DateTime)) return ("string", "date-time");
+        if (type == typeof(DateTimeOffset)) return ("string", "date-time");
+        if (type == typeof(DateOnly)) return ("string", "date");
+        if (type == typeof(TimeOnly)) return ("string", "time");
+        if (type == typeof(Guid)) return ("string", "uuid");
+        if (type == typeof(Uri)) return ("string", "uri");
+        if (type.IsEnum) return ("string", null);
+
+        return ("object", null);
+    }
+
+    private static void WriteEnumValues(Utf8JsonWriter writer, Type enumType)
+    {
+        writer.WritePropertyName("enum");
+        writer.WriteStartArray();
+        foreach (var name in Enum.GetNames(enumType))
+        {
+            writer.WriteStringValue(name);
+        }
+        writer.WriteEndArray();
+    }
+
+    private static bool TryGetCollectionElementType(Type type, out Type? elementType)
+    {
+        // Array
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType()!;
+            return true;
+        }
+
+        // IEnumerable<T> or any interface/class implementing it
+        foreach (var iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                elementType = iface.GetGenericArguments()[0];
+                return true;
+            }
+        }
+
+        elementType = null;
+        return false;
+    }
+}


### PR DESCRIPTION
  Implement Blueprint-to-JSON-Schema conversion supporting Draft 2020-12
  and Draft 7, enabling client-side validation, form generation with
  constraints, and data contract documentation.

  New Schema infrastructure (Core package, zero new dependencies):
  - JsonSchemaGenerator: Utf8JsonWriter-based generator using reflection on typeof(T) to discover properties and GetRuleDescriptors() to overlay validation constraints
  - JsonSchemaTypeMapper: maps 20+ CLR types to JSON Schema type/format including nullable, collections, enums, date/time, and Guid
  - JsonSchemaRuleMapper: switches on 26+ operation names to emit native JSON Schema keywords (minLength, maxLength, pattern, minimum, maximum, exclusiveMinimum, exclusiveMaximum, required, format, enum, const) with x-fo-validation fallback for unmapped rules
  - JsonSchemaOptions: configurable draft version, extensions, indentation
  - BlueprintJsonSchemaExtensions: ToJsonSchema() and ToJsonSchemaString() public extension methods on QualityBlueprint<T>

  Scenarios produce allOf with if/then blocks in Draft 2020-12.