### PR TITLE
Add snapshot validation for QualityReport regression detection

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Extensions/QualityReportSnapshotExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations/Extensions/QualityReportSnapshotExtensions.cs
@@ -1,0 +1,139 @@
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Handler;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Snapshot;
+
+namespace JAAvila.FluentOperations.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="QualityReport"/> that enable snapshot-based regression testing.
+/// </summary>
+public static class QualityReportSnapshotExtensions
+{
+    /// <summary>
+    /// Asserts that the <paramref name="report"/> matches the stored snapshot identified by
+    /// <paramref name="snapshotName"/>. On the first run (when no snapshot file exists), the
+    /// behavior depends on <see cref="SnapshotOptions.UpdateMode"/>:
+    /// <list type="bullet">
+    ///   <item><see cref="SnapshotUpdateMode.Manual"/> — throws, instructing you to call <see cref="UpdateSnapshot"/>.</item>
+    ///   <item><see cref="SnapshotUpdateMode.CreateOnly"/> — creates the snapshot file and passes (baseline established).</item>
+    ///   <item><see cref="SnapshotUpdateMode.AutoUpdate"/> — always overwrites the snapshot and passes.</item>
+    /// </list>
+    /// </summary>
+    /// <param name="report">The quality report to compare.</param>
+    /// <param name="snapshotName">A unique name for the snapshot (file stem, without extension).</param>
+    /// <param name="options">Optional snapshot options. When <c>null</c>, defaults are used.</param>
+    /// <param name="callerFilePath">Injected automatically by the compiler — do not supply manually.</param>
+    public static void ShouldMatchSnapshot(
+        this QualityReport report,
+        string snapshotName,
+        SnapshotOptions? options = null,
+        [CallerFilePath] string callerFilePath = "")
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotName);
+
+        options ??= new SnapshotOptions();
+
+        var (dir, filePath) = ResolvePaths(snapshotName, options, callerFilePath);
+
+        if (!File.Exists(filePath))
+        {
+            switch (options.UpdateMode)
+            {
+                case SnapshotUpdateMode.Manual:
+                    ExceptionHandler.Throw(
+                        $"Snapshot file '{filePath}' does not exist. " +
+                        $"Call report.UpdateSnapshot(\"{snapshotName}\") once to create the baseline snapshot file.");
+                    return;
+
+                case SnapshotUpdateMode.CreateOnly:
+                case SnapshotUpdateMode.AutoUpdate:
+                    WriteSnapshot(report, options, dir, filePath);
+                    return;
+            }
+        }
+
+        // File exists
+        if (options.UpdateMode == SnapshotUpdateMode.AutoUpdate)
+        {
+            WriteSnapshot(report, options, dir, filePath);
+            return;
+        }
+
+        var storedJson = File.ReadAllText(filePath);
+        SnapshotSerializer.SnapshotData stored;
+
+        try
+        {
+            stored = SnapshotSerializer.Deserialize(storedJson);
+        }
+        catch (InvalidOperationException ex)
+        {
+            ExceptionHandler.Throw(ex.Message);
+            return;
+        }
+
+        var diff = SnapshotComparer.Compare(stored, report, snapshotName, options);
+
+        if (!diff.IsMatch)
+        {
+            ExceptionHandler.Throw(diff.FormatReport());
+        }
+    }
+
+    /// <summary>
+    /// Writes the <paramref name="report"/> as a snapshot file, always overwriting any existing file.
+    /// Use this method once to create or regenerate a baseline snapshot.
+    /// </summary>
+    /// <param name="report">The quality report to snapshot.</param>
+    /// <param name="snapshotName">A unique name for the snapshot (file stem, without extension).</param>
+    /// <param name="options">Optional snapshot options. When <c>null</c>, defaults are used.</param>
+    /// <param name="callerFilePath">Injected automatically by the compiler — do not supply manually.</param>
+    public static void UpdateSnapshot(
+        this QualityReport report,
+        string snapshotName,
+        SnapshotOptions? options = null,
+        [CallerFilePath] string callerFilePath = "")
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentException.ThrowIfNullOrWhiteSpace(snapshotName);
+
+        options ??= new SnapshotOptions();
+
+        var (dir, filePath) = ResolvePaths(snapshotName, options, callerFilePath);
+        WriteSnapshot(report, options, dir, filePath);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static (string dir, string filePath) ResolvePaths(
+        string snapshotName, SnapshotOptions options, string callerFilePath)
+    {
+        // When SnapshotDirectory is an absolute path (e.g. a temp dir in tests), use it directly.
+        // Otherwise, resolve relative to the caller's source file directory.
+        string dir;
+        if (Path.IsPathRooted(options.SnapshotDirectory))
+        {
+            dir = options.SnapshotDirectory;
+        }
+        else
+        {
+            var callerDir = Path.GetDirectoryName(callerFilePath) ?? Directory.GetCurrentDirectory();
+            dir = Path.Combine(callerDir, options.SnapshotDirectory);
+        }
+
+        var filePath = Path.Combine(dir, snapshotName + ".json");
+        return (dir, filePath);
+    }
+
+    private static void WriteSnapshot(
+        QualityReport report, SnapshotOptions options, string dir, string filePath)
+    {
+        Directory.CreateDirectory(dir);
+        var json = SnapshotSerializer.Serialize(report, options);
+        File.WriteAllText(filePath, json);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Model/SnapshotOptions.cs
+++ b/Distributed/JAAvila.FluentOperations/Model/SnapshotOptions.cs
@@ -1,0 +1,32 @@
+namespace JAAvila.FluentOperations.Model;
+
+/// <summary>
+/// Configuration options for snapshot-based validation via <c>ShouldMatchSnapshot</c>.
+/// </summary>
+public class SnapshotOptions
+{
+    /// <summary>
+    /// The directory (relative to the calling test file) where snapshot JSON files are stored.
+    /// Defaults to <c>__snapshots__</c>.
+    /// </summary>
+    public string SnapshotDirectory { get; init; } = "__snapshots__";
+
+    /// <summary>
+    /// When <c>true</c>, the <c>attemptedValue</c> field is included in the snapshot JSON and compared during matching.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool IncludeAttemptedValues { get; init; } = false;
+
+    /// <summary>
+    /// When <c>true</c>, failure messages are included in the snapshot JSON and compared during matching.
+    /// Set to <c>false</c> to ignore message changes (useful when messages are volatile).
+    /// Defaults to <c>true</c>.
+    /// </summary>
+    public bool IncludeMessages { get; init; } = true;
+
+    /// <summary>
+    /// Controls how snapshot files are created and updated.
+    /// Defaults to <see cref="SnapshotUpdateMode.Manual"/>.
+    /// </summary>
+    public SnapshotUpdateMode UpdateMode { get; init; } = SnapshotUpdateMode.Manual;
+}

--- a/Distributed/JAAvila.FluentOperations/Model/SnapshotUpdateMode.cs
+++ b/Distributed/JAAvila.FluentOperations/Model/SnapshotUpdateMode.cs
@@ -1,0 +1,26 @@
+namespace JAAvila.FluentOperations.Model;
+
+/// <summary>
+/// Controls how snapshot files are created and updated during snapshot validation.
+/// </summary>
+public enum SnapshotUpdateMode
+{
+    /// <summary>
+    /// Never auto-creates or auto-updates snapshot files.
+    /// If the snapshot file is missing, the assertion throws instructing the user to call <c>UpdateSnapshot()</c>.
+    /// This is the default and safest mode for CI environments.
+    /// </summary>
+    Manual = 0,
+
+    /// <summary>
+    /// Creates the snapshot file if it does not exist (first run establishes the baseline),
+    /// but throws on any mismatch against an existing snapshot.
+    /// </summary>
+    CreateOnly = 1,
+
+    /// <summary>
+    /// Always overwrites the snapshot file with the current report.
+    /// Use temporarily to regenerate snapshots after intentional changes.
+    /// </summary>
+    AutoUpdate = 2,
+}

--- a/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotComparer.cs
+++ b/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotComparer.cs
@@ -1,0 +1,171 @@
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Snapshot;
+
+/// <summary>
+/// Compares a stored <see cref="SnapshotSerializer.SnapshotData"/> against the current <see cref="QualityReport"/>
+/// and returns a structured <see cref="SnapshotDiff"/>.
+/// </summary>
+internal static class SnapshotComparer
+{
+    /// <summary>
+    /// Compares <paramref name="stored"/> against <paramref name="current"/> and returns all detected differences.
+    /// </summary>
+    internal static SnapshotDiff Compare(
+        SnapshotSerializer.SnapshotData stored,
+        QualityReport current,
+        string snapshotName,
+        SnapshotOptions options)
+    {
+        IsValidChange? isValidChange = stored.IsValid != current.IsValid
+            ? new IsValidChange(stored.IsValid, current.IsValid)
+            : null;
+
+        RulesEvaluatedChange? rulesEvaluatedChange = stored.RulesEvaluated != current.RulesEvaluated
+            ? new RulesEvaluatedChange(stored.RulesEvaluated, current.RulesEvaluated)
+            : null;
+
+        // Build lookup from stored failures by composite key (PropertyName, ErrorCode, Message)
+        // Multiple failures can share the same key — track which stored entries have been matched.
+        var storedLookup = BuildLookup(stored.Failures, options);
+        var currentLookup = BuildCurrentLookup(current.Failures, options);
+
+        var added = new List<QualityFailure>();
+        var removed = new List<QualityFailure>();
+        var changed = new List<FailureChange>();
+
+        // Find added and changed failures (present in current but different or absent in stored)
+        foreach (var (key, currentFailure) in currentLookup)
+        {
+            if (!storedLookup.TryGetValue(key, out var storedFailure))
+            {
+                added.Add(currentFailure);
+                continue;
+            }
+
+            // Mark stored entry as matched by removing it
+            storedLookup.Remove(key);
+
+            // Check for field-level differences
+            var severityChange = CompareSeverity(storedFailure, currentFailure);
+            var messageChange = options.IncludeMessages
+                ? CompareMessage(storedFailure, currentFailure)
+                : null;
+            var errorCodeChange = CompareErrorCode(storedFailure, currentFailure);
+
+            if (severityChange is not null || messageChange is not null || errorCodeChange is not null)
+            {
+                changed.Add(new FailureChange
+                {
+                    PropertyName = currentFailure.PropertyName,
+                    ErrorCode = currentFailure.ErrorCode,
+                    SeverityChange = severityChange,
+                    MessageChange = messageChange,
+                    ErrorCodeChange = errorCodeChange,
+                });
+            }
+        }
+
+        // Any remaining stored entries were not matched — they were removed
+        foreach (var (_, storedFailure) in storedLookup)
+        {
+            removed.Add(new QualityFailure
+            {
+                PropertyName = storedFailure.PropertyName,
+                Message = storedFailure.Message ?? string.Empty,
+                Severity = ParseSeverity(storedFailure.Severity),
+                ErrorCode = storedFailure.ErrorCode,
+            });
+        }
+
+        return new SnapshotDiff
+        {
+            SnapshotName = snapshotName,
+            IsValidChange = isValidChange,
+            RulesEvaluatedChange = rulesEvaluatedChange,
+            AddedFailures = added,
+            RemovedFailures = removed,
+            ChangedFailures = changed,
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static string BuildKey(string propertyName, string? errorCode, string? message, SnapshotOptions options)
+    {
+        var messagePart = options.IncludeMessages ? (message ?? string.Empty) : string.Empty;
+        return string.Join("|", propertyName, errorCode ?? string.Empty, messagePart);
+    }
+
+    private static Dictionary<string, SnapshotSerializer.SnapshotFailure> BuildLookup(
+        List<SnapshotSerializer.SnapshotFailure> failures, SnapshotOptions options)
+    {
+        // Use a counter-based suffix to handle duplicate keys
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var result = new Dictionary<string, SnapshotSerializer.SnapshotFailure>(StringComparer.Ordinal);
+
+        foreach (var f in failures)
+        {
+            var baseKey = BuildKey(f.PropertyName, f.ErrorCode, f.Message, options);
+            counts.TryGetValue(baseKey, out var count);
+            var uniqueKey = count == 0 ? baseKey : $"{baseKey}#{count}";
+            counts[baseKey] = count + 1;
+            result[uniqueKey] = f;
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, QualityFailure> BuildCurrentLookup(
+        List<QualityFailure> failures, SnapshotOptions options)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var result = new Dictionary<string, QualityFailure>(StringComparer.Ordinal);
+
+        foreach (var f in failures)
+        {
+            var baseKey = BuildKey(f.PropertyName, f.ErrorCode, f.Message, options);
+            counts.TryGetValue(baseKey, out var count);
+            var uniqueKey = count == 0 ? baseKey : $"{baseKey}#{count}";
+            counts[baseKey] = count + 1;
+            result[uniqueKey] = f;
+        }
+
+        return result;
+    }
+
+    private static (Severity Expected, Severity Actual)? CompareSeverity(
+        SnapshotSerializer.SnapshotFailure stored, QualityFailure current)
+    {
+        var storedSeverity = ParseSeverity(stored.Severity);
+        return storedSeverity != current.Severity
+            ? (storedSeverity, current.Severity)
+            : null;
+    }
+
+    private static (string Expected, string Actual)? CompareMessage(
+        SnapshotSerializer.SnapshotFailure stored, QualityFailure current)
+    {
+        var storedMessage = stored.Message ?? string.Empty;
+        return !string.Equals(storedMessage, current.Message, StringComparison.Ordinal)
+            ? (storedMessage, current.Message)
+            : null;
+    }
+
+    private static (string? Expected, string? Actual)? CompareErrorCode(
+        SnapshotSerializer.SnapshotFailure stored, QualityFailure current)
+    {
+        return !string.Equals(stored.ErrorCode, current.ErrorCode, StringComparison.Ordinal)
+            ? (stored.ErrorCode, current.ErrorCode)
+            : null;
+    }
+
+    private static Severity ParseSeverity(string value)
+    {
+        return Enum.TryParse<Severity>(value, ignoreCase: true, out var result)
+            ? result
+            : Severity.Error;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotDiff.cs
+++ b/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotDiff.cs
@@ -1,0 +1,122 @@
+using JAAvila.FluentOperations.Model;
+using System.Text;
+
+namespace JAAvila.FluentOperations.Snapshot;
+
+/// <summary>
+/// Records a single changed failure: the same key exists in both snapshots but one or more fields differ.
+/// </summary>
+internal class FailureChange
+{
+    /// <summary>The property name that identifies this failure (shared between stored and current).</summary>
+    public string PropertyName { get; init; } = string.Empty;
+
+    /// <summary>The error code that identifies this failure (shared between stored and current).</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>Non-null when the severity changed. Item1 = stored, Item2 = current.</summary>
+    public (Severity Expected, Severity Actual)? SeverityChange { get; init; }
+
+    /// <summary>Non-null when the message changed. Item1 = stored, Item2 = current.</summary>
+    public (string Expected, string Actual)? MessageChange { get; init; }
+
+    /// <summary>Non-null when the error code changed. Item1 = stored, Item2 = current.</summary>
+    public (string? Expected, string? Actual)? ErrorCodeChange { get; init; }
+}
+
+/// <summary>
+/// Captures the structural differences found between a stored snapshot and the current <see cref="QualityReport"/>.
+/// </summary>
+internal class SnapshotDiff
+{
+    /// <summary>The name of the snapshot being compared.</summary>
+    public string SnapshotName { get; init; } = string.Empty;
+
+    /// <summary>Non-null when the <c>isValid</c> flag changed.</summary>
+    public IsValidChange? IsValidChange { get; init; }
+
+    /// <summary>Non-null when the <c>rulesEvaluated</c> count changed.</summary>
+    public RulesEvaluatedChange? RulesEvaluatedChange { get; init; }
+
+    /// <summary>Failures present in the current report but absent from the stored snapshot.</summary>
+    public List<QualityFailure> AddedFailures { get; init; } = [];
+
+    /// <summary>Failures present in the stored snapshot but absent from the current report.</summary>
+    public List<QualityFailure> RemovedFailures { get; init; } = [];
+
+    /// <summary>Failures that exist in both but have one or more field differences.</summary>
+    public List<FailureChange> ChangedFailures { get; init; } = [];
+
+    /// <summary>
+    /// Returns <c>true</c> when there are no differences of any kind.
+    /// </summary>
+    public bool IsMatch =>
+        IsValidChange is null &&
+        RulesEvaluatedChange is null &&
+        AddedFailures.Count == 0 &&
+        RemovedFailures.Count == 0 &&
+        ChangedFailures.Count == 0;
+
+    /// <summary>
+    /// Produces a human-readable diff report for use in assertion failure messages.
+    /// </summary>
+    public string FormatReport()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Snapshot '{SnapshotName}' does not match the current QualityReport.");
+        sb.AppendLine();
+
+        if (IsValidChange is not null)
+        {
+            sb.AppendLine($"  IsValid changed: expected '{IsValidChange.Expected}', got '{IsValidChange.Actual}'");
+        }
+
+        if (RulesEvaluatedChange is not null)
+        {
+            sb.AppendLine($"  RulesEvaluated changed: expected '{RulesEvaluatedChange.Expected}', got '{RulesEvaluatedChange.Actual}'");
+        }
+
+        if (AddedFailures.Count > 0)
+        {
+            sb.AppendLine($"  Added failures ({AddedFailures.Count}):");
+            foreach (var f in AddedFailures)
+            {
+                sb.AppendLine($"    + [{f.Severity}] {f.PropertyName}: {f.Message}" +
+                    (f.ErrorCode is not null ? $" (Code: {f.ErrorCode})" : ""));
+            }
+        }
+
+        if (RemovedFailures.Count > 0)
+        {
+            sb.AppendLine($"  Removed failures ({RemovedFailures.Count}):");
+            foreach (var f in RemovedFailures)
+            {
+                sb.AppendLine($"    - [{f.Severity}] {f.PropertyName}: {f.Message}" +
+                    (f.ErrorCode is not null ? $" (Code: {f.ErrorCode})" : ""));
+            }
+        }
+
+        if (ChangedFailures.Count > 0)
+        {
+            sb.AppendLine($"  Changed failures ({ChangedFailures.Count}):");
+            foreach (var c in ChangedFailures)
+            {
+                sb.AppendLine($"    ~ {c.PropertyName}" + (c.ErrorCode is not null ? $" (Code: {c.ErrorCode})" : "") + ":");
+                if (c.SeverityChange is not null)
+                    sb.AppendLine($"        Severity: '{c.SeverityChange.Value.Expected}' → '{c.SeverityChange.Value.Actual}'");
+                if (c.MessageChange is not null)
+                    sb.AppendLine($"        Message:  '{c.MessageChange.Value.Expected}' → '{c.MessageChange.Value.Actual}'");
+                if (c.ErrorCodeChange is not null)
+                    sb.AppendLine($"        ErrorCode: '{c.ErrorCodeChange.Value.Expected}' → '{c.ErrorCodeChange.Value.Actual}'");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}
+
+/// <summary>Captures a change in the <c>isValid</c> flag between snapshot and current report.</summary>
+internal record IsValidChange(bool Expected, bool Actual);
+
+/// <summary>Captures a change in the <c>rulesEvaluated</c> count between snapshot and current report.</summary>
+internal record RulesEvaluatedChange(int Expected, int Actual);

--- a/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotSerializer.cs
+++ b/Distributed/JAAvila.FluentOperations/Snapshot/SnapshotSerializer.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Snapshot;
+
+/// <summary>
+/// Serializes and deserializes <see cref="QualityReport"/> snapshots as deterministic JSON.
+/// </summary>
+internal static class SnapshotSerializer
+{
+    private const int CurrentVersion = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    // -------------------------------------------------------------------------
+    // Internal models
+    // -------------------------------------------------------------------------
+
+    internal class SnapshotData
+    {
+        [JsonPropertyName("$snapshotVersion")]
+        public int SnapshotVersion { get; set; } = CurrentVersion;
+
+        public bool IsValid { get; set; }
+        public int RulesEvaluated { get; set; }
+        public List<SnapshotFailure> Failures { get; set; } = [];
+    }
+
+    internal class SnapshotFailure
+    {
+        public string PropertyName { get; set; } = string.Empty;
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Message { get; set; }
+
+        public string Severity { get; set; } = string.Empty;
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? ErrorCode { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? AttemptedValue { get; set; }
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Serializes a <see cref="QualityReport"/> to a deterministic JSON string.
+    /// Failures are ordered by PropertyName, then Severity, then Message for stability.
+    /// </summary>
+    internal static string Serialize(QualityReport report, SnapshotOptions options)
+    {
+        var failures = report.Failures
+            .OrderBy(f => f.PropertyName, StringComparer.Ordinal)
+            .ThenBy(f => f.Severity.ToString(), StringComparer.Ordinal)
+            .ThenBy(f => f.Message, StringComparer.Ordinal)
+            .Select(f => new SnapshotFailure
+            {
+                PropertyName = f.PropertyName,
+                Message = options.IncludeMessages ? f.Message : null,
+                Severity = f.Severity.ToString(),
+                ErrorCode = f.ErrorCode,
+                AttemptedValue = options.IncludeAttemptedValues
+                    ? f.AttemptedValue?.ToString()
+                    : null,
+            })
+            .ToList();
+
+        var data = new SnapshotData
+        {
+            SnapshotVersion = CurrentVersion,
+            IsValid = report.IsValid,
+            RulesEvaluated = report.RulesEvaluated,
+            Failures = failures,
+        };
+
+        return JsonSerializer.Serialize(data, JsonOptions);
+    }
+
+    /// <summary>
+    /// Deserializes a JSON string back into a <see cref="SnapshotData"/> instance.
+    /// Throws <see cref="InvalidOperationException"/> when the snapshot version is unsupported.
+    /// </summary>
+    internal static SnapshotData Deserialize(string json)
+    {
+        var data = JsonSerializer.Deserialize<SnapshotData>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Failed to deserialize snapshot: the JSON content is null or empty.");
+
+        if (data.SnapshotVersion != CurrentVersion)
+        {
+            throw new InvalidOperationException(
+                $"Unsupported snapshot version '{data.SnapshotVersion}'. " +
+                $"The current supported version is {CurrentVersion}. " +
+                "Regenerate the snapshot file by calling UpdateSnapshot().");
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
  Introduce ShouldMatchSnapshot() and UpdateSnapshot() extension methods
  on QualityReport that compare validation results against stored golden
  snapshots, detecting unintended changes to Blueprint behavior.

  Snapshot infrastructure:
  - SnapshotSerializer: deterministic JSON serialization ordered by PropertyName/Severity/Message with StringComparer.Ordinal for cross-platform stability and version-tagged format ('$\snapshotVersion': 1)
  - SnapshotComparer: key-based failure matching (PropertyName, ErrorCode, Message) producing structured SnapshotDiff with added, removed, and changed failures including field-level severity/message/errorCode diffs
  - SnapshotDiff.FormatReport(): human-readable diff output with Added/ Removed/Changed sections and inline expected vs actual comparisons

  Configuration via SnapshotOptions:
  - SnapshotUpdateMode: Manual (default, never auto-creates), CreateOnly (creates baseline on first run), AutoUpdate (always overwrites)
  - IncludeMessages: true by default, false for localization-tolerant diffs
  - IncludeAttemptedValues: false by default to avoid dynamic data breakage
  - SnapshotDirectory: relative to test file via CallerFilePath