### PR TITLE
Add gRPC server interceptor package for Blueprint validation

### DIFF
--- a/Distributed/JAAvila.FluentOperations.Grpc/AssemblyInfo.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("JAAvila.FluentOperations.Testing.NUnit")]

--- a/Distributed/JAAvila.FluentOperations.Grpc/GrpcBlueprintInterceptor.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/GrpcBlueprintInterceptor.cs
@@ -1,0 +1,132 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// gRPC server interceptor that automatically validates incoming requests using Quality Blueprints.
+/// Finds the first registered <see cref="IBlueprintValidator"/> that can validate the request type
+/// and runs it before the handler is invoked.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interceptor is AOT-safe: it depends on <see cref="IBlueprintValidator"/> via DI
+/// and never uses <c>MakeGenericType</c> or <c>GetMethod</c> at runtime.
+/// </para>
+/// <para>
+/// Register via <see cref="GrpcExtensions.AddGrpcBlueprintValidation(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/> and configure gRPC
+/// to use the interceptor via <c>services.AddGrpc(o => o.Interceptors.Add&lt;GrpcBlueprintInterceptor&gt;())</c>.
+/// </para>
+/// </remarks>
+public class GrpcBlueprintInterceptor : Interceptor
+{
+    private readonly IEnumerable<IBlueprintValidator> _validators;
+    private readonly GrpcBlueprintOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="GrpcBlueprintInterceptor"/>.
+    /// </summary>
+    /// <param name="validators">All registered blueprint validators.</param>
+    /// <param name="options">Interceptor options. When <see langword="null"/>, defaults are used.</param>
+    public GrpcBlueprintInterceptor(
+        IEnumerable<IBlueprintValidator> validators,
+        GrpcBlueprintOptions? options = null)
+    {
+        _validators = validators ?? throw new ArgumentNullException(nameof(validators));
+        _options = options ?? new GrpcBlueprintOptions();
+    }
+
+    /// <inheritdoc/>
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateOrThrowAsync(request);
+        return await continuation(request, context);
+    }
+
+    /// <inheritdoc/>
+    public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        ServerCallContext context,
+        ClientStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        if (_options.StreamValidation == StreamValidationMode.Skip)
+        {
+            return await continuation(requestStream, context);
+        }
+
+        var wrappedStream = new ValidatingStreamReader<TRequest>(requestStream, ValidateOrThrowAsync, _options.StreamValidation);
+        return await continuation(wrappedStream, context);
+    }
+
+    /// <inheritdoc/>
+    public override async Task ServerStreamingServerHandler<TRequest, TResponse>(
+        TRequest request,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        ServerStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        await ValidateOrThrowAsync(request);
+        await continuation(request, responseStream, context);
+    }
+
+    /// <inheritdoc/>
+    public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(
+        IAsyncStreamReader<TRequest> requestStream,
+        IServerStreamWriter<TResponse> responseStream,
+        ServerCallContext context,
+        DuplexStreamingServerMethod<TRequest, TResponse> continuation)
+    {
+        if (_options.StreamValidation == StreamValidationMode.Skip)
+        {
+            await continuation(requestStream, responseStream, context);
+            return;
+        }
+
+        var wrappedStream = new ValidatingStreamReader<TRequest>(requestStream, ValidateOrThrowAsync, _options.StreamValidation);
+        await continuation(wrappedStream, responseStream, context);
+    }
+
+    /// <summary>
+    /// Finds the matching validator for <typeparamref name="T"/>, runs it, and throws
+    /// an <see cref="RpcException"/> if the report is invalid. Passes through when no
+    /// matching validator is registered.
+    /// </summary>
+    internal async Task ValidateOrThrowAsync<T>(T request)
+    {
+        if (request is null)
+        {
+            return;
+        }
+
+        var validator = FindValidator(typeof(T));
+
+        if (validator is null)
+        {
+            return;
+        }
+
+        var report = await validator.ValidateAsync(request);
+
+        if (!report.IsValid)
+        {
+            throw GrpcStatusMapper.ToRpcException(report, _options);
+        }
+    }
+
+    private IBlueprintValidator? FindValidator(Type requestType)
+    {
+        foreach (var validator in _validators)
+        {
+            if (validator.CanValidate(requestType))
+            {
+                return validator;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Grpc/GrpcBlueprintOptions.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/GrpcBlueprintOptions.cs
@@ -1,0 +1,28 @@
+using Grpc.Core;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// Configuration options for <see cref="GrpcBlueprintInterceptor"/>.
+/// </summary>
+public class GrpcBlueprintOptions
+{
+    /// <summary>
+    /// The gRPC status code returned when validation fails.
+    /// Defaults to <see cref="StatusCode.InvalidArgument"/>.
+    /// </summary>
+    public StatusCode FailureStatusCode { get; set; } = StatusCode.InvalidArgument;
+
+    /// <summary>
+    /// Controls how messages are validated on client-streaming and duplex-streaming calls.
+    /// Defaults to <see cref="StreamValidationMode.FirstMessageOnly"/>.
+    /// </summary>
+    public StreamValidationMode StreamValidation { get; set; } = StreamValidationMode.FirstMessageOnly;
+
+    /// <summary>
+    /// When <see langword="true"/>, a binary trailer entry <c>validation-errors-bin</c>
+    /// containing a JSON-serialized error dictionary is included in the <see cref="RpcException"/> metadata.
+    /// Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool IncludeReportInTrailers { get; set; } = true;
+}

--- a/Distributed/JAAvila.FluentOperations.Grpc/GrpcExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/GrpcExtensions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// Extension methods for integrating Quality Blueprint validation with gRPC services.
+/// </summary>
+public static class GrpcExtensions
+{
+    /// <summary>
+    /// Registers <see cref="GrpcBlueprintInterceptor"/> as a transient service so it can be
+    /// added to a gRPC service via <c>services.AddGrpc(o => o.Interceptors.Add&lt;GrpcBlueprintInterceptor&gt;())</c>.
+    /// Uses default <see cref="GrpcBlueprintOptions"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGrpcBlueprintValidation(this IServiceCollection services)
+    {
+        services.AddTransient<GrpcBlueprintInterceptor>();
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="GrpcBlueprintInterceptor"/> as a transient service and configures
+    /// <see cref="GrpcBlueprintOptions"/> via the provided delegate.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">A delegate to configure interceptor options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddGrpcBlueprintValidation(
+        this IServiceCollection services,
+        Action<GrpcBlueprintOptions> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        var options = new GrpcBlueprintOptions();
+        configureOptions(options);
+
+        services.AddSingleton(options);
+        services.AddTransient<GrpcBlueprintInterceptor>();
+        return services;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Grpc/GrpcStatusMapper.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/GrpcStatusMapper.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Grpc.Core;
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// Converts a <see cref="QualityReport"/> into an <see cref="RpcException"/>
+/// with structured validation error metadata in gRPC trailers.
+/// </summary>
+public static class GrpcStatusMapper
+{
+    /// <summary>
+    /// Converts a failed <see cref="QualityReport"/> to an <see cref="RpcException"/>.
+    /// </summary>
+    /// <param name="report">The quality report containing validation failures.</param>
+    /// <param name="options">Options that control the status code and trailer inclusion.</param>
+    /// <returns>An <see cref="RpcException"/> with validation error metadata.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="report"/> is <see langword="null"/>.</exception>
+    public static RpcException ToRpcException(QualityReport report, GrpcBlueprintOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        options ??= new GrpcBlueprintOptions();
+
+        var errorDictionary = report.ToErrorDictionary();
+        var errorCount = errorDictionary.Values.Sum(errors => errors.Length);
+        var statusMessage = $"Validation failed with {errorCount} error(s).";
+
+        var status = new Status(options.FailureStatusCode, statusMessage);
+        var metadata = new Metadata();
+
+        // Add per-property metadata entries for each Error-level failure.
+        // gRPC metadata keys must be lowercase ASCII.
+        foreach (var kvp in errorDictionary)
+        {
+            var key = $"validation-error-{kvp.Key.ToLowerInvariant()}";
+            foreach (var message in kvp.Value)
+            {
+                metadata.Add(key, message);
+            }
+        }
+
+        // Optionally add a binary trailer with the full JSON-serialized error dictionary.
+        // Binary metadata keys MUST end in -bin per the gRPC spec.
+        if (options.IncludeReportInTrailers && errorDictionary.Count > 0)
+        {
+            var json = JsonSerializer.Serialize(errorDictionary);
+            metadata.Add(new Metadata.Entry("validation-errors-bin", System.Text.Encoding.UTF8.GetBytes(json)));
+        }
+
+        return new RpcException(status, metadata);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Grpc/JAAvila.FluentOperations.Grpc.csproj
+++ b/Distributed/JAAvila.FluentOperations.Grpc/JAAvila.FluentOperations.Grpc.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PackageIcon>icon.png</PackageIcon>
+    <Authors>JAAvila</Authors>
+    <Description>gRPC server interceptor integration for JAAvila.FluentOperations Quality Blueprints. Provides automatic request validation with structured error metadata in gRPC trailers.</Description>
+    <PackageId>JAAvila.FluentOperations.Grpc</PackageId>
+    <PackageTags>FluentOperations;gRPC;Validation;Interceptor;ServerInterceptor</PackageTags>
+    <PackageProjectUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Copyright>Copyright (C) $([System.DateTime]::Now.Year) JAAvila</Copyright>
+    <MinVerTagPrefix>grpc-</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore.Server" Version="2.57.0" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JAAvila.FluentOperations\JAAvila.FluentOperations.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <Target Name="SetAssemblyVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/Distributed/JAAvila.FluentOperations.Grpc/README.md
+++ b/Distributed/JAAvila.FluentOperations.Grpc/README.md
@@ -1,0 +1,94 @@
+# JAAvila.FluentOperations.Grpc
+
+gRPC server interceptor integration for [JAAvila.FluentOperations](https://github.com/JAAvila-Of/JAAvila.FluentOperations) Quality Blueprints. Provides automatic request validation with structured error metadata in gRPC trailers.
+
+## Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.Grpc
+```
+
+## Usage
+
+### 1. Define a Quality Blueprint
+
+```csharp
+public class CreateOrderBlueprint : QualityBlueprint<CreateOrderRequest>
+{
+    public CreateOrderBlueprint()
+    {
+        using (Define())
+        {
+            For(x => x.ProductId).Test().NotBeNull().NotBeEmpty();
+            For(x => x.Quantity).Test().BePositive();
+        }
+    }
+}
+```
+
+### 2. Register services
+
+```csharp
+// Program.cs
+builder.Services.AddSingleton<CreateOrderBlueprint>();
+builder.Services.AddSingleton<IBlueprintValidator>(sp =>
+    sp.GetRequiredService<CreateOrderBlueprint>());
+
+// Register the interceptor (with optional configuration)
+builder.Services.AddGrpcBlueprintValidation(options =>
+{
+    options.FailureStatusCode = StatusCode.InvalidArgument;
+    options.IncludeReportInTrailers = true;
+    options.StreamValidation = StreamValidationMode.FirstMessageOnly;
+});
+
+// Enable the interceptor on all gRPC services
+builder.Services.AddGrpc(options =>
+{
+    options.Interceptors.Add<GrpcBlueprintInterceptor>();
+});
+```
+
+### 3. Validation behavior
+
+When a request fails validation, the interceptor throws an `RpcException` with:
+
+- **Status code**: configured via `FailureStatusCode` (default: `InvalidArgument`)
+- **Status message**: `"Validation failed with N error(s)."`
+- **Metadata entries**: one `validation-error-{propertyname}` entry per Error-level failure message
+- **Binary trailer** (`validation-errors-bin`): JSON-serialized error dictionary (when `IncludeReportInTrailers = true`)
+
+Only `Severity.Error` failures block the call. `Warning` and `Info` failures are not included in error metadata.
+
+### Streaming modes
+
+The `StreamValidation` option controls validation on client-streaming and duplex-streaming calls:
+
+| Mode | Behavior |
+|------|----------|
+| `FirstMessageOnly` (default) | Validates only the first message; subsequent messages pass through |
+| `EveryMessage` | Validates every message on the stream |
+| `Skip` | No validation for streaming calls |
+
+Server-streaming calls validate the single request message the same way as unary calls.
+
+## Example client error handling
+
+```csharp
+try
+{
+    await client.CreateOrderAsync(request);
+}
+catch (RpcException ex) when (ex.StatusCode == StatusCode.InvalidArgument)
+{
+    // Read per-property errors from metadata
+    var productErrors = ex.Trailers.GetAll("validation-error-productid");
+
+    // Or read the full JSON dictionary from the binary trailer
+    var entry = ex.Trailers.Get("validation-errors-bin");
+    if (entry is not null)
+    {
+        var errors = JsonSerializer.Deserialize<Dictionary<string, string[]>>(entry.ValueBytes);
+    }
+}
+```

--- a/Distributed/JAAvila.FluentOperations.Grpc/StreamValidationMode.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/StreamValidationMode.cs
@@ -1,0 +1,24 @@
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// Controls how incoming messages are validated on client-streaming and duplex-streaming gRPC calls.
+/// </summary>
+public enum StreamValidationMode
+{
+    /// <summary>
+    /// Validate only the first message received on the stream.
+    /// Subsequent messages are passed through without validation.
+    /// This is the default mode.
+    /// </summary>
+    FirstMessageOnly,
+
+    /// <summary>
+    /// Validate every message received on the stream.
+    /// </summary>
+    EveryMessage,
+
+    /// <summary>
+    /// Skip validation entirely for streaming calls.
+    /// </summary>
+    Skip
+}

--- a/Distributed/JAAvila.FluentOperations.Grpc/ValidatingStreamReader.cs
+++ b/Distributed/JAAvila.FluentOperations.Grpc/ValidatingStreamReader.cs
@@ -1,0 +1,55 @@
+using Grpc.Core;
+
+namespace JAAvila.FluentOperations.Integration;
+
+/// <summary>
+/// Wraps an <see cref="IAsyncStreamReader{T}"/> and validates each message
+/// according to the configured <see cref="StreamValidationMode"/>.
+/// </summary>
+/// <typeparam name="T">The request message type.</typeparam>
+internal sealed class ValidatingStreamReader<T> : IAsyncStreamReader<T>
+{
+    private readonly IAsyncStreamReader<T> _inner;
+    private readonly Func<T, Task> _validate;
+    private readonly StreamValidationMode _mode;
+    private bool _firstMessageValidated;
+
+    internal ValidatingStreamReader(
+        IAsyncStreamReader<T> inner,
+        Func<T, Task> validate,
+        StreamValidationMode mode)
+    {
+        _inner = inner;
+        _validate = validate;
+        _mode = mode;
+    }
+
+    /// <inheritdoc/>
+    public T Current => _inner.Current;
+
+    /// <inheritdoc/>
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        var hasNext = await _inner.MoveNext(cancellationToken);
+
+        if (!hasNext)
+        {
+            return false;
+        }
+
+        var shouldValidate = _mode switch
+        {
+            StreamValidationMode.EveryMessage => true,
+            StreamValidationMode.FirstMessageOnly => !_firstMessageValidated,
+            _ => false
+        };
+
+        if (shouldValidate)
+        {
+            _firstMessageValidated = true;
+            await _validate(_inner.Current);
+        }
+
+        return true;
+    }
+}

--- a/JAAvila.FluentOperations.sln
+++ b/JAAvila.FluentOperations.sln
@@ -16,6 +16,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.An
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.OpenApi", "Distributed\JAAvila.FluentOperations.OpenApi\JAAvila.FluentOperations.OpenApi.csproj", "{E7DF8B17-5526-46C7-AE99-1E8C4E26D727}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Grpc", "Distributed\JAAvila.FluentOperations.Grpc\JAAvila.FluentOperations.Grpc.csproj", "{856C3FD8-F8C6-4399-9733-8D4089BA60AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,6 +112,18 @@ Global
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727}.Release|x64.Build.0 = Release|Any CPU
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727}.Release|x86.ActiveCfg = Release|Any CPU
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727}.Release|x86.Build.0 = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|x64.Build.0 = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Debug|x86.Build.0 = Debug|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x64.ActiveCfg = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x64.Build.0 = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x86.ActiveCfg = Release|Any CPU
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -122,5 +136,6 @@ Global
 		{35A4BEB5-3B2D-465C-96B9-D044E250E1E2} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{F110E7AD-E8D9-45CC-AB0D-763B61475D26} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
+		{856C3FD8-F8C6-4399-9733-8D4089BA60AD} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
  Introduce JAAvila.FluentOperations.Grpc, a new NuGet package providing
  a gRPC ServerInterceptor that validates incoming requests using Quality
  Blueprints before they reach the service handler.

  Package contents:
  - GrpcBlueprintInterceptor: extends Interceptor, overrides all 4 handler types (Unary, ClientStreaming, ServerStreaming, DuplexStreaming), uses IEnumerable<IBlueprintValidator> from DI for AOT-safe resolution
  - GrpcStatusMapper: converts QualityReport to RpcException with StatusCode.InvalidArgument, per-property metadata entries, and optional JSON binary trailer (validation-errors-bin)
  - ValidatingStreamReader<T>: IAsyncStreamReader wrapper for streaming validation with configurable modes (FirstMessageOnly, EveryMessage, Skip)
  - GrpcBlueprintOptions: configurable StatusCode, streaming mode, trailer inclusion
  - GrpcExtensions: AddGrpcBlueprintValidation() DI registration

  Only Severity.Error failures block the request. Warnings and Info-level
  findings pass through transparently.