### PR TITLE
Add validation telemetry with System.Diagnostics.Metrics

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/FluentOperationsConfig.cs
@@ -95,6 +95,11 @@ public static class FluentOperationsConfig
     /// </summary>
     public static TestFrameworkConfig GetTestFrameworkConfig() => GlobalConfig.GetTestFrameworkConfig();
 
+    /// <summary>
+    /// Returns the current effective TelemetryConfig, or <c>null</c> when telemetry is disabled.
+    /// </summary>
+    internal static TelemetryConfig? GetTelemetryConfig() => GlobalConfig.GetTelemetryConfig();
+
 }
 
 /// <summary>
@@ -133,6 +138,11 @@ public class ConfigBuilder
     /// </summary>
     public LocalizationConfigBuilder Localization { get; } = new();
 
+    /// <summary>
+    /// Configuration options for validation telemetry emitted via <c>System.Diagnostics.Metrics</c>.
+    /// </summary>
+    public TelemetryConfigBuilder Telemetry { get; } = new();
+
     internal static ConfigBuilder FromExisting(GlobalConfig existing)
     {
         var builder = new ConfigBuilder();
@@ -168,6 +178,15 @@ public class ConfigBuilder
             builder.Localization.Provider = lc.Provider;
             builder.Localization.Culture = lc.Culture;
             builder.Localization.EnableCache = lc.EnableCache;
+        }
+
+        var tc = existing.GetTelemetryConfigInternal();
+        if (tc is not null)
+        {
+            builder.Telemetry.Enabled = tc.Enabled;
+            builder.Telemetry.TrackRuleExecutionTime = tc.TrackRuleExecutionTime;
+            builder.Telemetry.TrackFailureRates = tc.TrackFailureRates;
+            builder.Telemetry.TrackBlueprintExecutionTime = tc.TrackBlueprintExecutionTime;
         }
 
         return builder;
@@ -220,6 +239,19 @@ public class ConfigBuilder
             Provider = Localization.Provider,
             Culture = Localization.Culture,
             EnableCache = Localization.EnableCache
+        };
+    }
+
+    internal TelemetryConfig? BuildTelemetryConfig()
+    {
+        if (!Telemetry.Enabled) return null;
+
+        return new TelemetryConfig
+        {
+            Enabled = true,
+            TrackRuleExecutionTime = Telemetry.TrackRuleExecutionTime,
+            TrackFailureRates = Telemetry.TrackFailureRates,
+            TrackBlueprintExecutionTime = Telemetry.TrackBlueprintExecutionTime
         };
     }
 }

--- a/Distributed/JAAvila.FluentOperations/Config/GlobalConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/GlobalConfig.cs
@@ -28,6 +28,7 @@ internal class GlobalConfig
     private FormattingConfig Formatting { get; init; } = new();
     private TestFrameworkConfig TestFramework { get; init; } = new();
     private LocalizationConfig? Localization { get; init; }
+    private TelemetryConfig? Telemetry { get; init; }
 
     private static GlobalConfig Default => new()
     {
@@ -113,6 +114,7 @@ internal class GlobalConfig
     public static FormattingConfig GetFormattingConfig() => GetInstance().Formatting;
     public static TestFrameworkConfig GetTestFrameworkConfig() => GetInstance().TestFramework;
     public static LocalizationConfig? GetLocalizationConfig() => GetInstance().Localization;
+    public static TelemetryConfig? GetTelemetryConfig() => GetInstance().Telemetry;
 
     // --- Internal accessors for ConfigBuilder.FromExisting() ---
 
@@ -122,6 +124,7 @@ internal class GlobalConfig
     internal FormattingConfig GetFormattingConfigInternal() => Formatting;
     internal TestFrameworkConfig GetTestFrameworkConfigInternal() => TestFramework;
     internal LocalizationConfig? GetLocalizationConfigInternal() => Localization;
+    internal TelemetryConfig? GetTelemetryConfigInternal() => Telemetry;
 
     // --- Scope management (used by FluentOperationsConfig) ---
 
@@ -142,7 +145,8 @@ internal class GlobalConfig
             DateTime = builder.BuildDateTimeConfig(),
             Formatting = builder.BuildFormattingConfig(),
             TestFramework = newTestFrameworkConfig,
-            Localization = builder.BuildLocalizationConfig()
+            Localization = builder.BuildLocalizationConfig(),
+            Telemetry = builder.BuildTelemetryConfig()
         };
 
         if (previousFramework != newTestFrameworkConfig.Framework)

--- a/Distributed/JAAvila.FluentOperations/Config/TelemetryConfig.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/TelemetryConfig.cs
@@ -1,0 +1,30 @@
+namespace JAAvila.FluentOperations.Config;
+
+/// <summary>
+/// Immutable telemetry configuration. Controls which validation metrics are emitted
+/// via <c>System.Diagnostics.Metrics</c>.
+/// </summary>
+internal class TelemetryConfig
+{
+    /// <summary>
+    /// When <c>true</c>, telemetry metrics are emitted. Defaults to <c>false</c>.
+    /// All other flags are only meaningful when this is <c>true</c>.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, the duration of each eager rule execution is recorded as a histogram.
+    /// </summary>
+    public bool TrackRuleExecutionTime { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, failure rate counters are emitted for eager rule executions.
+    /// </summary>
+    public bool TrackFailureRates { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, the total duration of each <c>Check</c> / <c>CheckAsync</c> call is
+    /// recorded as a histogram.
+    /// </summary>
+    public bool TrackBlueprintExecutionTime { get; init; }
+}

--- a/Distributed/JAAvila.FluentOperations/Config/TelemetryConfigBuilder.cs
+++ b/Distributed/JAAvila.FluentOperations/Config/TelemetryConfigBuilder.cs
@@ -1,0 +1,30 @@
+namespace JAAvila.FluentOperations.Config;
+
+/// <summary>
+/// Mutable builder for <see cref="TelemetryConfig"/>. Used inside <see cref="FluentOperationsConfig.Configure"/>.
+/// </summary>
+public class TelemetryConfigBuilder
+{
+    /// <summary>
+    /// Enables or disables telemetry metric emission. Defaults to <c>false</c>.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the duration of each eager rule execution is recorded.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool TrackRuleExecutionTime { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, failure rate counters are emitted for eager rule executions.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool TrackFailureRates { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, the total duration of each blueprint <c>Check</c> / <c>CheckAsync</c> call is recorded.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool TrackBlueprintExecutionTime { get; set; }
+}

--- a/Distributed/JAAvila.FluentOperations/ExecutionEngine.cs
+++ b/Distributed/JAAvila.FluentOperations/ExecutionEngine.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics;
+using JAAvila.FluentOperations.Config;
 using JAAvila.FluentOperations.Contract;
 using JAAvila.FluentOperations.Handler;
 using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Telemetry;
 
 namespace JAAvila.FluentOperations;
 
@@ -176,6 +179,10 @@ internal class ExecutionEngine<T, TS>(T manager) : IQualityRule, IRuleDescriptor
             return;
         }
 
+        var telemetryConfig = GlobalConfig.GetTelemetryConfig();
+        var sw = (telemetryConfig is { Enabled: true, TrackRuleExecutionTime: true })
+            ? Stopwatch.StartNew() : null;
+
         var fail = EnsureFailConditions();
 
         if (fail)
@@ -185,11 +192,30 @@ internal class ExecutionEngine<T, TS>(T manager) : IQualityRule, IRuleDescriptor
             {
                 ExceptionHandler.Handle(_customMessage ?? _template);
             }
+
+            if (telemetryConfig is { Enabled: true })
+            {
+                sw?.Stop();
+                FluentOperationsMeter.RecordEagerRuleExecution(
+                    false,
+                    _severity.ToString(),
+                    sw?.Elapsed.TotalMilliseconds ?? 0);
+            }
+
             // Warning and Info are silently ignored in eager mode for FailIf conditions
             return;
         }
 
         var result = BaseOperations.SafeExecute(() => _operation!.Validate());
+
+        if (telemetryConfig is { Enabled: true })
+        {
+            sw?.Stop();
+            FluentOperationsMeter.RecordEagerRuleExecution(
+                result,
+                _severity.ToString(),
+                sw?.Elapsed.TotalMilliseconds ?? 0);
+        }
 
         if (!result)
         {
@@ -281,15 +307,38 @@ internal class ExecutionEngine<T, TS>(T manager) : IQualityRule, IRuleDescriptor
             return;
         }
 
+        var telemetryConfig = GlobalConfig.GetTelemetryConfig();
+        var sw = (telemetryConfig is { Enabled: true, TrackRuleExecutionTime: true })
+            ? Stopwatch.StartNew() : null;
+
         var fail = EnsureFailConditions();
 
         if (fail)
         {
             ExceptionHandler.Handle(_template);
+
+            if (telemetryConfig is { Enabled: true })
+            {
+                sw?.Stop();
+                FluentOperationsMeter.RecordEagerRuleExecution(
+                    false,
+                    _severity.ToString(),
+                    sw?.Elapsed.TotalMilliseconds ?? 0);
+            }
+
             return;
         }
 
         var result = await BaseOperations.SafeExecuteAsync(() => _operation!.ValidateAsync());
+
+        if (telemetryConfig is { Enabled: true })
+        {
+            sw?.Stop();
+            FluentOperationsMeter.RecordEagerRuleExecution(
+                result,
+                _severity.ToString(),
+                sw?.Elapsed.TotalMilliseconds ?? 0);
+        }
 
         if (!result)
         {

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
 using JAAvila.FluentOperations.Contract;
 using JAAvila.FluentOperations.Manager;
 using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Telemetry;
 
 // ReSharper disable once RedundantUsingDirective (kept for clarity with System.DateTime/TimeSpan overloads)
 
@@ -259,6 +262,10 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
     /// <returns>A <see cref="QualityReport"/> containing validation results and any failures.</returns>
     public async Task<QualityReport> CheckAsync(T instance, Type? activeScenario)
     {
+        var telemetryConfig = GlobalConfig.GetTelemetryConfig();
+        var telemetryEnabled = telemetryConfig is { Enabled: true };
+        var sw = FluentOperationsMeter.StartTimingIfEnabled(telemetryEnabled && telemetryConfig!.TrackBlueprintExecutionTime);
+
         ResetConditionGroups();
         _instance = instance;
         var report = new QualityReport();
@@ -464,6 +471,18 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
             }
         }
 
+        if (telemetryEnabled)
+        {
+            sw?.Stop();
+            FluentOperationsMeter.RecordBlueprintCheck(
+                GetType().Name,
+                typeof(T).Name,
+                report.IsValid,
+                report.RulesEvaluated,
+                report.Errors.Count,
+                sw?.Elapsed.TotalMilliseconds ?? 0);
+        }
+
         return report;
     }
 
@@ -500,6 +519,10 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
     /// <returns>A <see cref="QualityReport"/> containing validation results and any failures.</returns>
     public QualityReport Check(T instance, Type? activeScenario)
     {
+        var telemetryConfig = GlobalConfig.GetTelemetryConfig();
+        var telemetryEnabled = telemetryConfig is { Enabled: true };
+        var sw = FluentOperationsMeter.StartTimingIfEnabled(telemetryEnabled && telemetryConfig!.TrackBlueprintExecutionTime);
+
         ResetConditionGroups();
         _instance = instance;
         var report = new QualityReport();
@@ -676,6 +699,18 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
                 report.Failures.AddRange(failures);
                 report.RulesEvaluated++;
             }
+        }
+
+        if (telemetryEnabled)
+        {
+            sw?.Stop();
+            FluentOperationsMeter.RecordBlueprintCheck(
+                GetType().Name,
+                typeof(T).Name,
+                report.IsValid,
+                report.RulesEvaluated,
+                report.Errors.Count,
+                sw?.Elapsed.TotalMilliseconds ?? 0);
         }
 
         return report;

--- a/Distributed/JAAvila.FluentOperations/Telemetry/FluentOperationsMeter.cs
+++ b/Distributed/JAAvila.FluentOperations/Telemetry/FluentOperationsMeter.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using JAAvila.FluentOperations.Config;
+
+namespace JAAvila.FluentOperations.Telemetry;
+
+/// <summary>
+/// Central metrics hub for FluentOperations. Emits counters and histograms via
+/// <c>System.Diagnostics.Metrics</c> — zero external dependencies, consumable by
+/// OpenTelemetry, dotnet-counters, and any <see cref="MeterListener"/>.
+/// </summary>
+internal static class FluentOperationsMeter
+{
+    private static readonly Meter Meter = new("JAAvila.FluentOperations", "1.0.0");
+
+    // Counters
+    private static readonly Counter<long> RulesEvaluated =
+        Meter.CreateCounter<long>("fo.rules.evaluated", description: "Total number of rules evaluated.");
+
+    private static readonly Counter<long> RulesFailed =
+        Meter.CreateCounter<long>("fo.rules.failed", description: "Total number of rules that failed.");
+
+    // Histograms
+    private static readonly Histogram<double> RuleDuration =
+        Meter.CreateHistogram<double>("fo.rule.duration", unit: "ms", description: "Duration of individual rule execution in milliseconds.");
+
+    private static readonly Histogram<double> BlueprintDuration =
+        Meter.CreateHistogram<double>("fo.blueprint.duration", unit: "ms", description: "Duration of a full blueprint Check() / CheckAsync() call in milliseconds.");
+
+    /// <summary>
+    /// Records metrics for a completed blueprint <c>Check</c> / <c>CheckAsync</c> call.
+    /// Early-returns when telemetry is disabled (null config or <c>Enabled == false</c>).
+    /// </summary>
+    internal static void RecordBlueprintCheck(
+        string blueprintTypeName,
+        string modelTypeName,
+        bool isValid,
+        int rulesEvaluated,
+        int rulesFailed,
+        double elapsedMs)
+    {
+        var config = GlobalConfig.GetTelemetryConfig();
+        if (config is not { Enabled: true })
+        {
+            return;
+        }
+
+        var tags = new TagList
+        {
+            { "blueprint", blueprintTypeName },
+            { "model", modelTypeName },
+            { "is_valid", isValid.ToString().ToLowerInvariant() }
+        };
+
+        RulesEvaluated.Add(rulesEvaluated, tags);
+
+        if (rulesFailed > 0)
+        {
+            RulesFailed.Add(rulesFailed, tags);
+        }
+
+        if (config.TrackBlueprintExecutionTime)
+        {
+            BlueprintDuration.Record(elapsedMs, tags);
+        }
+    }
+
+    /// <summary>
+    /// Records metrics for a single eager rule execution (inline assertion path).
+    /// Early-returns when telemetry is disabled.
+    /// </summary>
+    internal static void RecordEagerRuleExecution(bool passed, string severity, double elapsedMs)
+    {
+        var config = GlobalConfig.GetTelemetryConfig();
+        if (config is not { Enabled: true })
+        {
+            return;
+        }
+
+        var tags = new TagList
+        {
+            { "passed", passed.ToString().ToLowerInvariant() },
+            { "severity", severity }
+        };
+
+        RulesEvaluated.Add(1, tags);
+
+        if (!passed)
+        {
+            RulesFailed.Add(1, tags);
+        }
+
+        if (config.TrackRuleExecutionTime && elapsedMs > 0)
+        {
+            RuleDuration.Record(elapsedMs, tags);
+        }
+    }
+
+    /// <summary>
+    /// Returns a running <see cref="Stopwatch"/> when <paramref name="needsTiming"/> is <c>true</c>;
+    /// otherwise returns <c>null</c> to avoid unnecessary allocations.
+    /// </summary>
+    internal static Stopwatch? StartTimingIfEnabled(bool needsTiming) =>
+        needsTiming ? Stopwatch.StartNew() : null;
+}


### PR DESCRIPTION
  Introduce opt-in observability for validation rule execution using
  System.Diagnostics.Metrics (OTel-compatible, zero external dependencies).

  Metrics emitted:
  - fo.rules.evaluated (Counter): total rules evaluated
  - fo.rules.failed (Counter): total rules that failed validation
  - fo.rule.duration (Histogram): individual rule execution time in ms
  - fo.blueprint.duration (Histogram): Blueprint Check() total time in ms

  Tags (low cardinality): blueprint type name, model type name, is_valid,
  severity level.

  Configuration:
  - Disabled by default (zero overhead: no Stopwatch, no tag allocation)
  - FluentOperationsConfig.Configure(c => c.Telemetry.Enabled = true)
  - Granular control: TrackRuleExecutionTime, TrackFailureRates, TrackBlueprintExecutionTime independently toggleable

  Instrumentation points:
  - QualityBlueprint.Check/CheckAsync: blueprint-level counters + duration
  - ExecutionEngine.Execute/ExecuteAsync: per-rule counters + duration (eager mode only, Blueprint collection mode excluded to prevent double-counting)