### PR TITLE
Add HaveScaledPrecision for decimal, double, and float types

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Common/MessageKeys.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/MessageKeys.cs
@@ -242,6 +242,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "Decimal.BeRoundedTo";
         public const string BeZero = "Decimal.BeZero";
         public const string HavePrecision = "Decimal.HavePrecision";
+        public const string HaveScaledPrecision = "Decimal.HaveScaledPrecision";
         public const string NotBe = "Decimal.NotBe";
         public const string NotBeInRange = "Decimal.NotBeInRange";
         public const string NotBeOneOf = "Decimal.NotBeOneOf";
@@ -284,6 +285,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "Double.BeRoundedTo";
         public const string BeZero = "Double.BeZero";
         public const string HavePrecision = "Double.HavePrecision";
+        public const string HaveScaledPrecision = "Double.HaveScaledPrecision";
         public const string NotBe = "Double.NotBe";
         public const string NotBeInRange = "Double.NotBeInRange";
         public const string NotBeNaN = "Double.NotBeNaN";
@@ -323,6 +325,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "Float.BeRoundedTo";
         public const string BeZero = "Float.BeZero";
         public const string HavePrecision = "Float.HavePrecision";
+        public const string HaveScaledPrecision = "Float.HaveScaledPrecision";
         public const string NotBe = "Float.NotBe";
         public const string NotBeInRange = "Float.NotBeInRange";
         public const string NotBeNaN = "Float.NotBeNaN";
@@ -534,6 +537,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "NullableDecimal.BeRoundedTo";
         public const string BeZero = "NullableDecimal.BeZero";
         public const string HavePrecision = "NullableDecimal.HavePrecision";
+        public const string HaveScaledPrecision = "NullableDecimal.HaveScaledPrecision";
         public const string HaveValue = "NullableDecimal.HaveValue";
         public const string NotBe = "NullableDecimal.NotBe";
         public const string NotBeInRange = "NullableDecimal.NotBeInRange";
@@ -562,6 +566,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "NullableDouble.BeRoundedTo";
         public const string BeZero = "NullableDouble.BeZero";
         public const string HavePrecision = "NullableDouble.HavePrecision";
+        public const string HaveScaledPrecision = "NullableDouble.HaveScaledPrecision";
         public const string HaveValue = "NullableDouble.HaveValue";
         public const string NotBe = "NullableDouble.NotBe";
         public const string NotBeInRange = "NullableDouble.NotBeInRange";
@@ -605,6 +610,7 @@ public static class MessageKeys
         public const string BeRoundedTo = "NullableFloat.BeRoundedTo";
         public const string BeZero = "NullableFloat.BeZero";
         public const string HavePrecision = "NullableFloat.HavePrecision";
+        public const string HaveScaledPrecision = "NullableFloat.HaveScaledPrecision";
         public const string HaveValue = "NullableFloat.HaveValue";
         public const string NotBe = "NullableFloat.NotBe";
         public const string NotBeInRange = "NullableFloat.NotBeInRange";

--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -855,6 +855,9 @@ public struct Operations
         [EnumStringValue("haveprecision")]
         HavePrecision,
 
+        [EnumStringValue("havescaledprecision")]
+        HaveScaledPrecision,
+
         [EnumStringValue("beroundedto")]
         BeRoundedTo,
 
@@ -911,6 +914,9 @@ public struct Operations
 
         [EnumStringValue("haveprecision")]
         HavePrecision,
+
+        [EnumStringValue("havescaledprecision")]
+        HaveScaledPrecision,
 
         [EnumStringValue("beroundedto")]
         BeRoundedTo,
@@ -983,6 +989,9 @@ public struct Operations
 
         [EnumStringValue("haveprecision")]
         HavePrecision,
+
+        [EnumStringValue("havescaledprecision")]
+        HaveScaledPrecision,
 
         [EnumStringValue("beroundedto")]
         BeRoundedTo,

--- a/Distributed/JAAvila.FluentOperations/Manager/DecimalOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DecimalOperationsManager.cs
@@ -537,6 +537,79 @@ public class DecimalOperationsManager : ITestManager<DecimalOperationsManager, d
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="expectedDecimals"/> is negative,
+    /// <paramref name="maxTotalDigits"/> is less than 1, or
+    /// <paramref name="expectedDecimals"/> exceeds <paramref name="maxTotalDigits"/>.
+    /// </remarks>
+    public DecimalOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Decimal.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DecimalOperationsManager, decimal>
+            .New(this)
+            .WithOperation(
+                DecimalHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedDecimals,
+                            maxTotalDigits
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to at most <paramref name="decimals"/> decimal places.
     /// </summary>
     /// <param name="decimals">The maximum number of decimal places allowed.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/DoubleOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/DoubleOperationsManager.cs
@@ -710,6 +710,89 @@ public class DoubleOperationsManager : ITestManager<DoubleOperationsManager, dou
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="expectedDecimals"/> is negative,
+    /// <paramref name="maxTotalDigits"/> is less than 1, or
+    /// <paramref name="expectedDecimals"/> exceeds <paramref name="maxTotalDigits"/>.
+    /// </remarks>
+    public DoubleOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Double.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<DoubleOperationsManager, double>
+            .New(this)
+            .WithOperation(
+                DoubleHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expectedDecimals),
+                            BaseFormatter.Format(maxTotalDigits)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        double.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to at most <paramref name="decimals"/> decimal places.
     /// </summary>
     /// <param name="decimals">The maximum number of decimal places allowed.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/FloatOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/FloatOperationsManager.cs
@@ -710,6 +710,89 @@ public class FloatOperationsManager : ITestManager<FloatOperationsManager, float
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if <paramref name="expectedDecimals"/> is negative,
+    /// <paramref name="maxTotalDigits"/> is less than 1, or
+    /// <paramref name="expectedDecimals"/> exceeds <paramref name="maxTotalDigits"/>.
+    /// </remarks>
+    public FloatOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Float.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<FloatOperationsManager, float>
+            .New(this)
+            .WithOperation(
+                FloatHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            BaseFormatter.Format(expectedDecimals),
+                            BaseFormatter.Format(maxTotalDigits)
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        float.IsNaN(manager.PrincipalChain.GetValue()),
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to at most <paramref name="decimals"/> decimal places.
     /// </summary>
     /// <param name="decimals">The maximum number of decimal places allowed.</param>

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDecimalOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDecimalOperationsManager.cs
@@ -732,6 +732,81 @@ public class NullableDecimalOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard — use <c>NotBeNull</c> first to cover that scenario).
+    /// </remarks>
+    public NullableDecimalOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Decimal.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDecimalOperationsManager, decimal?>
+            .New(this)
+            .WithOperation(
+                NullableDecimalHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to <paramref name="decimals"/> decimal places
     /// (i.e. has at most that many significant decimal digits).
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableDoubleOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableDoubleOperationsManager.cs
@@ -844,6 +844,92 @@ public class NullableDoubleOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard — use <c>NotBeNull</c> first to cover that scenario).
+    /// </remarks>
+    public NullableDoubleOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Double.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableDoubleOperationsManager, double?>
+            .New(this)
+            .WithOperation(
+                NullableDoubleHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && double.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to <paramref name="decimals"/> decimal places
     /// (i.e. has at most that many significant decimal digits).
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/Manager/NullableFloatOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/NullableFloatOperationsManager.cs
@@ -834,6 +834,92 @@ public class NullableFloatOperationsManager
     }
 
     /// <summary>
+    /// Asserts that the value has at most <paramref name="expectedDecimals"/> decimal places
+    /// and at most <paramref name="maxTotalDigits"/> total significant digits.
+    /// </summary>
+    /// <param name="expectedDecimals">The maximum number of decimal places allowed.</param>
+    /// <param name="maxTotalDigits">The maximum number of total significant digits allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    /// <remarks>
+    /// Throws immediately if the value is <c>null</c> (null guard — use <c>NotBeNull</c> first to cover that scenario).
+    /// </remarks>
+    public NullableFloatOperationsManager HaveScaledPrecision(
+        int expectedDecimals,
+        int maxTotalDigits,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Float.HaveScaledPrecision))
+        {
+            return this;
+        }
+
+        ExecutionEngine<NullableFloatOperationsManager, float?>
+            .New(this)
+            .WithOperation(
+                NullableFloatHaveScaledPrecisionValidator.New(PrincipalChain, expectedDecimals, maxTotalDigits)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the resulting value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                manager =>
+                    (
+                        manager.PrincipalChain.GetValue() is not null
+                            && float.IsNaN(manager.PrincipalChain.GetValue()!.Value),
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the value was NaN. "
+                            + $"Use {nameof(BeNaN)} or {nameof(NotBeNaN)} to validate NaN values."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals < 0,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot be negative."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        maxTotalDigits < 1,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the total number of digits must be at least 1."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedDecimals > maxTotalDigits,
+                        Fail.New(
+                            $"The {nameof(HaveScaledPrecision)} operation failed because the number of decimal places cannot exceed the total number of digits."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
     /// Asserts that the value is rounded to <paramref name="decimals"/> decimal places
     /// (i.e. has at most that many significant decimal digits).
     /// </summary>

--- a/Distributed/JAAvila.FluentOperations/Validators/DecimalHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DecimalHaveScaledPrecisionValidator.cs
@@ -1,0 +1,62 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the decimal value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class DecimalHaveScaledPrecisionValidator(
+    PrincipalChain<decimal> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static DecimalHaveScaledPrecisionValidator New(
+        PrincipalChain<decimal> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "Decimal.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(decimal);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+        var bits = decimal.GetBits(value);
+        var scale = (bits[3] >> 16) & 0x7F;
+
+        if (scale > expectedDecimals)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but {1} decimal places were found.";
+            return false;
+        }
+
+        var absValue = Math.Abs(value);
+        var integerPart = decimal.Truncate(absValue);
+        var integerDigits = integerPart == 0m ? 1 : (int)Math.Floor(Math.Log10((double)integerPart)) + 1;
+        var totalDigits = integerDigits + scale;
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but {1} total digits were found.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/DoubleHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/DoubleHaveScaledPrecisionValidator.cs
@@ -1,0 +1,70 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the double value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class DoubleHaveScaledPrecisionValidator(
+    PrincipalChain<double> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static DoubleHaveScaledPrecisionValidator New(
+        PrincipalChain<double> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "Double.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(double);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        // Scale check: ensure value rounds cleanly to expectedDecimals places
+        var rounded = Math.Round(value, expectedDecimals);
+        if (Math.Abs(rounded - value) >= double.Epsilon)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but more decimal places were found.";
+            return false;
+        }
+
+        // Total digits check: count integer digits + decimal places
+        var absValue = Math.Abs(value);
+        var integerPart = Math.Truncate(absValue);
+        var integerDigits = integerPart == 0.0 ? 1 : (int)Math.Floor(Math.Log10(integerPart)) + 1;
+        var actualScale = (int)Math.Round(
+            -Math.Log10(Math.Abs(value - Math.Truncate(value)) + double.Epsilon)
+        );
+        // Use the string representation to reliably count decimal places
+        var strValue = value.ToString("G17");
+        var dotIndex = strValue.IndexOf('.');
+        var actualDecimals = dotIndex < 0 ? 0 : strValue.Length - dotIndex - 1;
+        var totalDigits = integerDigits + Math.Min(actualDecimals, expectedDecimals);
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but {1} total digits were found.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/FloatHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/FloatHaveScaledPrecisionValidator.cs
@@ -1,0 +1,66 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the float value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class FloatHaveScaledPrecisionValidator(
+    PrincipalChain<float> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static FloatHaveScaledPrecisionValidator New(
+        PrincipalChain<float> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "Float.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(float);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue();
+
+        // Scale check: ensure value rounds cleanly to expectedDecimals places
+        var rounded = (float)Math.Round(value, expectedDecimals);
+        if (Math.Abs(rounded - value) >= float.Epsilon)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but more decimal places were found.";
+            return false;
+        }
+
+        // Total digits check using string representation for reliability
+        var absValue = Math.Abs(value);
+        var integerPart = (float)Math.Truncate(absValue);
+        var integerDigits = integerPart == 0f ? 1 : (int)Math.Floor(Math.Log10(integerPart)) + 1;
+        var strValue = value.ToString("G9");
+        var dotIndex = strValue.IndexOf('.');
+        var actualDecimals = dotIndex < 0 ? 0 : strValue.Length - dotIndex - 1;
+        var totalDigits = integerDigits + Math.Min(actualDecimals, expectedDecimals);
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but {1} total digits were found.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDecimalHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDecimalHaveScaledPrecisionValidator.cs
@@ -1,0 +1,63 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable decimal value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class NullableDecimalHaveScaledPrecisionValidator(
+    PrincipalChain<decimal?> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static NullableDecimalHaveScaledPrecisionValidator New(
+        PrincipalChain<decimal?> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "NullableDecimal.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(decimal?);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+        var bits = decimal.GetBits(value);
+        var scale = (bits[3] >> 16) & 0x7F;
+
+        if (scale > expectedDecimals)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but it did not.";
+            return false;
+        }
+
+        var absValue = Math.Abs(value);
+        var integerPart = decimal.Truncate(absValue);
+        var integerDigits = integerPart == 0m ? 1 : (int)Math.Floor(Math.Log10((double)integerPart)) + 1;
+        var totalDigits = integerDigits + scale;
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but it did not.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableDoubleHaveScaledPrecisionValidator.cs
@@ -1,0 +1,67 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable double value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class NullableDoubleHaveScaledPrecisionValidator(
+    PrincipalChain<double?> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static NullableDoubleHaveScaledPrecisionValidator New(
+        PrincipalChain<double?> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "NullableDouble.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(double?);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        // Scale check
+        var rounded = Math.Round(value, expectedDecimals);
+        if (Math.Abs(rounded - value) >= double.Epsilon)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but it did not.";
+            return false;
+        }
+
+        // Total digits check using string representation for reliability
+        var absValue = Math.Abs(value);
+        var integerPart = Math.Truncate(absValue);
+        var integerDigits = integerPart == 0.0 ? 1 : (int)Math.Floor(Math.Log10(integerPart)) + 1;
+        var strValue = value.ToString("G17");
+        var dotIndex = strValue.IndexOf('.');
+        var actualDecimals = dotIndex < 0 ? 0 : strValue.Length - dotIndex - 1;
+        var totalDigits = integerDigits + Math.Min(actualDecimals, expectedDecimals);
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but it did not.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/NullableFloatHaveScaledPrecisionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/NullableFloatHaveScaledPrecisionValidator.cs
@@ -1,0 +1,67 @@
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the nullable float value has at most <c>expectedDecimals</c> decimal places
+/// and at most <c>maxTotalDigits</c> total significant digits.
+/// </summary>
+internal class NullableFloatHaveScaledPrecisionValidator(
+    PrincipalChain<float?> chain,
+    int expectedDecimals,
+    int maxTotalDigits
+) : IValidator, IRuleDescriptor
+{
+    public static NullableFloatHaveScaledPrecisionValidator New(
+        PrincipalChain<float?> chain,
+        int expectedDecimals,
+        int maxTotalDigits
+    ) => new(chain, expectedDecimals, maxTotalDigits);
+
+    public string Expected { get; }
+    public string ResultValidation { get; set; }
+    public string MessageKey => "NullableFloat.HaveScaledPrecision";
+    string IRuleDescriptor.OperationName => "HaveScaledPrecision";
+    Type IRuleDescriptor.SubjectType => typeof(float?);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["expectedDecimals"] = expectedDecimals,
+            ["maxTotalDigits"] = maxTotalDigits,
+        };
+
+    public bool Validate()
+    {
+        var value = chain.GetValue().SafeNull();
+
+        // Scale check
+        var rounded = (float)Math.Round(value, expectedDecimals);
+        if (Math.Abs(rounded - value) >= float.Epsilon)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} decimal places, but it did not.";
+            return false;
+        }
+
+        // Total digits check using string representation for reliability
+        var absValue = Math.Abs(value);
+        var integerPart = (float)Math.Truncate(absValue);
+        var integerDigits = integerPart == 0f ? 1 : (int)Math.Floor(Math.Log10(integerPart)) + 1;
+        var strValue = value.ToString("G9");
+        var dotIndex = strValue.IndexOf('.');
+        var actualDecimals = dotIndex < 0 ? 0 : strValue.Length - dotIndex - 1;
+        var totalDigits = integerDigits + Math.Min(actualDecimals, expectedDecimals);
+
+        if (totalDigits > maxTotalDigits)
+        {
+            ResultValidation =
+                "The resulting value was expected to have at most {0} total digits, but it did not.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}


### PR DESCRIPTION
Validates that a numeric value has at most N decimal places AND at most M total significant digits. Includes FailIf guards for negative decimals, zero total digits, and decimals exceeding total. Covers both non-nullable and nullable variants with NaN guards for double/float.