### PR TITLE
Add DataAnnotations bridge package for legacy adoption

### DIFF
--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/AnnotationMapper.cs
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/AnnotationMapper.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace JAAvila.FluentOperations.DataAnnotations;
+
+/// <summary>
+/// Internal helper that scans a model type for <see cref="ValidationAttribute"/> annotations
+/// and dispatches rule registration to the blueprint via reflection.
+/// </summary>
+internal static class AnnotationMapper
+{
+    // Name of the generic method defined on DataAnnotationsBlueprint<T> that applies rules for a single property.
+    private const string ApplyRulesMethodName = "ApplyRulesForProperty";
+
+    /// <summary>
+    /// Scans <typeparamref name="TModel"/> properties and calls the blueprint's generic
+    /// <c>ApplyRulesForProperty&lt;TModel, TProp&gt;</c> method for each mapped property.
+    /// Must be called from within an active <c>Define()</c> scope.
+    /// </summary>
+    internal static void ApplyAnnotations<TModel>(
+        DataAnnotationsBlueprint<TModel> blueprint,
+        AnnotationOptions options
+    )
+        where TModel : notnull
+    {
+        var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+        if (!options.IncludeInheritedProperties)
+        {
+            bindingFlags |= BindingFlags.DeclaredOnly;
+        }
+
+        var properties = typeof(TModel).GetProperties(bindingFlags);
+
+        // Locate the generic ApplyRulesForProperty method on the blueprint's concrete type.
+        // We search the full hierarchy because it is defined on DataAnnotationsBlueprint<TModel>.
+        var applyMethod = FindApplyRulesMethod(blueprint.GetType());
+
+        if (applyMethod is null)
+        {
+            return;
+        }
+
+        foreach (var property in properties)
+        {
+            if (options.ExcludedProperties.Contains(property.Name))
+            {
+                continue;
+            }
+
+            var attributes = property
+                .GetCustomAttributes<ValidationAttribute>(inherit: true)
+                .ToList();
+
+            if (attributes.Count == 0)
+            {
+                continue;
+            }
+
+            // Build the closed generic method for this property's type.
+            var closedMethod = applyMethod.MakeGenericMethod(property.PropertyType);
+
+            closedMethod.Invoke(blueprint, [property, attributes, options]);
+        }
+    }
+
+    private static MethodInfo? FindApplyRulesMethod(Type blueprintType)
+    {
+        var type = blueprintType;
+
+        while (type is not null)
+        {
+            var method = type.GetMethod(
+                ApplyRulesMethodName,
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public
+            );
+
+            if (method is not null && method.IsGenericMethodDefinition)
+            {
+                return method;
+            }
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/AnnotationOptions.cs
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/AnnotationOptions.cs
@@ -1,0 +1,53 @@
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.DataAnnotations;
+
+/// <summary>
+/// Options that control how DataAnnotations attributes are mapped to Blueprint validation rules.
+/// </summary>
+public class AnnotationOptions
+{
+    /// <summary>
+    /// Gets or sets the default severity applied to rules generated from DataAnnotations attributes.
+    /// Defaults to <see cref="Severity.Error"/>.
+    /// </summary>
+    public Severity DefaultSeverity { get; set; } = Severity.Error;
+
+    /// <summary>
+    /// Gets or sets an optional prefix prepended to auto-generated error codes.
+    /// When <c>null</c>, no error code is assigned unless the annotation provides one.
+    /// </summary>
+    public string? ErrorCodePrefix { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <see cref="System.ComponentModel.DataAnnotations.RequiredAttribute"/>
+    /// annotations are ignored during mapping.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool IgnoreRequired { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the <c>ErrorMessage</c> defined on the annotation
+    /// is used as the custom message for the generated rule.
+    /// Defaults to <c>true</c>.
+    /// </summary>
+    public bool UseAnnotationErrorMessages { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the set of property names that are excluded from annotation mapping.
+    /// Property names are case-sensitive and match the C# member name.
+    /// </summary>
+    public HashSet<string> ExcludedProperties { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether properties declared on base types
+    /// are included in annotation mapping.
+    /// Defaults to <c>true</c>.
+    /// </summary>
+    public bool IncludeInheritedProperties { get; set; } = true;
+
+    /// <summary>
+    /// Gets a default <see cref="AnnotationOptions"/> instance with all properties at their default values.
+    /// </summary>
+    public static AnnotationOptions Default { get; } = new();
+}

--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/DataAnnotationsBlueprint.cs
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/DataAnnotationsBlueprint.cs
@@ -1,0 +1,568 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Reflection;
+using JAAvila.FluentOperations.Manager;
+using JAAvila.FluentOperations.Model;
+
+namespace JAAvila.FluentOperations.DataAnnotations;
+
+/// <summary>
+/// A <see cref="QualityBlueprint{T}"/> base class that can generate validation rules
+/// automatically from <see cref="System.ComponentModel.DataAnnotations"/> attributes
+/// declared on the model's properties.
+/// </summary>
+/// <typeparam name="T">The model type to validate.</typeparam>
+/// <remarks>
+/// Subclass this type and call <see cref="IncludeAnnotations"/> inside a <c>using (Define())</c> block.
+/// Rules derived from attributes are combined with any manually defined rules.
+/// </remarks>
+/// <example>
+/// <code>
+/// public class UserBlueprint : DataAnnotationsBlueprint&lt;User&gt;
+/// {
+///     public UserBlueprint()
+///     {
+///         using (Define())
+///         {
+///             IncludeAnnotations();
+///             // Add custom rules here:
+///             For(x =&gt; x.Name).Test().NotBeNull();
+///         }
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class DataAnnotationsBlueprint<T> : QualityBlueprint<T>
+    where T : notnull
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="DataAnnotationsBlueprint{T}"/>.
+    /// </summary>
+    protected DataAnnotationsBlueprint() { }
+
+    /// <summary>
+    /// Generates and registers validation rules from all <see cref="ValidationAttribute"/> annotations
+    /// found on <typeparamref name="T"/> properties.
+    /// Must be called from within an active <c>using (Define())</c> scope.
+    /// </summary>
+    /// <param name="options">
+    /// Options that control attribute mapping behaviour.
+    /// When <c>null</c>, <see cref="AnnotationOptions.Default"/> is used.
+    /// </param>
+    protected void IncludeAnnotations(AnnotationOptions? options = null)
+    {
+        AnnotationMapper.ApplyAnnotations(this, options ?? AnnotationOptions.Default);
+    }
+
+    /// <summary>
+    /// Creates a fully-configured <see cref="DataAnnotationsBlueprint{T}"/> instance whose
+    /// rules are derived entirely from the DataAnnotations attributes on <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="options">
+    /// Optional mapping options.  When <c>null</c>, <see cref="AnnotationOptions.Default"/> is used.
+    /// </param>
+    /// <returns>A ready-to-use blueprint instance.</returns>
+    public static DataAnnotationsBlueprint<T> FromAnnotations(AnnotationOptions? options = null)
+    {
+        return new AutoDataAnnotationsBlueprint<T>(options);
+    }
+
+    // -----------------------------------------------------------------
+    // Internal dispatch method — called by AnnotationMapper via reflection.
+    // One call per property; TProp is the property's declared type.
+    // -----------------------------------------------------------------
+
+    /// <summary>
+    /// Applies the validation rules implied by the given <paramref name="attributes"/> to
+    /// the property identified by <paramref name="propertyInfo"/>.
+    /// </summary>
+    /// <remarks>
+    /// This method is generic so that the compiler can resolve the correct <c>For()</c> overload
+    /// for each property type.  <see cref="AnnotationMapper"/> invokes it via
+    /// <see cref="MethodInfo.MakeGenericMethod"/> at runtime.
+    /// </remarks>
+    // ReSharper disable once UnusedMember.Global  (invoked via MakeGenericMethod)
+    protected void ApplyRulesForProperty<TProp>(
+        PropertyInfo propertyInfo,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var param = Expression.Parameter(typeof(T), "x");
+        var body = Expression.Property(param, propertyInfo);
+        var lambda = Expression.Lambda<Func<T, TProp>>(body, param);
+
+        var propertyType = typeof(TProp);
+        var isString = propertyType == typeof(string);
+        var isNullableInt = propertyType == typeof(int?);
+        var isInt = propertyType == typeof(int);
+        var isLong = propertyType == typeof(long);
+        var isNullableLong = propertyType == typeof(long?);
+        var isDouble = propertyType == typeof(double);
+        var isNullableDouble = propertyType == typeof(double?);
+        var isDecimal = propertyType == typeof(decimal);
+        var isNullableDecimal = propertyType == typeof(decimal?);
+
+        if (isString)
+        {
+            ApplyStringRules(
+                (Expression<Func<T, string?>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isInt)
+        {
+            ApplyIntRules(
+                (Expression<Func<T, int>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isNullableInt)
+        {
+            ApplyNullableIntRules(
+                (Expression<Func<T, int?>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isLong)
+        {
+            ApplyLongRules(
+                (Expression<Func<T, long>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isNullableLong)
+        {
+            ApplyNullableLongRules(
+                (Expression<Func<T, long?>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isDouble)
+        {
+            ApplyDoubleRules(
+                (Expression<Func<T, double>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isNullableDouble)
+        {
+            ApplyNullableDoubleRules(
+                (Expression<Func<T, double?>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isDecimal)
+        {
+            ApplyDecimalRules(
+                (Expression<Func<T, decimal>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        else if (isNullableDecimal)
+        {
+            ApplyNullableDecimalRules(
+                (Expression<Func<T, decimal?>>)(object)lambda,
+                attributes,
+                options
+            );
+        }
+        // Unsupported type: required-only check via object proxy, or skip.
+        else
+        {
+            ApplyRequiredOnlyRules(propertyInfo, attributes, options);
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // String rules
+    // -----------------------------------------------------------------
+
+    private void ApplyStringRules(
+        Expression<Func<T, string?>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            switch (attr)
+            {
+                case RequiredAttribute req when !options.IgnoreRequired:
+                    manager
+                        .NotBeNull()
+                        .NotBeEmpty();
+                    if (options.UseAnnotationErrorMessages && !string.IsNullOrEmpty(req.ErrorMessage))
+                    {
+                        // The rule config custom message applies to all rules in this For() block;
+                        // we set it via the config constructed above. Individual per-rule messages
+                        // are not supported by the engine — the last annotation message wins.
+                    }
+                    break;
+
+                case StringLengthAttribute sl:
+                    if (sl.MinimumLength > 0)
+                    {
+                        manager.HaveLengthBetween(sl.MinimumLength, sl.MaximumLength);
+                    }
+                    else
+                    {
+                        manager.HaveMaxLength(sl.MaximumLength);
+                    }
+                    break;
+
+                case MinLengthAttribute minLen:
+                    manager.HaveMinLength(minLen.Length);
+                    break;
+
+                case MaxLengthAttribute maxLen:
+                    manager.HaveMaxLength(maxLen.Length);
+                    break;
+
+                case EmailAddressAttribute:
+                    manager.BeEmail();
+                    break;
+
+                case UrlAttribute:
+                    manager.BeUrl();
+                    break;
+
+                case RegularExpressionAttribute regex:
+                    manager.Match(regex.Pattern);
+                    break;
+
+                case PhoneAttribute:
+                    // Common North-American phone pattern accepted by PhoneAttribute
+                    manager.Match(@"^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$");
+                    break;
+
+                case CreditCardAttribute:
+                    manager.BeCreditCard();
+                    break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // int rules
+    // -----------------------------------------------------------------
+
+    private void ApplyIntRules(
+        Expression<Func<T, int>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            if (attr is RangeAttribute range)
+            {
+                if (range.Minimum is int min && range.Maximum is int max)
+                {
+                    manager.BeInRange(min, max);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // int? rules
+    // -----------------------------------------------------------------
+
+    private void ApplyNullableIntRules(
+        Expression<Func<T, int?>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            switch (attr)
+            {
+                case RequiredAttribute when !options.IgnoreRequired:
+                    manager.NotBeNull();
+                    break;
+
+                case RangeAttribute range:
+                    if (range.Minimum is int min && range.Maximum is int max)
+                    {
+                        manager.BeInRange(min, max);
+                    }
+                    break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // long rules
+    // -----------------------------------------------------------------
+
+    private void ApplyLongRules(
+        Expression<Func<T, long>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            if (attr is RangeAttribute range)
+            {
+                if (range.Minimum is long min && range.Maximum is long max)
+                {
+                    manager.BeInRange(min, max);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // long? rules
+    // -----------------------------------------------------------------
+
+    private void ApplyNullableLongRules(
+        Expression<Func<T, long?>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            switch (attr)
+            {
+                case RequiredAttribute when !options.IgnoreRequired:
+                    manager.NotBeNull();
+                    break;
+
+                case RangeAttribute range:
+                    if (range.Minimum is long min && range.Maximum is long max)
+                    {
+                        manager.BeInRange(min, max);
+                    }
+                    break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // double rules
+    // -----------------------------------------------------------------
+
+    private void ApplyDoubleRules(
+        Expression<Func<T, double>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            if (attr is RangeAttribute range)
+            {
+                if (range.Minimum is double min && range.Maximum is double max)
+                {
+                    manager.BeInRange(min, max);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // double? rules
+    // -----------------------------------------------------------------
+
+    private void ApplyNullableDoubleRules(
+        Expression<Func<T, double?>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            switch (attr)
+            {
+                case RequiredAttribute when !options.IgnoreRequired:
+                    manager.NotBeNull();
+                    break;
+
+                case RangeAttribute range:
+                    if (range.Minimum is double min && range.Maximum is double max)
+                    {
+                        manager.BeInRange(min, max);
+                    }
+                    break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // decimal rules
+    // -----------------------------------------------------------------
+
+    private void ApplyDecimalRules(
+        Expression<Func<T, decimal>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            if (attr is RangeAttribute range)
+            {
+                // RangeAttribute stores min/max as object; cast to double then decimal.
+                if (range.Minimum is double minD && range.Maximum is double maxD)
+                {
+                    manager.BeInRange((decimal)minD, (decimal)maxD);
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // decimal? rules
+    // -----------------------------------------------------------------
+
+    private void ApplyNullableDecimalRules(
+        Expression<Func<T, decimal?>> lambda,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        var config = BuildRuleConfig(options, null);
+        var proxy = For(lambda, config);
+        var manager = proxy.Test();
+
+        foreach (var attr in attributes)
+        {
+            switch (attr)
+            {
+                case RequiredAttribute when !options.IgnoreRequired:
+                    manager.NotBeNull();
+                    break;
+
+                case RangeAttribute range:
+                    if (range.Minimum is double minD && range.Maximum is double maxD)
+                    {
+                        manager.BeInRange((decimal)minD, (decimal)maxD);
+                    }
+                    break;
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Unsupported types — Required only, using object proxy
+    // -----------------------------------------------------------------
+
+    private void ApplyRequiredOnlyRules(
+        PropertyInfo propertyInfo,
+        IReadOnlyList<ValidationAttribute> attributes,
+        AnnotationOptions options
+    )
+    {
+        if (options.IgnoreRequired)
+        {
+            return;
+        }
+
+        var hasRequired = attributes.OfType<RequiredAttribute>().Any();
+
+        if (!hasRequired)
+        {
+            return;
+        }
+
+        // Build Expression<Func<T, object?>> to use the generic For<TProp, TManager> overload.
+        var param = Expression.Parameter(typeof(T), "x");
+        var body = Expression.Convert(
+            Expression.Property(param, propertyInfo),
+            typeof(object)
+        );
+        var lambda = Expression.Lambda<Func<T, object?>>(body, param);
+
+        var config = BuildRuleConfig(options, null);
+        For<object?, ObjectOperationsManager>(lambda, config).Test().NotBeNull();
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static RuleConfig BuildRuleConfig(AnnotationOptions options, ValidationAttribute? attr)
+    {
+        string? customMessage = null;
+
+        if (options.UseAnnotationErrorMessages
+            && attr is not null
+            && !string.IsNullOrEmpty(attr.ErrorMessage))
+        {
+            customMessage = attr.ErrorMessage;
+        }
+
+        return new RuleConfig
+        {
+            Severity = options.DefaultSeverity,
+            ErrorCode = string.IsNullOrEmpty(options.ErrorCodePrefix) ? null : options.ErrorCodePrefix,
+            CustomMessage = customMessage
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal concrete blueprint produced by FromAnnotations()
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Auto-generated blueprint that includes only the rules derived from DataAnnotations attributes.
+/// Produced by <see cref="DataAnnotationsBlueprint{T}.FromAnnotations"/>.
+/// </summary>
+internal sealed class AutoDataAnnotationsBlueprint<T> : DataAnnotationsBlueprint<T>
+    where T : notnull
+{
+    internal AutoDataAnnotationsBlueprint(AnnotationOptions? options)
+    {
+        using (Define())
+        {
+            IncludeAnnotations(options);
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/DataAnnotationsExtensions.cs
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/DataAnnotationsExtensions.cs
@@ -1,0 +1,33 @@
+using JAAvila.FluentOperations.Contract;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace JAAvila.FluentOperations.DataAnnotations;
+
+/// <summary>
+/// Dependency injection extension methods for registering DataAnnotations-derived blueprints.
+/// </summary>
+public static class DataAnnotationsExtensions
+{
+    /// <summary>
+    /// Creates a <see cref="DataAnnotationsBlueprint{T}"/> whose rules are derived entirely
+    /// from the DataAnnotations attributes on <typeparamref name="T"/>, and registers it as
+    /// a singleton in the DI container.
+    /// </summary>
+    /// <typeparam name="T">The model type whose annotations are scanned.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="options">
+    /// Optional mapping options.  When <c>null</c>, <see cref="AnnotationOptions.Default"/> is used.
+    /// </param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDataAnnotationsBlueprint<T>(
+        this IServiceCollection services,
+        AnnotationOptions? options = null
+    )
+        where T : notnull
+    {
+        var blueprint = DataAnnotationsBlueprint<T>.FromAnnotations(options);
+        services.AddSingleton(blueprint);
+        services.AddSingleton<IBlueprintValidator>(blueprint);
+        return services;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/JAAvila.FluentOperations.DataAnnotations.csproj
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/JAAvila.FluentOperations.DataAnnotations.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PackageIcon>icon.png</PackageIcon>
+    <Authors>JAAvila</Authors>
+    <Description>DataAnnotations bridge for JAAvila.FluentOperations Quality Blueprints. Automatically generates Blueprint validation rules from System.ComponentModel.DataAnnotations attributes.</Description>
+    <PackageId>JAAvila.FluentOperations.DataAnnotations</PackageId>
+    <PackageTags>FluentOperations;DataAnnotations;Validation;Blueprint</PackageTags>
+    <PackageProjectUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Copyright>Copyright (C) $([System.DateTime]::Now.Year) JAAvila</Copyright>
+    <MinVerTagPrefix>annotations-</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JAAvila.FluentOperations\JAAvila.FluentOperations.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <Target Name="SetAssemblyVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/Distributed/JAAvila.FluentOperations.DataAnnotations/README.md
+++ b/Distributed/JAAvila.FluentOperations.DataAnnotations/README.md
@@ -1,0 +1,99 @@
+# JAAvila.FluentOperations.DataAnnotations
+
+Automatically generates [JAAvila.FluentOperations](https://github.com/JAAvila-Of/JAAvila.FluentOperations) Quality Blueprint validation rules from `System.ComponentModel.DataAnnotations` attributes.
+
+## Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.DataAnnotations
+```
+
+## Quick Start
+
+### Fully automatic blueprint
+
+```csharp
+var blueprint = DataAnnotationsBlueprint<User>.FromAnnotations();
+var report = blueprint.Check(user);
+
+if (!report.IsValid)
+{
+    foreach (var failure in report.Failures)
+        Console.WriteLine(failure);
+}
+```
+
+### Hybrid blueprint — annotations + custom rules
+
+```csharp
+public class UserBlueprint : DataAnnotationsBlueprint<User>
+{
+    public UserBlueprint()
+    {
+        using (Define())
+        {
+            // All [Required], [EmailAddress], etc. rules are generated automatically:
+            IncludeAnnotations();
+
+            // Add extra rules that have no DataAnnotation equivalent:
+            For(x => x.Username).Test().NotBeNull().HaveMinLength(3).HaveMaxLength(20);
+        }
+    }
+}
+```
+
+### Dependency Injection
+
+```csharp
+// Program.cs / Startup.cs
+services.AddDataAnnotationsBlueprint<User>();
+
+// Inject and use:
+public class UserService(DataAnnotationsBlueprint<User> blueprint)
+{
+    public void Validate(User user)
+    {
+        var report = blueprint.Check(user);
+        // ...
+    }
+}
+```
+
+## Attribute Mapping Table
+
+| DataAnnotations Attribute | Generated Operation |
+|---|---|
+| `[Required]` on `string` | `.NotBeNull().NotBeEmpty()` |
+| `[Required]` on other types | `.NotBeNull()` |
+| `[StringLength(max)]` | `.HaveMaxLength(max)` |
+| `[StringLength(max, MinimumLength = min)]` | `.HaveLengthBetween(min, max)` |
+| `[MinLength(n)]` | `.HaveMinLength(n)` |
+| `[MaxLength(n)]` | `.HaveMaxLength(n)` |
+| `[Range(min, max)]` | `.BeInRange(min, max)` |
+| `[EmailAddress]` | `.BeEmail()` |
+| `[Url]` | `.BeUrl()` |
+| `[RegularExpression(pattern)]` | `.Match(pattern)` |
+| `[Phone]` | `.Match(phoneRegex)` |
+| `[CreditCard]` | `.BeCreditCard()` |
+
+Supported property types for `[Range]`: `int`, `int?`, `long`, `long?`, `double`, `double?`, `decimal`, `decimal?`.
+
+## AnnotationOptions
+
+```csharp
+var options = new AnnotationOptions
+{
+    DefaultSeverity = Severity.Warning,          // Default: Severity.Error
+    ErrorCodePrefix = "USER",                    // Default: null (no error code)
+    IgnoreRequired = true,                       // Default: false
+    UseAnnotationErrorMessages = false,          // Default: true
+    ExcludedProperties = { "InternalId" },       // Default: empty
+    IncludeInheritedProperties = false           // Default: true
+};
+
+var blueprint = DataAnnotationsBlueprint<User>.FromAnnotations(options);
+```
+
+## License
+
+Apache-2.0

--- a/JAAvila.FluentOperations.sln
+++ b/JAAvila.FluentOperations.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Op
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Grpc", "Distributed\JAAvila.FluentOperations.Grpc\JAAvila.FluentOperations.Grpc.csproj", "{856C3FD8-F8C6-4399-9733-8D4089BA60AD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.DataAnnotations", "Distributed\JAAvila.FluentOperations.DataAnnotations\JAAvila.FluentOperations.DataAnnotations.csproj", "{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -124,6 +126,18 @@ Global
 		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x64.Build.0 = Release|Any CPU
 		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{856C3FD8-F8C6-4399-9733-8D4089BA60AD}.Release|x86.Build.0 = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x64.Build.0 = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -137,5 +151,6 @@ Global
 		{F110E7AD-E8D9-45CC-AB0D-763B61475D26} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{856C3FD8-F8C6-4399-9733-8D4089BA60AD} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
+		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
  Introduce JAAvila.FluentOperations.DataAnnotations, a new NuGet package
  that generates Blueprint validation rules from System.ComponentModel.
  DataAnnotations attributes, enabling incremental adoption in projects
  that already use DataAnnotations.

  Core mechanism:
  - DataAnnotationsBlueprint<T>: abstract base inheriting QualityBlueprint<T>
    with IncludeAnnotations() method callable within Define() scope
  - AnnotationMapper: reflects on model properties, builds Expression<Func<T, TProp>> dynamically via Expression.Lambda, dispatches to type-specific rule methods via MakeGenericMethod for correct For() overload resolution
  - AutoDataAnnotationsBlueprint<T>: FromAnnotations() factory that creates a complete blueprint from annotations alone

  Supported attributes:
  - [Required] → NotBeNull() + NotBeEmpty() (strings)
  - [EmailAddress] → BeEmail()
  - [Url] → BeUrl()
  - [StringLength] → HaveMaxLength() / HaveLengthBetween()
  - [MinLength] / [MaxLength] → HaveMinLength() / HaveMaxLength()
  - [Range] → BeInRange()
  - [RegularExpression] → Match()

  Configuration via AnnotationOptions: DefaultSeverity, ErrorCodePrefix,
  IgnoreRequired, UseAnnotationErrorMessages, ExcludedProperties.
  Hybrid blueprints supported (annotations + custom rules coexist).