### PR TITLE
Add NOTICE, TRADEMARK, and CONTRIBUTING files for author protection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to JAAvila.FluentOperations
+
+Thank you for your interest in contributing to JAAvila.FluentOperations. This document outlines the guidelines and expectations for contributors.
+
+## Code of Ethics
+
+### For Contributors
+
+By contributing to this project, you agree to:
+
+1. **Respect the original work.** This project represents years of design and engineering effort. Contributions should enhance, not replace or undermine, the existing architecture.
+
+2. **Attribute properly.** If your contribution is inspired by or derived from another project, library, or resource, clearly state the source in your pull request description.
+
+3. **Act in good faith.** Do not submit contributions with the intent of introducing vulnerabilities, backdoors, or code that degrades the project's quality or security.
+
+4. **Maintain compatibility.** Follow the established architectural patterns (6 Pilares, ExecutionEngine pattern, one-validator-per-operation). Contributions that break these patterns without prior discussion will not be accepted.
+
+5. **Respect the license.** All contributions are submitted under the Apache License 2.0. You must have the legal right to submit the code.
+
+### For Fork Authors
+
+If you fork this project, we ask that you:
+
+1. **Choose a distinct name** for your fork. See [TRADEMARK.md](TRADEMARK.md) for naming guidelines.
+
+2. **Include attribution** as described in the [NOTICE](NOTICE) file. This is not a request — it is required by Section 4(d) of the Apache License 2.0.
+
+3. **Do not misrepresent** your fork as the official project or imply endorsement by the original author.
+
+4. **Consider contributing back.** If you fix a bug or add a feature that would benefit the community, consider submitting a pull request to the upstream project instead of maintaining a permanent fork.
+
+### For Commercial Users
+
+This project is free for commercial use under Apache 2.0. We ask that commercial users:
+
+1. **Comply with the NOTICE file** requirements when distributing the software.
+2. **Consider supporting the project** through contributions, bug reports, or public acknowledgment.
+3. **Do not rebrand and sell** the project as your own product. The code is free; the brand is not.
+
+## Contributor License Agreement (CLA)
+
+By submitting a pull request, you represent that:
+
+- You have the right to license the contribution under the Apache License 2.0.
+- Your contribution does not violate any third-party intellectual property rights.
+- You grant the project maintainer (JAAvila) a perpetual, worldwide, non-exclusive, royalty-free license to use, modify, and distribute your contribution as part of the project.
+- The project maintainer retains the right to relicense the project (including your contribution) under a different license in the future, provided the Apache 2.0 license for existing versions remains in effect.
+
+## How to Contribute
+
+### Reporting Issues
+
+- Use the [GitHub Issues](https://github.com/JAAvila-Of/JAAvila.FluentOperations/issues) tracker.
+- Include: .NET version, FluentOperations version, minimal reproduction code, expected vs actual behavior.
+
+### Submitting Pull Requests
+
+1. Fork the repository and create a feature branch.
+2. Follow the coding patterns documented in [CLAUDE.md](CLAUDE.md).
+3. Ensure all 6 Pilares are covered for new operations/validators.
+4. Every new validator MUST implement both `IValidator` and `IRuleDescriptor`.
+5. Run the full test suite: `dotnet test JAAvila.FluentOperations.Testing/JAAvila.FluentOperations.Testing.slnx`
+6. Update documentation (`README.md`, `docs/API.md`) as applicable.
+7. Use conventional commit messages in English.
+
+### What We Accept
+
+- Bug fixes with regression tests.
+- New validators/operations following the established patterns.
+- Improvements to error messages or formatting.
+- Documentation improvements.
+- Performance optimizations with benchmarks.
+- Localization translations (`.resx` files).
+
+### What We Do Not Accept
+
+- Changes that break backward compatibility without prior discussion.
+- Features that contradict the [Anti-Features](competitive_features_roadmap.md#7-anti-features-what-not-to-build) list.
+- Code without tests.
+- Pull requests that rename or rebrand the project.
+
+## Recognition
+
+All contributors are recognized in the project. Significant contributions will be acknowledged in release notes and the project's documentation.
+
+---
+
+*By contributing to this project, you agree to abide by this document and the project's [Apache License 2.0](LICENSE), [NOTICE](NOTICE), and [TRADEMARK](TRADEMARK.md) policies.*

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,80 @@
+JAAvila.FluentOperations
+Copyright 2025-2026 JAAvila (Jose Angel Avila)
+https://github.com/JAAvila-Of/JAAvila.FluentOperations
+
+This product includes software developed by JAAvila (Jose Angel Avila).
+
+===============================================================================
+
+ATTRIBUTION REQUIREMENTS
+
+This software is licensed under the Apache License, Version 2.0.
+As required by Section 4(d) of the Apache License, any Derivative Works
+that you distribute MUST include a readable copy of this NOTICE file.
+
+If you redistribute this software or derivative works thereof, you must:
+
+  1. Retain this NOTICE file in its entirety in the Source form of any
+     Derivative Works you distribute.
+
+  2. Include the following attribution in any documentation, README, or
+     "About" section of your Derivative Work:
+
+       "Based on JAAvila.FluentOperations, originally created by JAAvila
+       (Jose Angel Avila). https://github.com/JAAvila-Of/JAAvila.FluentOperations"
+
+  3. If your Derivative Work includes a user-visible "About", "Credits",
+     or "Acknowledgments" section, include the attribution above.
+
+===============================================================================
+
+TRADEMARK NOTICE
+
+"JAAvila", "JAAvila.FluentOperations", "FluentOperations", "Quality Blueprint",
+and "QualityBlueprint" are trademarks of Jose Angel Avila.
+
+The Apache License, Version 2.0 (Section 6) does NOT grant permission to use
+the trade names, trademarks, service marks, or product names of the Licensor,
+except as required for describing the origin of the Work and reproducing the
+content of this NOTICE file.
+
+Specifically, Derivative Works (forks) MAY NOT:
+
+  - Use "JAAvila.FluentOperations" or "JAAvila" as the product name,
+    package name, NuGet package ID, or any identifier that could cause
+    confusion with the original project.
+
+  - Use the names "FluentOperations" or "Quality Blueprint" as the primary
+    name of a Derivative Work without clearly distinguishing it from the
+    original (e.g., "MyProject powered by FluentOperations" is acceptable;
+    "FluentOperations v2" is not).
+
+  - Use the project's icon, logo, or visual branding in any way that
+    implies endorsement by or affiliation with the original author.
+
+Derivative Works MUST:
+
+  - Choose a distinct name that does not create confusion with the original
+    project.
+
+  - Clearly state that the Derivative Work is not the official
+    JAAvila.FluentOperations project.
+
+If you have questions about permitted use of these marks, contact the
+original author via the project's GitHub repository.
+
+===============================================================================
+
+THIRD-PARTY NOTICES
+
+This software depends on the following third-party libraries:
+
+  - JAAvila.SafeTypes (Apache-2.0) — Copyright JAAvila
+  - JetBrains.Annotations (MIT) — Copyright JetBrains s.r.o.
+  - MinVer (Apache-2.0) — Copyright Adam Ralph
+  - MediatR (Apache-2.0) — Copyright Jimmy Bogard
+  - Swashbuckle.AspNetCore (MIT) — Copyright Richard Morris
+  - Grpc.AspNetCore.Server (Apache-2.0) — Copyright The gRPC Authors
+  - System.ComponentModel.Annotations (MIT) — Copyright .NET Foundation
+
+Each library is subject to its own license terms.

--- a/README.md
+++ b/README.md
@@ -487,9 +487,11 @@ FluentOperationsConfig.Configure(c =>
 
 ## Documentation
 
-- [API Reference](./docs/API.md) - Complete API documentation
-- [Integration Guide](./docs/INTEGRATION.md) - ASP.NET Core, MediatR, Minimal API, gRPC, and more
-- [Localization Guide](./docs/LOCALIZATION.md) - Configuring localized validation messages
+- [API Reference](./docs/API.md) — Complete API documentation
+- [Integration Guide](./docs/INTEGRATION.md) — ASP.NET Core, MediatR, Minimal API, gRPC, and more
+- [Localization Guide](./docs/LOCALIZATION.md) — Configuring localized validation messages
+- [Contributing](./CONTRIBUTING.md) — How to contribute, code of ethics, CLA
+- [Trademark Policy](./TRADEMARK.md) — Naming guidelines for forks and derivative works
 
 ## Project Stats
 
@@ -501,8 +503,10 @@ FluentOperationsConfig.Configure(c =>
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 — see the [LICENSE](LICENSE) file for details.
+
+The names "JAAvila.FluentOperations", "FluentOperations", and "Quality Blueprint" are trademarks of Jose Angel Avila. See the [NOTICE](NOTICE) file and [TRADEMARK.md](TRADEMARK.md) for attribution requirements and naming restrictions for derivative works.
 
 ## Author
 
-Built by JAAvila
+Created and maintained by **JAAvila (Jose Angel Avila)**

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,70 @@
+# Trademark Policy
+
+## Protected Marks
+
+The following names and marks are trademarks of Jose Angel Avila ("JAAvila"):
+
+- **JAAvila.FluentOperations**
+- **FluentOperations** (in the context of .NET validation libraries)
+- **Quality Blueprint** / **QualityBlueprint**
+- The JAAvila.FluentOperations logo and icon
+
+## Permitted Uses
+
+You **MAY** use these marks to:
+
+- Refer to the original project by name in documentation, articles, talks, or comparisons (e.g., "compatible with JAAvila.FluentOperations").
+- Describe the origin of a Derivative Work (e.g., "forked from JAAvila.FluentOperations").
+- Use the package names in `PackageReference` elements when consuming the official NuGet packages.
+
+## Restricted Uses
+
+You **MAY NOT** use these marks to:
+
+- Name a fork, Derivative Work, or competing product in a way that could cause confusion with the original (e.g., naming your fork "JAAvila.FluentOperations" or "FluentOperations 2.0").
+- Publish NuGet packages using identifiers that start with "JAAvila.FluentOperations" unless you are the original author or have explicit written permission.
+- Create a website, social media account, or organization name using "JAAvila.FluentOperations" or "FluentOperations" as the primary identifier.
+- Use the project's icon or logo in your own project's branding.
+- Imply endorsement, sponsorship, or affiliation with the original author or project.
+
+## Naming Guidelines for Forks and Derivative Works
+
+If you create a fork or Derivative Work, you must:
+
+1. **Choose a distinct name** that clearly differentiates your project from the original. Examples of acceptable names:
+   - `MyCompany.ValidationLib` (based on FluentOperations)
+   - `SuperValidator` — powered by FluentOperations
+   - `AcmeValidation` (originally forked from JAAvila.FluentOperations)
+
+2. **Include attribution** as described in the [NOTICE](NOTICE) file.
+
+3. **Do not** use names like:
+   - `FluentOperations` (standalone)
+   - `FluentOperations-Extended`
+   - `JAAvila.FluentOperations.Community`
+   - `FluentOps` (too similar, creates confusion)
+
+## Rationale
+
+This policy exists to:
+
+- Protect users from confusion about which project is the official, maintained version.
+- Ensure the original author receives proper credit for the work.
+- Prevent fragmentation of the ecosystem under similar names.
+- Allow the community to freely fork and modify the code (as guaranteed by Apache 2.0) while maintaining clarity about project identity.
+
+## Enforcement
+
+Trademark rights exist independently of the Apache 2.0 license. The Apache License (Section 6) explicitly states that it does not grant permission to use the Licensor's trademarks. Violations of this trademark policy may result in:
+
+- A request to rename the project or package.
+- A takedown request to NuGet.org or other package registries.
+- Legal action if necessary to protect the marks.
+
+## Contact
+
+For questions about trademark usage, licensing, or permission requests, please open an issue on the [official GitHub repository](https://github.com/JAAvila-Of/JAAvila.FluentOperations) or contact the author directly.
+
+---
+
+*This trademark policy is supplementary to the [Apache License 2.0](LICENSE) and the [NOTICE](NOTICE) file. It does not modify the terms of the Apache License.*


### PR DESCRIPTION
  Establish legal and ethical protections for the project while
  maintaining the Apache 2.0 open source license.

  NOTICE (required by Apache 2.0 Section 4d):
  - Copyright attribution with full author name
  - Explicit attribution requirements for derivative works
  - Trademark notice for JAAvila.FluentOperations, FluentOperations, and Quality Blueprint names
  - Naming restrictions for forks (must choose a distinct name)
  - Third-party dependency notices with licenses

  TRADEMARK.md:
  - Permitted and restricted uses of project names and marks
  - Naming guidelines for forks with acceptable/unacceptable examples
  - Enforcement mechanisms (rename requests, NuGet takedowns)
  - Rationale for trademark policy alongside Apache 2.0

  CONTRIBUTING.md:
  - Code of ethics for contributors, fork authors, and commercial users
  - Implicit CLA granting perpetual license on submitted contributions
  - Guidelines for pull requests following established patterns
  - What the project accepts and does not accept

  README.md:
  - License section updated with trademark notice and links to NOTICE and TRADEMARK.md
  - Documentation links updated with CONTRIBUTING.md and TRADEMARK.md
  - Author section updated with full name