### PR TITLE
Update README and docs for new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JAAvila.FluentOperations
 
-[![Tests](https://img.shields.io/badge/tests-6335%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-6528%2B%20passing-brightgreen)]()
 [![.NET](https://img.shields.io/badge/.NET-8.0-blue)](https://dotnet.microsoft.com)
 [![C#](https://img.shields.io/badge/C%23-13.0-blue)](https://docs.microsoft.com/dotnet/csharp/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
@@ -17,6 +17,9 @@ A fluent validation and testing library for .NET that unifies inline assertions 
 | `JAAvila.FluentOperations.MediatR` | MediatR pipeline behavior for request validation |
 | `JAAvila.FluentOperations.MinimalApi` | Minimal API endpoint filters for automatic validation |
 | `JAAvila.FluentOperations.Analyzers` | Roslyn analyzers for compile-time usage checks (FO001, FO003) |
+| `JAAvila.FluentOperations.OpenApi` | Swashbuckle schema filter that enriches OpenAPI schemas with blueprint constraints |
+| `JAAvila.FluentOperations.Grpc` | gRPC server interceptor for automatic request validation |
+| `JAAvila.FluentOperations.DataAnnotations` | DataAnnotations bridge — generate blueprint rules from attributes |
 
 ```bash
 dotnet add package JAAvila.FluentOperations
@@ -319,7 +322,131 @@ app.MapPost("/orders", (CreateOrderRequest request) => Results.Ok(request))
 // Returns RFC 7807 ValidationProblem on failure
 ```
 
+### gRPC
+
+```bash
+dotnet add package JAAvila.FluentOperations.Grpc
+```
+
+```csharp
+builder.Services.AddGrpcBlueprintValidation();
+builder.Services.AddGrpc(o => o.Interceptors.Add<GrpcBlueprintInterceptor>());
+builder.Services.AddBlueprints(typeof(Program).Assembly);
+```
+
+When validation fails, the interceptor throws an `RpcException` with `StatusCode.InvalidArgument` and per-property validation errors in gRPC trailers.
+
 See [Integration Guide](./docs/INTEGRATION.md) for full examples.
+
+## OpenAPI Schema Generation
+
+```bash
+dotnet add package JAAvila.FluentOperations.OpenApi
+```
+
+Automatically enrich Swashbuckle OpenAPI schemas with validation constraints derived from registered blueprints:
+
+```csharp
+builder.Services.AddSwaggerGen(options =>
+{
+    options.AddFluentOperationsValidation(
+        app.Services.GetRequiredService<IEnumerable<IBlueprintValidator>>());
+});
+```
+
+## JSON Schema Generation
+
+Generate a JSON Schema document or string directly from any blueprint — no additional package required:
+
+```csharp
+var blueprint = new UserBlueprint();
+
+// Returns JsonDocument
+JsonDocument schema = blueprint.ToJsonSchema();
+
+// Returns formatted JSON string
+string schemaJson = blueprint.ToJsonSchemaString();
+```
+
+## Validation Telemetry
+
+Emit metrics via `System.Diagnostics.Metrics` (OpenTelemetry-compatible, zero external dependencies):
+
+```csharp
+FluentOperationsConfig.Configure(c =>
+{
+    c.Telemetry.Enabled = true;
+    c.Telemetry.TrackBlueprintExecutionTime = true;
+    c.Telemetry.TrackRuleExecutionTime = true;
+    c.Telemetry.TrackFailureRates = true;
+});
+```
+
+| Instrument | Kind | Description |
+|------------|------|-------------|
+| `fo.rules.evaluated` | Counter | Total rules evaluated |
+| `fo.rules.failed` | Counter | Total rules that failed |
+| `fo.rule.duration` | Histogram (ms) | Duration of individual eager rule execution |
+| `fo.blueprint.duration` | Histogram (ms) | Duration of a full `Check()` / `CheckAsync()` call |
+
+Metrics are tagged with `blueprint`, `model`, `is_valid`, `passed`, and `severity` dimensions.
+
+## Snapshot Validation
+
+Compare `QualityReport` results against stored JSON snapshots for regression testing:
+
+```csharp
+var report = blueprint.Check(model);
+
+// First run: creates the snapshot file
+report.UpdateSnapshot("UserBlueprint_CreateUser");
+
+// Subsequent runs: assert the report matches the stored snapshot
+report.ShouldMatchSnapshot("UserBlueprint_CreateUser");
+```
+
+## DataAnnotations Bridge
+
+```bash
+dotnet add package JAAvila.FluentOperations.DataAnnotations
+```
+
+Generate blueprint rules automatically from `System.ComponentModel.DataAnnotations` attributes:
+
+```csharp
+// Auto-generate from annotations only
+var blueprint = DataAnnotationsBlueprint<User>.FromAnnotations();
+var report = blueprint.Check(user);
+
+// Or subclass to combine with custom rules
+public class UserBlueprint : DataAnnotationsBlueprint<User>
+{
+    public UserBlueprint()
+    {
+        using (Define())
+        {
+            IncludeAnnotations(); // maps [Required], [EmailAddress], [StringLength], [Range], etc.
+            For(x => x.Name).Test().NotBeEmpty(); // additional custom rules
+        }
+    }
+}
+```
+
+## Blueprint Introspection
+
+Inspect the rules registered in any blueprint at runtime:
+
+```csharp
+var blueprint = new UserBlueprint();
+IReadOnlyList<BlueprintRuleInfo> rules = blueprint.GetRuleDescriptors();
+
+foreach (var rule in rules)
+{
+    Console.WriteLine($"{rule.PropertyName}: {rule.OperationName} ({rule.Severity})");
+}
+```
+
+`BlueprintRuleInfo` exposes `PropertyName`, `OperationName`, `PropertyType`, `Parameters`, `Severity`, `ErrorCode`, and `Scenario`.
 
 ## Localization
 
@@ -361,15 +488,15 @@ FluentOperationsConfig.Configure(c =>
 ## Documentation
 
 - [API Reference](./docs/API.md) - Complete API documentation
-- [Integration Guide](./docs/INTEGRATION.md) - ASP.NET Core, MediatR, and Minimal API setup
+- [Integration Guide](./docs/INTEGRATION.md) - ASP.NET Core, MediatR, Minimal API, gRPC, and more
 - [Localization Guide](./docs/LOCALIZATION.md) - Configuring localized validation messages
 
 ## Project Stats
 
-- **6335+ tests** across NUnit test projects
+- **6528+ tests** across NUnit test projects
 - **730+ validators** covering 20+ data types
-- **37 operation managers** with fluent chaining
-- **6 NuGet packages** (core + 3 integrations + MinimalApi + Analyzers)
+- **37+ operation managers** with fluent chaining
+- **9 NuGet packages** (core + integrations + analyzers + tooling)
 - **Performance optimized** with lazy initialization, caching, and zero-allocation patterns
 
 ## License

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,6 +48,10 @@ Complete API documentation for JAAvila.FluentOperations.
   - [ForEachWhere](#foreachwhere)
 - [AssertionScope](#assertionscope)
 - [FluentOperationsConfig](#fluentoperationsconfig)
+- [Blueprint Introspection](#blueprint-introspection)
+- [JSON Schema Generation](#json-schema-generation)
+- [Snapshot Validation](#snapshot-validation)
+- [Validation Telemetry](#validation-telemetry)
 ---
 
 ## Test Extensions
@@ -1127,6 +1131,15 @@ public QualityReport Check(T instance, Type? activeScenario)
 // Asynchronous validation
 public Task<QualityReport> CheckAsync(T instance)
 public Task<QualityReport> CheckAsync(T instance, Type? activeScenario)
+
+// Assertion bridge — throw on failure (integrates with AssertionScope)
+public void Assert(T instance)
+public void Assert(T instance, Type? activeScenario)
+public Task AssertAsync(T instance)
+public Task AssertAsync(T instance, Type? activeScenario)
+
+// Introspection
+public IReadOnlyList<BlueprintRuleInfo> GetRuleDescriptors()
 ```
 
 ---
@@ -1149,6 +1162,12 @@ Methods:
 - `FailuresByProperty(string)` - Failures for specific property
 - `FailuresBySeverity(Severity)` - Failures at specific severity
 - `ToString()` - Formatted summary
+
+Extension methods (in `QualityReportExtensions`):
+- `ToErrorDictionary()` - Returns `IDictionary<string, string[]>` keyed by property name (Error failures only)
+
+Extension methods (in `QualityReportAspNetExtensions`, requires `AspNetCore` package):
+- `ToProblemDetails()` - Returns `ValidationProblemDetails` (RFC 7807) from Error failures
 
 ---
 
@@ -1393,6 +1412,124 @@ using (FluentOperationsConfig.Scope(options =>
     // Config applies only within this scope
 }
 ```
+
+---
+
+---
+
+## Blueprint Introspection
+
+`GetRuleDescriptors()` returns a read-only list of `BlueprintRuleInfo` records describing every rule registered in the blueprint (including rules inside `ForEach` definitions; `ForNested` delegates to the child blueprint's own call).
+
+```csharp
+var blueprint = new UserBlueprint();
+IReadOnlyList<BlueprintRuleInfo> rules = blueprint.GetRuleDescriptors();
+
+foreach (var rule in rules)
+    Console.WriteLine($"{rule.PropertyName}: {rule.OperationName} ({rule.Severity})");
+```
+
+### BlueprintRuleInfo
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `PropertyName` | `string` | Property name (collection rules use `"Items[]"` suffix) |
+| `OperationName` | `string` | Operation name, e.g. `"NotBeNull"`, `"BeEmail"` |
+| `PropertyType` | `Type` | CLR type of the subject |
+| `Parameters` | `IReadOnlyDictionary<string, object>` | Captured rule parameters |
+| `Severity` | `Severity` | Severity from `RuleConfig` (defaults to `Error`) |
+| `ErrorCode` | `string?` | Error code from `RuleConfig` |
+| `Scenario` | `Type?` | Scenario marker interface if rule is inside a `Scenario<T>()` block |
+
+The `IRuleDescriptor` interface (implemented by validators) is the source of `OperationName`, `SubjectType`, and `Parameters`. The introspection API is used internally by `BlueprintSchemaFilter` (OpenAPI package) and `JsonSchemaGenerator`.
+
+---
+
+## JSON Schema Generation
+
+Extension methods on `QualityBlueprint<T>` (no additional package required):
+
+```csharp
+// Returns JsonDocument — caller must dispose
+JsonDocument schema = blueprint.ToJsonSchema();
+
+// Returns indented JSON string
+string schemaJson = blueprint.ToJsonSchemaString();
+
+// With options
+string schemaJson = blueprint.ToJsonSchemaString(new JsonSchemaOptions
+{
+    Draft = JsonSchemaDraft.Draft07,
+    WriteIndented = true
+});
+```
+
+The generated schema is derived from the blueprint's rule descriptors. Only rule-expressible constraints are emitted (e.g., `minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`). Properties not covered by any rule are still included in the schema based on CLR reflection.
+
+---
+
+## Snapshot Validation
+
+Extension methods on `QualityReport` for regression testing:
+
+```csharp
+// First run — create the baseline snapshot file
+report.UpdateSnapshot("MyBlueprint_Scenario1");
+
+// Subsequent runs — assert the report matches the stored snapshot
+report.ShouldMatchSnapshot("MyBlueprint_Scenario1");
+
+// With options
+report.ShouldMatchSnapshot("MyBlueprint_Scenario1", new SnapshotOptions
+{
+    SnapshotDirectory = "__snapshots__", // relative to the calling test file (default)
+    UpdateMode = SnapshotUpdateMode.Manual // Manual | CreateOnly | AutoUpdate
+});
+```
+
+Snapshot files are stored as JSON in `__snapshots__/` (default) relative to the calling source file, using `[CallerFilePath]` for automatic path resolution.
+
+### SnapshotUpdateMode
+
+| Mode | Behavior when snapshot exists | Behavior when snapshot missing |
+|------|-------------------------------|-------------------------------|
+| `Manual` (default) | Compares and throws on mismatch | Throws with instructions to call `UpdateSnapshot()` |
+| `CreateOnly` | Compares and throws on mismatch | Creates snapshot file and passes |
+| `AutoUpdate` | Always overwrites and passes | Creates snapshot file and passes |
+
+---
+
+## Validation Telemetry
+
+Emit metrics via `System.Diagnostics.Metrics` (compatible with OpenTelemetry, `dotnet-counters`, and any `MeterListener`). Zero external dependencies.
+
+### Configuration
+
+```csharp
+FluentOperationsConfig.Configure(c =>
+{
+    c.Telemetry.Enabled = true;
+    c.Telemetry.TrackBlueprintExecutionTime = true; // fo.blueprint.duration histogram
+    c.Telemetry.TrackRuleExecutionTime = true;      // fo.rule.duration histogram
+    c.Telemetry.TrackFailureRates = true;           // fo.rules.failed counter
+});
+```
+
+### Instruments
+
+Meter name: `JAAvila.FluentOperations`
+
+| Instrument | Kind | Unit | Description |
+|------------|------|------|-------------|
+| `fo.rules.evaluated` | Counter | — | Total rules evaluated |
+| `fo.rules.failed` | Counter | — | Total rules that failed |
+| `fo.rule.duration` | Histogram | ms | Duration of individual eager rule execution |
+| `fo.blueprint.duration` | Histogram | ms | Duration of a full `Check()` / `CheckAsync()` call |
+
+### Dimensions
+
+Blueprint check metrics are tagged with: `blueprint` (type name), `model` (type name), `is_valid`.
+Eager rule metrics are tagged with: `passed`, `severity`.
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -9,6 +9,9 @@ Guide for integrating Quality Blueprints with ASP.NET Core and MediatR.
 - [ASP.NET Core Integration](#aspnet-core-integration)
 - [MediatR Integration](#mediatr-integration)
 - [Minimal API Integration](#minimal-api-integration)
+- [gRPC Integration](#grpc-integration)
+- [OpenAPI Integration](#openapi-integration)
+- [DataAnnotations Bridge](#dataannotations-bridge)
 - [Assembly Scanning](#assembly-scanning)
 - [AOT Compatibility](#aot-compatibility)
 - [Combined Example](#combined-example)
@@ -28,6 +31,9 @@ The library is split into focused packages with minimal dependencies:
 | `JAAvila.FluentOperations.MediatR` | MediatR 12.x (Apache 2.0) | Pipeline behavior for request validation |
 | `JAAvila.FluentOperations.MinimalApi` | Microsoft.AspNetCore.App (FrameworkReference) | Endpoint filter for Minimal APIs with RFC 7807 output |
 | `JAAvila.FluentOperations.Analyzers` | Microsoft.CodeAnalysis.CSharp 4.8.0 | Roslyn analyzers (compile-time, not runtime) |
+| `JAAvila.FluentOperations.OpenApi` | Swashbuckle.AspNetCore.SwaggerGen | Schema filter that enriches OpenAPI schemas from blueprints |
+| `JAAvila.FluentOperations.Grpc` | Grpc.Core.Api, Grpc.AspNetCore | Server interceptor for automatic gRPC request validation |
+| `JAAvila.FluentOperations.DataAnnotations` | (none — ships with core only) | Generate blueprint rules from DataAnnotations attributes |
 
 > **Note on MediatR version:** The MediatR package is pinned to `[12.4.1, 13.0.0)` because MediatR v13+ changed its license to RPL-1.5, which is incompatible with Apache 2.0.
 
@@ -299,6 +305,172 @@ When validation fails, the filter returns an RFC 7807 `ValidationProblem` respon
 | Error    | Yes            | Yes                  |
 | Warning  | No             | No                   |
 | Info     | No             | No                   |
+
+---
+
+## gRPC Integration
+
+### Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.Grpc
+```
+
+### Setup
+
+```csharp
+using JAAvila.FluentOperations.Integration;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Register blueprints (any approach — individual or assembly scanning)
+builder.Services.AddBlueprints(typeof(Program).Assembly);
+
+// Register the interceptor
+builder.Services.AddGrpcBlueprintValidation();
+
+// Add the interceptor to the gRPC pipeline
+builder.Services.AddGrpc(o =>
+{
+    o.Interceptors.Add<GrpcBlueprintInterceptor>();
+});
+```
+
+### Options
+
+Configure status code and trailer behavior:
+
+```csharp
+builder.Services.AddGrpcBlueprintValidation(options =>
+{
+    options.FailureStatusCode = StatusCode.InvalidArgument; // default
+    options.IncludeReportInTrailers = true; // include full JSON error map as binary trailer
+    options.StreamValidation = StreamValidationMode.ValidateFirst; // or Skip
+});
+```
+
+### Error Format
+
+When validation fails the interceptor throws an `RpcException` with:
+- `Status.Detail`: `"Validation failed with N error(s)."`
+- Metadata entries: one entry per error, keyed as `validation-error-{propertyname}` (lowercase)
+- Optional binary trailer `validation-errors-bin`: full JSON-serialized error dictionary (when `IncludeReportInTrailers = true`)
+
+### Streaming Support
+
+The interceptor validates each message in client-streaming and duplex-streaming RPCs using `ValidatingStreamReader<T>`. Behavior is controlled by `StreamValidationMode`:
+
+| Mode | Behavior |
+|------|----------|
+| `ValidateFirst` | Validates the first message before forwarding the stream |
+| `ValidateAll` | Validates every message in the stream |
+| `Skip` | Passes streams through without validation |
+
+---
+
+## OpenAPI Integration
+
+### Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.OpenApi
+```
+
+### Setup
+
+```csharp
+using JAAvila.FluentOperations.OpenApi;
+
+builder.Services.AddSwaggerGen(options =>
+{
+    // Resolve all registered IBlueprintValidator instances and pass them to the schema filter
+    options.AddFluentOperationsValidation(
+        app.Services.GetRequiredService<IEnumerable<IBlueprintValidator>>());
+});
+```
+
+The `BlueprintSchemaFilter` calls `GetRuleDescriptors()` on each blueprint and maps the resulting `BlueprintRuleInfo` records to OpenAPI schema constraints (e.g., `minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`).
+
+### Constraints Mapped
+
+| Blueprint Rule | OpenAPI Constraint |
+|----------------|--------------------|
+| `HaveMinLength(n)` | `minLength: n` |
+| `HaveMaxLength(n)` | `maxLength: n` |
+| `HaveLengthBetween(min, max)` | `minLength` + `maxLength` |
+| `Match(pattern)` | `pattern` |
+| `BeEmail()` | `format: email` |
+| `BeUrl()` | `format: uri` |
+| `BeGreaterThan(n)` / `BeGreaterThanOrEqualTo(n)` | `exclusiveMinimum` / `minimum` |
+| `BeLessThan(n)` / `BeLessThanOrEqualTo(n)` | `exclusiveMaximum` / `maximum` |
+| `BeInRange(min, max)` | `minimum` + `maximum` |
+| `NotBeNull()` | marks property as `required` |
+
+---
+
+## DataAnnotations Bridge
+
+### Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.DataAnnotations
+```
+
+### Quick Start — Annotation-only Blueprint
+
+```csharp
+using JAAvila.FluentOperations.DataAnnotations;
+
+// Create a blueprint entirely from DataAnnotations on the model class
+var blueprint = DataAnnotationsBlueprint<User>.FromAnnotations();
+var report = blueprint.Check(userModel);
+```
+
+### Subclassing — Mix Annotations with Custom Rules
+
+```csharp
+public class UserBlueprint : DataAnnotationsBlueprint<User>
+{
+    public UserBlueprint()
+    {
+        using (Define())
+        {
+            IncludeAnnotations(); // translate [Required], [EmailAddress], [StringLength], [Range], etc.
+
+            // Additional rules not expressible via attributes:
+            For(x => x.Name).Test().NotBeNullOrWhiteSpace();
+        }
+    }
+}
+```
+
+### Supported Attributes
+
+| Attribute | Blueprint Rule Generated |
+|-----------|--------------------------|
+| `[Required]` | `NotBeNull()` (+ `NotBeEmpty()` for strings) |
+| `[EmailAddress]` | `BeEmail()` |
+| `[Url]` | `BeUrl()` |
+| `[Phone]` | `Match(phonePattern)` |
+| `[CreditCard]` | `BeCreditCard()` |
+| `[StringLength(max)]` | `HaveMaxLength(max)` |
+| `[StringLength(max, MinimumLength = min)]` | `HaveLengthBetween(min, max)` |
+| `[MinLength(n)]` | `HaveMinLength(n)` |
+| `[MaxLength(n)]` | `HaveMaxLength(n)` |
+| `[RegularExpression(pattern)]` | `Match(pattern)` |
+| `[Range(min, max)]` | `BeInRange(min, max)` |
+
+### AnnotationOptions
+
+```csharp
+DataAnnotationsBlueprint<User>.FromAnnotations(new AnnotationOptions
+{
+    IgnoreRequired = false,              // default: translate [Required]
+    UseAnnotationErrorMessages = true,   // use attribute ErrorMessage as CustomMessage
+    DefaultSeverity = Severity.Error,    // default: Error
+    ErrorCodePrefix = "DA"               // prefix for all generated error codes
+});
+```
 
 ---
 


### PR DESCRIPTION
  Bring all documentation up to date with the 9 NuGet packages and
  features implemented across Phase 1, Phase 2, and Phase 3.

  README.md:
  - Badge updated to 6528+ tests, 9 NuGet packages
  - Added OpenApi, Grpc, DataAnnotations to packages table
  - Added sections: OpenAPI Schema Generation, JSON Schema Generation, Validation Telemetry, Snapshot Validation, DataAnnotations Bridge, Blueprint Introspection, gRPC integration

  docs/INTEGRATION.md:
  - Package architecture table expanded to 9 packages
  - Added gRPC Integration section with streaming modes and error format
  - Added OpenAPI Integration section with constraints mapping table
  - Added DataAnnotations Bridge section with supported attributes

  docs/API.md:
  - Added Assert/AssertAsync, GetRuleDescriptors, ToErrorDictionary, ToProblemDetails to public methods reference
  - Added Blueprint Introspection section with BlueprintRuleInfo
  - Added JSON Schema Generation section with ToJsonSchema API
  - Added Snapshot Validation section with ShouldMatchSnapshot API
  - Added Validation Telemetry section with instruments and dimensions