### PR TITLE
Document HaveScaledPrecision, MessageFactory, CompositeBlueprint, and reusable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,37 @@ report.HasWarnings;  // Only Severity.Warning
 report.Errors;       // Filtered list
 ```
 
+### Dynamic Error Messages (MessageFactory)
+
+Use `MessageFactory` in `RuleConfig` to generate error messages with access to the root model instance:
+
+```csharp
+using (Define())
+{
+    For(x => x.Items, new RuleConfig
+    {
+        MessageFactory = model =>
+        {
+            var order = (Order)model;
+            return $"Order #{order.Id} for '{order.CustomerName}' exceeds the maximum of {order.MaxItems} items.";
+        }
+    }).Test().HaveLengthLessThanOrEqualTo(10);
+
+    For(x => x.Email, new RuleConfig
+    {
+        Severity = Severity.Warning,
+        ErrorCode = "EMAIL_FORMAT",
+        MessageFactory = model =>
+        {
+            var user = (User)model;
+            return $"Email format for user '{user.Name}' (role: {user.Role}) is non-standard.";
+        }
+    }).Test().BeEmail();
+}
+```
+
+`MessageFactory` receives the model as `object` — cast to your model type inside the lambda. It takes precedence over `CustomMessage` and the auto-generated template. It is only invoked during Blueprint `Check()`/`CheckAsync()` evaluation when the rule fails.
+
 ### Async Validation
 
 ```csharp
@@ -217,6 +248,38 @@ using (Define())
 }
 ```
 
+### CompositeBlueprint&lt;T&gt;
+
+Compose N independent blueprints at runtime and merge their results into a single `QualityReport`. Each blueprint runs independently — unlike `Include()` (static rule copy), composites keep blueprints fully decoupled.
+
+```csharp
+var composite = new CompositeBlueprint<User>(
+    new NameBlueprint(),
+    new EmailBlueprint(),
+    new AgeBlueprint());
+
+// Sequential
+QualityReport report = composite.Check(user);
+
+// Parallel (Task.WhenAll)
+QualityReport report = await composite.CheckAsync(user);
+
+Console.WriteLine(report.IsValid);         // false if any sub-blueprint has Error failures
+Console.WriteLine(report.RulesEvaluated);  // sum across all blueprints
+Console.WriteLine(report.Failures.Count);  // all failures from all blueprints
+```
+
+**DI registration** (with `JAAvila.FluentOperations.DependencyInjection`):
+
+```csharp
+// Only the composite is registered as IBlueprintValidator — NOT the individual blueprints.
+services.AddCompositeBlueprint<User>(
+    typeof(NameBlueprint),
+    typeof(EmailBlueprint));
+```
+
+---
+
 ### CascadeMode
 
 ```csharp
@@ -263,6 +326,35 @@ using (Define())
     ForCustom(x => x.CardNumber, new LuhnValidator());
 }
 ```
+
+### Reusable Rules
+
+Define domain rules as extension methods on concrete managers — they work in inline, blueprint, and `AssertionScope` modes without any library changes:
+
+```csharp
+public static StringOperationsManager MustBeValidIban(this StringOperationsManager m)
+    => m.NotBeNull().HaveLengthBetween(15, 34)
+        .Match(@"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$");
+
+public static DecimalOperationsManager MustBeValidAmount(this DecimalOperationsManager m)
+    => m.BePositive().BeInRange(0.01m, 999_999_999.99m).HaveMaxDecimalPlaces(2);
+
+// Inline
+iban.Test().MustBeValidIban();
+
+// Blueprint
+For(x => x.Iban).Test().MustBeValidIban();
+For(x => x.Amount).Test().MustBeValidAmount();
+
+// AssertionScope
+using (new AssertionScope())
+{
+    iban.Test().MustBeValidIban();
+    amount.Test().MustBeValidAmount();
+}
+```
+
+Rules with parameters, ForTransform, Scenarios, and RuleConfig all work transparently. See [Reusable Rule Builders Guide](./docs/REUSABLE_RULES.md) for the full guide.
 
 ### Blueprint Assertions (Test-to-Production Bridge)
 
@@ -492,6 +584,7 @@ FluentOperationsConfig.Configure(c =>
 ## Documentation
 
 - [API Reference](./docs/API.md) — Complete API documentation
+- [Reusable Rule Builders Guide](./docs/REUSABLE_RULES.md) — Domain rules via extension methods
 - [Integration Guide](./docs/INTEGRATION.md) — ASP.NET Core, MediatR, Minimal API, gRPC, and more
 - [Localization Guide](./docs/LOCALIZATION.md) — Configuring localized validation messages
 - [Contributing](./CONTRIBUTING.md) — How to contribute, code of ethics, CLA

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,7 @@ Complete API documentation for JAAvila.FluentOperations.
   - [Custom Validator Operations](#custom-validator-operations)
   - [Action / Async Action](#action-validations)
   - [ActionStats (Execution Statistics)](#actionstats-execution-statistics)
+- [Reusable Rule Builders](#reusable-rule-builders)
 - [Quality Blueprints](#quality-blueprints)
   - [QualityBlueprint&lt;T&gt;](#qualityblueprintt)
   - [QualityReport](#qualityreport)
@@ -505,6 +506,7 @@ All Integer operations plus:
 | Method | Description |
 |--------|-------------|
 | `HavePrecision(int)` | Exact decimal places |
+| `HaveScaledPrecision(int, int)` | At most N decimal places AND at most M total significant digits |
 | `BeRoundedTo(int)` | Rounded to N places |
 | `BeApproximately(decimal, decimal)` | Within tolerance of expected value |
 
@@ -1058,11 +1060,191 @@ Console.WriteLine($"Took {info.ElapsedMilliseconds}ms, Memory: {info.MemoryDelta
 
 ---
 
+## Reusable Rule Builders
+
+FluentOperations supports reusable validation rules via standard C# extension methods on operation managers. Since all managers are public concrete classes that return `this` (the concrete type), you can compose any validation chain into a domain-specific rule and reuse it everywhere — inline, in blueprints, and inside `AssertionScope` — without any library changes.
+
+### Defining a reusable rule
+
+Create a static class with extension methods targeting the concrete manager type:
+
+```csharp
+public static class BankingRules
+{
+    private static readonly Regex IbanPattern = new(
+        @"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$",
+        RegexOptions.Compiled);
+
+    public static StringOperationsManager MustBeValidIban(
+        this StringOperationsManager manager)
+        => manager
+            .NotBeNull()
+            .NotBeEmpty()
+            .HaveLengthBetween(15, 34)
+            .Match(IbanPattern);
+}
+```
+
+### Using in inline mode
+
+```csharp
+order.Iban.Test().MustBeValidIban();
+```
+
+### Using in Blueprints
+
+```csharp
+public class PaymentBlueprint : QualityBlueprint<PaymentRequest>
+{
+    public PaymentBlueprint()
+    {
+        using (Define())
+        {
+            For(x => x.Iban).Test().MustBeValidIban();
+            For(x => x.Amount).Test().MustBeValidAmount();
+            For(x => x.Phone).Test().MustBeValidPhone();
+
+            // Mix with native operations freely
+            For(x => x.Reference).Test()
+                .NotBeNull()
+                .HaveLengthBetween(8, 20);
+        }
+    }
+}
+```
+
+### Using with AssertionScope
+
+Extension methods work transparently inside `AssertionScope`. Failures accumulate the same way as native operations:
+
+```csharp
+using (var scope = new AssertionScope("Payment validation"))
+{
+    iban.Test().MustBeValidIban();
+    amount.Test().MustBeValidAmount();
+}
+// Throws once with all accumulated failures
+```
+
+### Using with Scenarios
+
+Extension methods are regular operations — `Scenario<T>` applies to them exactly as to native operations:
+
+```csharp
+using (Define())
+{
+    For(x => x.Amount).Test().MustBeValidAmount(); // Always applied
+
+    Scenario<IInternationalPayment>(() =>
+    {
+        For(x => x.Iban).Test().MustBeValidIban();
+        For(x => x.Phone).Test().MustBeValidPhone();
+    });
+}
+```
+
+### Using with RuleConfig
+
+`RuleConfig` (severity, error code, cascade mode) is set on the `For()` call, not inside the extension method. It applies to all operations within the method:
+
+```csharp
+// All operations inside MustBeValidIban run as Warning
+For(x => x.Iban, new RuleConfig { Severity = Severity.Warning, ErrorCode = "IBAN_001" })
+    .Test().MustBeValidIban();
+```
+
+### Using with ForTransform
+
+Extension methods chain naturally after `ForTransform`:
+
+```csharp
+ForTransform(x => x.Iban, v => v?.Trim().ToUpperInvariant())
+    .Test().MustBeValidIban();
+```
+
+### Rules with parameters
+
+Extension methods can accept parameters for configurable thresholds:
+
+```csharp
+public static class MoneyRules
+{
+    public static DecimalOperationsManager MustBeValidAmount(
+        this DecimalOperationsManager manager,
+        decimal maxAmount = 999_999_999.99m)
+        => manager
+            .BePositive()
+            .BeInRange(0.01m, maxAmount)
+            .HaveMaxDecimalPlaces(2);
+}
+
+// Usage
+price.Test().MustBeValidAmount();
+price.Test().MustBeValidAmount(maxAmount: 50_000m);
+```
+
+### More examples
+
+```csharp
+// Phone (E.164)
+public static StringOperationsManager MustBeValidPhone(
+    this StringOperationsManager manager)
+    => manager
+        .NotBeNull()
+        .NotBeEmpty()
+        .HaveLengthBetween(7, 15)
+        .Match(@"^\+?[1-9]\d{1,14}$");
+
+// Age
+public static IntegerOperationsManager MustBeValidAge(
+    this IntegerOperationsManager manager)
+    => manager.BeInRange(0, 150);
+
+// Corporate email with configurable domain
+public static StringOperationsManager MustBeCorporateEmail(
+    this StringOperationsManager manager,
+    string domain)
+    => manager
+        .NotBeNull()
+        .BeEmail()
+        .EndWith($"@{domain}", StringComparison.OrdinalIgnoreCase);
+```
+
+### Limitations
+
+**`RuleConfig` applies to all operations in the extension method.** You cannot apply different severity levels to different operations inside a single extension method call. If you need different severities, split into multiple `For()` calls.
+
+**Nullable vs non-nullable managers are distinct types.** An extension on `IntegerOperationsManager` does not apply to `NullableIntegerOperationsManager`. Define two overloads if you need both:
+
+```csharp
+public static IntegerOperationsManager MustBeValidAge(this IntegerOperationsManager m)
+    => m.BeInRange(0, 150);
+
+public static NullableIntegerOperationsManager MustBeValidAge(this NullableIntegerOperationsManager m)
+    => m.HaveValue().BeInRange(0, 150);
+```
+
+**Error messages are per-operation, not per composite rule.** If `MustBeValidIban()` fails inside `Match()`, the message describes the `Match` failure, not a unified "invalid IBAN" message. Use the `Reason` parameter to add context, or use `ICustomValidator<T>` when a single unified message is required.
+
+**No async extension methods.** Managers return `this` synchronously; there is no `Task<TManager>` return path. For rules requiring async logic, use `IAsyncCustomValidator<T>` with `EvaluateAsync()`.
+
+For extended examples and testing guidance, see [Reusable Rule Builders Guide](./REUSABLE_RULES.md).
+
+---
+
 ## Quality Blueprints
 
 ### QualityBlueprint&lt;T&gt;
 
 Abstract base class for validation schemas.
+
+#### Protected Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `CascadeMode` | `CascadeMode` | `Continue` | Controls cascade behavior for the entire blueprint. |
+| `CascadeSeverityMode` | `CascadeSeverityMode` | `ErrorOnly` | Controls which severity levels can trigger cascade stop. |
+| `ParallelExecution` | `bool` | `false` | When `true`, `CheckAsync` evaluates all property definitions concurrently. See [ParallelExecution](#parallelexecution). |
 
 #### Protected Methods
 
@@ -1211,12 +1393,44 @@ Extension methods (in `QualityReportAspNetExtensions`, requires `AspNetCore` pac
 public record RuleConfig
 {
     public Severity? Severity { get; init; }
-    public ErrorCode? ErrorCode { get; init; }
+    public string? ErrorCode { get; init; }
     public string? CustomMessage { get; init; }
     public CascadeMode? CascadeMode { get; init; }
     public CascadeSeverityMode? CascadeSeverityMode { get; init; }
+    public Func<object, string>? MessageFactory { get; init; }
 }
 ```
+
+#### Message Priority Order
+
+When a rule fails, the message is resolved in this order:
+
+1. `MessageFactory` — dynamic factory function (highest priority)
+2. `CustomMessage` — static override string
+3. Localized message via `IMessageProvider` + `MessageKey`
+4. Auto-generated template (default)
+
+#### MessageFactory
+
+`MessageFactory` receives the root model instance as `object`. Cast to your model type inside the lambda:
+
+```csharp
+For(x => x.Email, new RuleConfig
+{
+    MessageFactory = model =>
+    {
+        var order = (Order)model;
+        return $"Email for customer '{order.CustomerName}' is invalid.";
+    }
+}).Test().BeEmail();
+```
+
+**Notes:**
+- Only invoked during Blueprint `Check()`/`CheckAsync()` evaluation — not in inline (eager) mode.
+- Only invoked when the rule fails — not for passing rules.
+- `MessageFactory` takes precedence over `CustomMessage` when both are set.
+- If `MessageFactory` throws, the exception propagates — the factory must not throw.
+- Compatible with all `For()`, `ForEach()`, `ForTransform()`, and `Scenario<T>()` overloads.
 
 ---
 
@@ -1289,6 +1503,67 @@ Include(new BaseEntityBlueprint()); // Call before Define()
 
 ---
 
+### CompositeBlueprint&lt;T&gt;
+
+Composes N independent blueprints at runtime and merges their `QualityReport` results into a single report. Unlike `Include()` (which copies rules at definition time into one blueprint), `CompositeBlueprint<T>` keeps each blueprint independent and merges their outputs on every `Check`/`CheckAsync` call.
+
+```csharp
+var composite = new CompositeBlueprint<User>(
+    new NameBlueprint(),
+    new EmailBlueprint(),
+    new AgeBlueprint());
+
+// Sequential execution
+QualityReport report = composite.Check(user);
+
+// Parallel execution (Task.WhenAll)
+QualityReport report = await composite.CheckAsync(user);
+
+Console.WriteLine(report.IsValid);          // false if any sub-blueprint has Error failures
+Console.WriteLine(report.RulesEvaluated);   // sum of RulesEvaluated across all blueprints
+Console.WriteLine(report.Failures.Count);   // all failures from all blueprints
+```
+
+**Constructors:**
+
+| Overload | Usage |
+|----------|-------|
+| `CompositeBlueprint<T>(IEnumerable<IBlueprintValidator>)` | DI / dynamic composition |
+| `CompositeBlueprint<T>(params QualityBlueprint<T>[])` | Manual / inline composition |
+
+**Merge strategy:**
+
+| Field | Strategy |
+|-------|----------|
+| `Failures` | Concatenated from all sub-reports in blueprint order |
+| `RulesEvaluated` | Sum of all sub-reports |
+| `IsValid`, `HasErrors`, `HasWarnings`, `HasInfos`, `Errors`, `Warnings`, `Infos` | Recalculated automatically from merged `Failures` |
+
+**`CheckAsync` parallelism:** blueprints execute concurrently via `Task.WhenAll`. Failures are merged in the original blueprint order regardless of completion order. Each blueprint must be a distinct instance — passing the same instance twice is not safe for concurrent async execution.
+
+**DI registration** (requires `JAAvila.FluentOperations.DependencyInjection`):
+
+```csharp
+// Register individual blueprints (by concrete type only — NOT as IBlueprintValidator)
+// and the composite (as both its concrete type and IBlueprintValidator):
+services.AddCompositeBlueprint<User>(
+    typeof(NameBlueprint),
+    typeof(EmailBlueprint));
+
+// Or with a factory for custom resolution:
+services.AddCompositeBlueprint<User>(sp =>
+[
+    sp.GetRequiredService<NameBlueprint>(),
+    sp.GetRequiredService<EmailBlueprint>()
+]);
+```
+
+> **Important**: Do NOT call `AddBlueprint<T>()` for blueprints that are part of a composite. `AddBlueprint<T>()` registers them as `IBlueprintValidator`, which causes integration filters to find the individual blueprint before the composite for the same model type `T`.
+
+**Integration filters** (`BlueprintValidationFilter`, `MediatRBlueprintBehavior`, `GrpcBlueprintInterceptor`) discover `CompositeBlueprint<T>` automatically via `IEnumerable<IBlueprintValidator>` — no special configuration needed. `MinimalApiBlueprintFilter<TModel, TBlueprint>` requires `TBlueprint : QualityBlueprint<TModel>` and is therefore not directly compatible; use the composite directly in the endpoint handler instead.
+
+---
+
 ### CascadeMode
 
 Control failure behavior:
@@ -1335,6 +1610,44 @@ For(x => x.Name, new RuleConfig
 ```
 
 > **Migration note**: In versions prior to this feature, `StopOnFirstFailure` was severity-blind (equivalent to `AllFailures`). If your blueprint relies on Warning/Info failures stopping cascade, set `CascadeSeverityMode = CascadeSeverityMode.AllFailures` to restore the previous behavior.
+
+---
+
+### ParallelExecution
+
+Enables concurrent evaluation of independent property definitions in `CheckAsync`. When `true`, each `For`, `ForEach`, and `ForNested` definition is dispatched as a separate task and all tasks run via `Task.WhenAll`. Rules within a single property definition are always evaluated sequentially.
+
+```csharp
+public class OrderBlueprint : QualityBlueprint<Order>
+{
+    public OrderBlueprint()
+    {
+        ParallelExecution = true; // opt-in; default is false
+
+        using (Define())
+        {
+            For(x => x.CustomerName).Test().NotBeNull().NotBeEmpty();
+            For(x => x.Email).Test().NotBeNull().BeEmail();
+            // Each For() definition runs concurrently when ParallelExecution = true
+        }
+    }
+}
+```
+
+**When to use**: Only beneficial when validators contain real async I/O (HTTP calls, database queries, file system access via `EvaluateAsync` / `ForAsync`). For CPU-bound validators, the overhead of task scheduling exceeds the benefit.
+
+**Restrictions**:
+
+| Scenario | Behavior |
+|----------|----------|
+| `ParallelExecution = false` (default) | Sequential; no change |
+| `ParallelExecution = true` + `CascadeMode.StopOnFirstFailure` (blueprint-level) | `InvalidOperationException` at runtime — incompatible |
+| `ParallelExecution = true` + per-property `RuleConfig.CascadeMode.StopOnFirstFailure` | Supported — each property's rules still run sequentially |
+| `Check()` (synchronous) | Always sequential; `ParallelExecution` is ignored |
+
+**Failure order**: Failures are merged in the original definition order (the order `For`/`ForEach`/`ForNested` was called), so `QualityReport.Failures` is deterministic regardless of task scheduling.
+
+**Isolation**: Each parallel task creates its own `TransactionalOperations` scope, ensuring there is no cross-contamination between property results.
 
 ---
 

--- a/docs/REUSABLE_RULES.md
+++ b/docs/REUSABLE_RULES.md
@@ -1,0 +1,351 @@
+# Reusable Rule Builders
+
+This guide explains how to define and use reusable validation rules in FluentOperations via standard C# extension methods.
+
+## Overview
+
+FluentOperations operation managers (`StringOperationsManager`, `DecimalOperationsManager`, etc.) are public, concrete, non-sealed classes. Each operation method returns the concrete manager type (`return this`), which is the exact property that makes C# extension methods work natively.
+
+**No library changes are required.** You define a static class with extension methods targeting the manager type, and the rules work everywhere automatically.
+
+## How It Works
+
+### Inline mode
+
+```csharp
+// Your extension method
+public static StringOperationsManager MustBeValidIban(this StringOperationsManager m)
+    => m.NotBeNull().HaveLengthBetween(15, 34).Match(@"^[A-Z]{2}\d{2}...");
+
+// Compiler expansion:
+// StringOperationsManager mgr = iban.Test();   // TestExtension
+// StringOperationsManager result = mgr.MustBeValidIban(); // your extension
+```
+
+Each call inside the extension method passes through `ExecutionEngine` normally. A failure throws immediately, exactly like any native operation.
+
+### Blueprint mode
+
+```csharp
+using (Define())
+{
+    For(x => x.Iban).Test().MustBeValidIban();
+}
+```
+
+1. `For(x => x.Iban)` returns `IPropertyProxy<StringOperationsManager>`.
+2. `.Test()` creates a `StringOperationsManager` and activates `RuleCaptureContext`.
+3. `.MustBeValidIban()` calls native operations on the same manager instance.
+4. `ExecutionEngine.Execute()` detects the active `RuleCaptureContext` and **captures** each rule instead of executing it.
+5. `Check(instance)` evaluates all captured rules and returns a `QualityReport`.
+
+### AssertionScope mode
+
+Extension methods are unaware of `AssertionScope`. `ExceptionHandler.Handle()` detects the active scope and accumulates failures — extension methods benefit from this automatically.
+
+## Example Gallery
+
+### IBAN Validation
+
+```csharp
+namespace MyProject.Validations;
+
+public static class BankingRules
+{
+    private static readonly Regex IbanPattern = new(
+        @"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$",
+        RegexOptions.Compiled);
+
+    /// <summary>Validates a string as a valid IBAN (ISO 13616).</summary>
+    public static StringOperationsManager MustBeValidIban(
+        this StringOperationsManager manager)
+        => manager
+            .NotBeNull()
+            .NotBeEmpty()
+            .HaveLengthBetween(15, 34)
+            .Match(IbanPattern);
+}
+```
+
+### Monetary Amount
+
+```csharp
+public static class MoneyRules
+{
+    /// <summary>Validates a decimal as a positive monetary amount with max 2 decimal places.</summary>
+    public static DecimalOperationsManager MustBeValidAmount(
+        this DecimalOperationsManager manager,
+        decimal maxAmount = 999_999_999.99m)
+        => manager
+            .BePositive()
+            .BeInRange(0.01m, maxAmount)
+            .HaveMaxDecimalPlaces(2);
+}
+```
+
+### Phone Number (E.164)
+
+```csharp
+public static class ContactRules
+{
+    private static readonly Regex PhonePattern = new(
+        @"^\+?[1-9]\d{1,14}$",
+        RegexOptions.Compiled);
+
+    /// <summary>Validates a string as an E.164 phone number.</summary>
+    public static StringOperationsManager MustBeValidPhone(
+        this StringOperationsManager manager)
+        => manager
+            .NotBeNull()
+            .NotBeEmpty()
+            .HaveLengthBetween(7, 15)
+            .Match(PhonePattern);
+}
+```
+
+### Age
+
+```csharp
+public static class PersonRules
+{
+    public static IntegerOperationsManager MustBeValidAge(
+        this IntegerOperationsManager manager)
+        => manager.BeInRange(0, 150);
+}
+```
+
+### Corporate Email
+
+```csharp
+public static class CorporateRules
+{
+    /// <summary>Validates a string as a corporate email for the given domain.</summary>
+    public static StringOperationsManager MustBeCorporateEmail(
+        this StringOperationsManager manager,
+        string domain)
+        => manager
+            .NotBeNull()
+            .BeEmail()
+            .EndWith($"@{domain}", StringComparison.OrdinalIgnoreCase);
+}
+```
+
+### Complete Blueprint with Reusable Rules
+
+```csharp
+public class PaymentBlueprint : QualityBlueprint<PaymentRequest>
+{
+    public PaymentBlueprint()
+    {
+        using (Define())
+        {
+            For(x => x.Iban).Test().MustBeValidIban();
+            For(x => x.Amount).Test().MustBeValidAmount();
+            For(x => x.Phone).Test().MustBeValidPhone();
+            For(x => x.ContactEmail).Test().MustBeCorporateEmail("enterprise.com");
+
+            // Mix with native operations freely
+            For(x => x.Reference).Test()
+                .NotBeNull()
+                .HaveLengthBetween(8, 20);
+        }
+    }
+}
+```
+
+## Advanced Patterns
+
+### Rules with parameters
+
+Pass parameters to customize thresholds or behavior:
+
+```csharp
+public static DecimalOperationsManager MustBeValidAmount(
+    this DecimalOperationsManager manager,
+    decimal maxAmount = 999_999_999.99m)
+    => manager
+        .BePositive()
+        .BeInRange(0.01m, maxAmount)
+        .HaveMaxDecimalPlaces(2);
+
+// Caller controls the cap
+price.Test().MustBeValidAmount(maxAmount: 50_000m);
+For(x => x.Price).Test().MustBeValidAmount(maxAmount: 50_000m);
+```
+
+### Adding contextual Reason
+
+Add a `Reason` parameter so callers can explain why the rule applies:
+
+```csharp
+public static StringOperationsManager MustBeValidIban(
+    this StringOperationsManager manager,
+    Reason? reason = null)
+    => manager
+        .NotBeNull()
+        .HaveLengthBetween(15, 34, reason)
+        .Match(IbanPattern, reason);
+```
+
+### Using with ForTransform
+
+Extension methods chain after `ForTransform` the same way:
+
+```csharp
+ForTransform(x => x.Iban, v => v?.Trim().ToUpperInvariant())
+    .Test().MustBeValidIban();
+```
+
+### Using with Scenarios
+
+Extension methods inside `Scenario<T>()` blocks are scoped exactly like native operations:
+
+```csharp
+using (Define())
+{
+    For(x => x.Amount).Test().MustBeValidAmount(); // Always applied
+
+    Scenario<IInternationalPayment>(() =>
+    {
+        For(x => x.Iban).Test().MustBeValidIban();
+        For(x => x.Phone).Test().MustBeValidPhone();
+    });
+}
+```
+
+### Using with RuleConfig
+
+`RuleConfig` is specified on `For()` and applies to all operations within the extension method:
+
+```csharp
+// All operations in MustBeValidIban run at Warning severity
+For(x => x.Iban, new RuleConfig { Severity = Severity.Warning, ErrorCode = "IBAN_001" })
+    .Test().MustBeValidIban();
+```
+
+This is by design — the `RuleConfig` governs the property group, not individual operations.
+
+## Limitations and Workarounds
+
+### RuleConfig applies to all operations in the extension method
+
+You cannot assign different severities to different operations inside a single extension method invocation. If you need that, split into multiple `For()` calls:
+
+```csharp
+// Separate RuleConfig per group of operations
+For(x => x.Iban).Test().NotBeNull();  // Error (default)
+For(x => x.Iban, new RuleConfig { Severity = Severity.Warning })
+    .Test().HaveLengthBetween(15, 34); // Warning
+```
+
+### Nullable vs non-nullable managers are distinct types
+
+An extension method on `IntegerOperationsManager` does not apply to `NullableIntegerOperationsManager`. Define two overloads when both are needed:
+
+```csharp
+public static IntegerOperationsManager MustBeValidAge(this IntegerOperationsManager m)
+    => m.BeInRange(0, 150);
+
+public static NullableIntegerOperationsManager MustBeValidAge(this NullableIntegerOperationsManager m)
+    => m.HaveValue().BeInRange(0, 150);
+```
+
+### Error messages are per-operation, not per composite rule
+
+If `MustBeValidIban()` fails at `Match()`, the message describes the regex mismatch, not a unified "invalid IBAN" message. To surface a domain-level message:
+
+**Option 1 — Use `Reason` for context:**
+
+```csharp
+public static StringOperationsManager MustBeValidIban(this StringOperationsManager m)
+    => m.NotBeNull()
+        .Match(IbanPattern, (Reason)"The value must be a valid IBAN (ISO 13616)");
+```
+
+**Option 2 — Use `ICustomValidator<T>` for a single unified message:**
+
+```csharp
+public class IbanValidator : ICustomValidator<string?>
+{
+    public bool IsValid(string? value)
+        => value is not null
+           && value.Length is >= 15 and <= 34
+           && Regex.IsMatch(value, @"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$");
+
+    public string GetFailureMessage(string? value)
+        => $"Expected a valid IBAN (ISO 13616), but found \"{value}\".";
+}
+
+// Inline
+iban.Test().Evaluate(new IbanValidator());
+
+// Blueprint
+For(x => x.Iban).Test().Evaluate(new IbanValidator());
+```
+
+Use `ICustomValidator<T>` when you need a single, unified failure message. Use extension methods when you want individual per-rule messages and fluent composability.
+
+### No async extension methods
+
+Managers return `this` synchronously. There is no `Task<TManager>` fluent return. For rules requiring async logic (e.g., database uniqueness checks), use `IAsyncCustomValidator<T>` with `EvaluateAsync()`.
+
+### Cross-type rules require multiple extension methods
+
+An extension method on `StringOperationsManager` cannot simultaneously validate a `decimal` property. Cross-property rules belong in the blueprint using `ForCompare()` or multiple `For()` calls.
+
+## Testing Reusable Rules
+
+Reusable rule extension methods should be tested across all 6 pillars, like any other operation:
+
+1. **Inline** — direct `.Test().MyRule()` calls, pass and fail cases
+2. **Blueprint** — via `For(x => x.Prop).Test().MyRule()`, verify `QualityReport.IsValid` and `Failures`
+3. **Blueprint with Scenarios** — verify the rule only applies when the model implements the marker interface
+4. **AssertionScope** — verify failures accumulate instead of throwing immediately
+5. **ForTransform** — verify the rule works after a transform
+6. **RuleConfig** — verify severity, error code, and custom message are respected
+
+Example test extension methods:
+
+```csharp
+internal static class TestReusableRules
+{
+    internal static StringOperationsManager MustBeValidIban(this StringOperationsManager m)
+        => m.NotBeNull().NotBeEmpty().HaveLengthBetween(15, 34)
+            .Match(@"^[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}([A-Z0-9]?){0,16}$");
+
+    internal static DecimalOperationsManager MustBeValidAmount(this DecimalOperationsManager m)
+        => m.BePositive().BeInRange(0.01m, 999_999_999.99m);
+}
+```
+
+Example blueprint test:
+
+```csharp
+public class PaymentBlueprint : QualityBlueprint<PaymentRequest>
+{
+    public PaymentBlueprint()
+    {
+        using (Define())
+        {
+            For(x => x.Iban).Test().MustBeValidIban();
+            For(x => x.Amount).Test().MustBeValidAmount();
+        }
+    }
+}
+
+[Test]
+public void MustBeValidIban_Blueprint_InvalidIban_ShouldReportFailure()
+{
+    var blueprint = new PaymentBlueprint();
+    var report = blueprint.Check(new PaymentRequest { Iban = "invalid", Amount = 1.00m });
+
+    Assert.That(report.IsValid, Is.False);
+    Assert.That(report.Failures.Any(f => f.PropertyName == "Iban"), Is.True);
+}
+```
+
+## IRuleDescriptor Behavior with Reusable Rules
+
+`GetRuleDescriptors()` on a blueprint returns individual rule descriptors — one per operation call inside the extension method, not one per extension method invocation. A call to `.MustBeValidIban()` that chains four operations will produce four `BlueprintRuleInfo` entries, each with its own `OperationName`, `Parameters`, and `Severity`.
+
+This is correct behavior: introspection reflects the actual validation operations, not the grouping abstraction.


### PR DESCRIPTION
Update API.md with HaveScaledPrecision operation tables, RuleSet API, ForSelf/ForPredicate methods, interceptor pipeline, and CompositeBlueprint. Update README.md with MessageFactory, CompositeBlueprint, and reusable rules examples. Add docs/REUSABLE_RULES.md with detailed guide on building domain-specific validation rules via extension methods.