### PR TITLE
Add architecture testing with Type and Assembly managers

### DIFF
--- a/Distributed/JAAvila.FluentOperations.Architecture/ArchitectureScannerConfig.cs
+++ b/Distributed/JAAvila.FluentOperations.Architecture/ArchitectureScannerConfig.cs
@@ -1,0 +1,43 @@
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Static configuration for architecture-level testing features.
+/// Call <see cref="UseCecilDependencyScanning"/> to activate IL-level dependency
+/// detection for <c>HaveDependencyOn</c>, <c>NotHaveDependencyOn</c>, and
+/// <c>OnlyHaveDependenciesOn</c> operations.
+/// </summary>
+public static class ArchitectureScannerConfig
+{
+    /// <summary>
+    /// Activates Mono.Cecil-based IL scanning for dependency detection.
+    /// When active, <c>HaveDependencyOn</c> and related operations detect
+    /// dependencies in method bodies (local variables, <c>new</c> calls,
+    /// <c>typeof()</c>, casts, method calls, field access, catch blocks).
+    /// </summary>
+    /// <remarks>
+    /// Call this once in test setup (e.g., <c>[OneTimeSetUp]</c> or
+    /// <c>[AssemblyInitialize]</c>). Call <see cref="Reset"/> in teardown.
+    /// </remarks>
+    /// <returns>The <see cref="CecilDependencyScanner"/> instance for advanced usage.</returns>
+    public static CecilDependencyScanner UseCecilDependencyScanning()
+    {
+        var scanner = new CecilDependencyScanner();
+        DependencyScannerProvider.SetScanner(scanner);
+        return scanner;
+    }
+
+    /// <summary>
+    /// Resets dependency scanning to the default reflection-based implementation
+    /// and disposes the Cecil scanner (releasing cached assemblies).
+    /// </summary>
+    public static void Reset()
+    {
+        var current = DependencyScannerProvider.Current;
+        DependencyScannerProvider.Reset();
+
+        if (current is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Architecture/CecilAssemblyResolver.cs
+++ b/Distributed/JAAvila.FluentOperations.Architecture/CecilAssemblyResolver.cs
@@ -1,0 +1,26 @@
+using Mono.Cecil;
+
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Custom assembly resolver for Mono.Cecil that adds the scanned assembly's
+/// directory and the .NET runtime directory to the search paths.
+/// </summary>
+internal sealed class CecilAssemblyResolver : DefaultAssemblyResolver
+{
+    /// <param name="assemblyDirectory">
+    /// The directory containing the assembly being analyzed.
+    /// </param>
+    public CecilAssemblyResolver(string assemblyDirectory)
+    {
+        AddSearchDirectory(assemblyDirectory);
+
+        // Add .NET runtime directory for BCL assembly resolution
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+
+        if (!string.IsNullOrEmpty(runtimeDir))
+        {
+            AddSearchDirectory(runtimeDir);
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Architecture/CecilDependencyScanner.cs
+++ b/Distributed/JAAvila.FluentOperations.Architecture/CecilDependencyScanner.cs
@@ -1,0 +1,400 @@
+using System.Collections.Concurrent;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// IL-level dependency scanner powered by Mono.Cecil. Detects dependencies
+/// that reflection cannot see: local variables, inline <c>new</c> calls,
+/// <c>typeof()</c> references, cast expressions, method calls, field access,
+/// exception handler catch types, and delegate target types.
+/// </summary>
+/// <remarks>
+/// This scanner performs two passes:
+/// <list type="number">
+///   <item>Reflection pass: delegates to <see cref="ReflectionDependencyScanner"/>
+///         for type signatures (fields, properties, constructors, methods, base types,
+///         interfaces, attributes, events, generic arguments).</item>
+///   <item>IL pass: scans method body instructions via Mono.Cecil for additional
+///         type references not visible through reflection.</item>
+/// </list>
+/// Install this package and call <see cref="ArchitectureScannerConfig.UseCecilDependencyScanning()"/>
+/// to activate IL-level scanning for <c>HaveDependencyOn</c>, <c>NotHaveDependencyOn</c>,
+/// and <c>OnlyHaveDependenciesOn</c> operations.
+/// </remarks>
+public sealed class CecilDependencyScanner : IDependencyScanner, IDisposable
+{
+    // AssemblyDefinition? allows null sentinel for failed loads
+    private readonly ConcurrentDictionary<string, AssemblyDefinition?> _assemblyCache = new();
+    private readonly ConcurrentDictionary<string, HashSet<string>> _typeCache = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Returns the set of all namespaces that the given type depends on,
+    /// combining reflection-level and IL-level analysis.
+    /// </summary>
+    public HashSet<string> GetReferencedNamespaces(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var cacheKey = type.AssemblyQualifiedName ?? type.FullName ?? type.Name;
+        return _typeCache.GetOrAdd(cacheKey, _ => ScanType(type));
+    }
+
+    /// <summary>
+    /// Checks whether the type has a dependency on any namespace matching the prefix,
+    /// using combined reflection + IL analysis.
+    /// </summary>
+    public bool HasDependencyOnNamespace(Type type, string namespacePrefix)
+    {
+        var namespaces = GetReferencedNamespaces(type);
+        return namespaces.Any(
+            ns =>
+                string.Equals(ns, namespacePrefix, StringComparison.Ordinal)
+                || ns.StartsWith(namespacePrefix + ".", StringComparison.Ordinal)
+        );
+    }
+
+    /// <summary>
+    /// Checks whether all non-BCL dependencies fall within the allowed namespaces,
+    /// using combined reflection + IL analysis.
+    /// </summary>
+    public (bool isCompliant, IReadOnlyList<string> violatingNamespaces) CheckOnlyDependenciesOn(
+        Type type,
+        IReadOnlyList<string> allowedNamespaces
+    )
+    {
+        var namespaces = GetReferencedNamespaces(type);
+        var violating = (
+            from ns in namespaces
+            where
+                !ns.StartsWith("System", StringComparison.Ordinal)
+                && !ns.StartsWith("Microsoft", StringComparison.Ordinal)
+            let isAllowed = allowedNamespaces.Any(
+                allowed =>
+                    string.Equals(ns, allowed, StringComparison.Ordinal)
+                    || ns.StartsWith(allowed + ".", StringComparison.Ordinal)
+            )
+            where !isAllowed
+            select ns
+        ).ToList();
+
+        return (violating.Count == 0, violating);
+    }
+
+    /// <summary>
+    /// Releases all cached <see cref="AssemblyDefinition"/> instances.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        foreach (var assembly in _assemblyCache.Values)
+        {
+            try
+            {
+                assembly?.Dispose();
+            }
+            catch
+            {
+                /* best effort */
+            }
+        }
+
+        _assemblyCache.Clear();
+        _typeCache.Clear();
+    }
+
+    // --- Private methods ---
+
+    private HashSet<string> ScanType(Type type)
+    {
+        // Pass 1: Reflection (reuse existing implementation)
+        var namespaces = ReflectionDependencyScanner.Instance.GetReferencedNamespaces(type);
+
+        // Pass 2: IL inspection via Cecil
+        ScanMethodBodiesFromCecil(type, namespaces);
+
+        return namespaces;
+    }
+
+    private void ScanMethodBodiesFromCecil(Type type, HashSet<string> namespaces)
+    {
+        var assemblyLocation = type.Assembly.Location;
+
+        if (string.IsNullOrEmpty(assemblyLocation))
+        {
+            // Dynamic assembly, no file on disk — fall back to reflection-only
+            return;
+        }
+
+        var assemblyDef = LoadAssembly(assemblyLocation);
+
+        if (assemblyDef == null)
+        {
+            // Could not load — fall back to reflection-only
+            return;
+        }
+
+        var typeDef = FindTypeDefinition(assemblyDef, type);
+
+        if (typeDef == null)
+        {
+            // Type isn't found in Cecil's view — fall back to reflection-only
+            return;
+        }
+
+        ScanMethodBodies(typeDef, namespaces);
+        ScanCompilerGeneratedNestedTypes(typeDef, namespaces);
+
+        // Remove the type's own namespace — IL pass may re-add it
+        namespaces.Remove(type.Namespace ?? string.Empty);
+    }
+
+    private AssemblyDefinition? LoadAssembly(string location)
+    {
+        if (_assemblyCache.TryGetValue(location, out var cached))
+        {
+            // Maybe null (failed load sentinel)
+            return cached;
+        }
+
+        AssemblyDefinition? loaded = null;
+
+        try
+        {
+            var assemblyDir = Path.GetDirectoryName(location) ?? string.Empty;
+            var resolver = new CecilAssemblyResolver(assemblyDir);
+            var readerParameters = new ReaderParameters
+            {
+                AssemblyResolver = resolver,
+                ReadingMode = ReadingMode.Deferred,
+                ReadSymbols = false,
+            };
+            loaded = AssemblyDefinition.ReadAssembly(location, readerParameters);
+        }
+        catch
+        {
+            // Graceful degradation: store null sentinel so we don't retry on every call
+        }
+
+        // Store result (null or loaded) as sentinel
+        _assemblyCache.TryAdd(location, loaded);
+        return loaded;
+    }
+
+    private static TypeDefinition? FindTypeDefinition(AssemblyDefinition assembly, Type type)
+    {
+        // Try by full name (handles nested types via '/' separator in Cecil)
+        var fullName = type.FullName;
+
+        if (fullName == null)
+        {
+            return null;
+        }
+
+        // Convert CLR nested type separator '+' to Cecil's '/'
+        var cecilName = fullName.Replace('+', '/');
+
+        foreach (var module in assembly.Modules)
+        {
+            var typeDef = module.GetType(cecilName);
+
+            if (typeDef != null)
+            {
+                return typeDef;
+            }
+
+            // Fallback: search by namespace + name
+            typeDef = module.GetType(type.Namespace ?? string.Empty, type.Name);
+
+            if (typeDef != null)
+            {
+                return typeDef;
+            }
+        }
+
+        return null;
+    }
+
+    private static void ScanMethodBodies(TypeDefinition typeDef, HashSet<string> namespaces)
+    {
+        foreach (var method in typeDef.Methods.Where(method => method.HasBody))
+        {
+            foreach (var instruction in method.Body.Instructions)
+            {
+                switch (instruction.Operand)
+                {
+                    case TypeReference typeRef:
+                        AddCecilTypeNamespace(typeRef, namespaces);
+                        break;
+
+                    case MethodReference methodRef:
+                        // The declaring type of the method being called
+                        AddCecilTypeNamespace(methodRef.DeclaringType, namespaces);
+                        // Return type
+                        AddCecilTypeNamespace(methodRef.ReturnType, namespaces);
+                        // Parameter types
+                        if (methodRef.HasParameters)
+                        {
+                            foreach (var param in methodRef.Parameters)
+                            {
+                                AddCecilTypeNamespace(param.ParameterType, namespaces);
+                            }
+                        }
+                        // Generic arguments (for GenericInstanceMethod)
+                        if (methodRef is GenericInstanceMethod gim)
+                        {
+                            foreach (var arg in gim.GenericArguments)
+                            {
+                                AddCecilTypeNamespace(arg, namespaces);
+                            }
+                        }
+                        break;
+
+                    case FieldReference fieldRef:
+                        AddCecilTypeNamespace(fieldRef.DeclaringType, namespaces);
+                        AddCecilTypeNamespace(fieldRef.FieldType, namespaces);
+                        break;
+                }
+            }
+
+            // Also scan local variables
+            if (method.Body.HasVariables)
+            {
+                foreach (var local in method.Body.Variables)
+                    AddCecilTypeNamespace(local.VariableType, namespaces);
+            }
+
+            // Scan exception handler catch types
+            if (!method.Body.HasExceptionHandlers)
+            {
+                continue;
+            }
+
+            foreach (var handler in method.Body.ExceptionHandlers)
+            {
+                if (handler.CatchType != null)
+                {
+                    AddCecilTypeNamespace(handler.CatchType, namespaces);
+                }
+            }
+        }
+    }
+
+    private static void ScanCompilerGeneratedNestedTypes(
+        TypeDefinition typeDef,
+        HashSet<string> namespaces
+    )
+    {
+        if (!typeDef.HasNestedTypes)
+        {
+            return;
+        }
+
+        foreach (var nested in typeDef.NestedTypes.Where(IsCompilerGenerated))
+        {
+            ScanMethodBodies(nested, namespaces);
+        }
+    }
+
+    private static void AddCecilTypeNamespace(TypeReference? typeRef, HashSet<string> namespaces)
+    {
+        if (typeRef == null)
+        {
+            return;
+        }
+
+        // Unwrap modifiers (required/optional)
+        if (typeRef is RequiredModifierType reqMod)
+        {
+            AddCecilTypeNamespace(reqMod.ElementType, namespaces);
+            AddCecilTypeNamespace(reqMod.ModifierType, namespaces);
+            return;
+        }
+
+        if (typeRef is OptionalModifierType optMod)
+        {
+            AddCecilTypeNamespace(optMod.ElementType, namespaces);
+            AddCecilTypeNamespace(optMod.ModifierType, namespaces);
+            return;
+        }
+
+        // Unwrap an array, pointer, by-ref, pinned
+        if (typeRef is ArrayType arrayType)
+        {
+            AddCecilTypeNamespace(arrayType.ElementType, namespaces);
+            return;
+        }
+
+        if (typeRef is PointerType pointerType)
+        {
+            AddCecilTypeNamespace(pointerType.ElementType, namespaces);
+            return;
+        }
+
+        if (typeRef is ByReferenceType byRefType)
+        {
+            AddCecilTypeNamespace(byRefType.ElementType, namespaces);
+            return;
+        }
+
+        if (typeRef is PinnedType pinnedType)
+        {
+            AddCecilTypeNamespace(pinnedType.ElementType, namespaces);
+            return;
+        }
+
+        // Handle generic instances (e.g., List<MyEntity>)
+        if (typeRef is GenericInstanceType genInst)
+        {
+            // Add the generic type definition's namespace
+            AddCecilTypeNamespace(genInst.ElementType, namespaces);
+
+            // Add each generic argument's namespace
+            foreach (var arg in genInst.GenericArguments)
+            {
+                AddCecilTypeNamespace(arg, namespaces);
+            }
+
+            return;
+        }
+
+        // Skip generic parameters (T, TKey, etc.) — they are placeholders
+        if (typeRef is GenericParameter)
+        {
+            return;
+        }
+
+        // Add the namespace
+        var ns = typeRef.Namespace;
+
+        if (!string.IsNullOrEmpty(ns))
+        {
+            namespaces.Add(ns);
+        }
+
+        // For nested types, also add the declaring type's namespace
+        if (typeRef.DeclaringType != null)
+        {
+            AddCecilTypeNamespace(typeRef.DeclaringType, namespaces);
+        }
+    }
+
+    private static bool IsCompilerGenerated(TypeDefinition typeDef)
+    {
+        return typeDef.HasCustomAttributes
+            && typeDef.CustomAttributes.Any(
+                a =>
+                    a.AttributeType.FullName
+                    == "System.Runtime.CompilerServices.CompilerGeneratedAttribute"
+            );
+    }
+}

--- a/Distributed/JAAvila.FluentOperations.Architecture/JAAvila.FluentOperations.Architecture.csproj
+++ b/Distributed/JAAvila.FluentOperations.Architecture/JAAvila.FluentOperations.Architecture.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <PackageIcon>icon.png</PackageIcon>
+    <Authors>JAAvila</Authors>
+    <Description>Mono.Cecil-powered IL-level dependency scanning for JAAvila.FluentOperations architecture testing. Enhances HaveDependencyOn and OnlyHaveDependenciesOn with deep method body analysis: local variables, new calls, typeof(), casts, method calls, field access, and exception handlers.</Description>
+    <PackageId>JAAvila.FluentOperations.Architecture</PackageId>
+    <PackageTags>FluentOperations;Architecture;ArchitectureTests;Mono.Cecil;IL;DependencyScanning</PackageTags>
+    <PackageProjectUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/JAAvila-Of/JAAvila.FluentOperations</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Copyright>Copyright (C) $([System.DateTime]::Now.Year) JAAvila</Copyright>
+    <MinVerTagPrefix>arch-</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JAAvila.FluentOperations\JAAvila.FluentOperations.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="README.md" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <Target Name="SetAssemblyVersion" AfterTargets="MinVer">
+    <PropertyGroup>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</AssemblyVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/Distributed/JAAvila.FluentOperations.Architecture/README.md
+++ b/Distributed/JAAvila.FluentOperations.Architecture/README.md
@@ -1,0 +1,90 @@
+# JAAvila.FluentOperations.Architecture
+
+Mono.Cecil-powered IL-level dependency scanning for [JAAvila.FluentOperations](https://github.com/JAAvila-Of/JAAvila.FluentOperations) architecture tests.
+
+## What it does
+
+This package enhances the `HaveDependencyOn`, `NotHaveDependencyOn`, and `OnlyHaveDependenciesOn` operations with **deep method body analysis** via Mono.Cecil IL inspection.
+
+Without this package, dependency operations use reflection-only scanning (type signatures: fields, properties, constructors, method signatures, base types, interfaces, attributes). This covers ~60% of real-world dependencies.
+
+With this package activated, the scanner also detects dependencies **inside method bodies**:
+
+| Dependency type | Reflection | Cecil |
+|----------------|-----------|-------|
+| Field types, property types, method signatures | YES | YES |
+| Constructor parameters, return types, base types, interfaces | YES | YES |
+| Custom attributes, generic type arguments | YES | YES |
+| **Local variables in method bodies** | NO | YES |
+| **`new SomeType()` in method bodies** | NO | YES |
+| **`typeof(SomeType)` in method bodies** | NO | YES |
+| **Cast expressions (`(T)obj`)** | NO | YES |
+| **`is`/`as` expressions** | NO | YES |
+| **Static and instance method calls** | NO | YES |
+| **Static and instance field access** | NO | YES |
+| **Exception catch types** | NO | YES |
+| **Lambda/closure target types** | NO | YES |
+| **Async state machine dependencies** | NO | YES |
+| **Iterator state machine dependencies** | NO | YES |
+
+## Requirements
+
+- `JAAvila.FluentOperations` (Core)
+- .NET 8.0 or later
+- Mono.Cecil 0.11.6 (included as a dependency)
+
+## Installation
+
+```bash
+dotnet add package JAAvila.FluentOperations.Architecture
+```
+
+## Usage
+
+Call `ArchitectureScannerConfig.UseCecilDependencyScanning()` once in your test setup:
+
+```csharp
+using JAAvila.FluentOperations.Architecture;
+
+[TestFixture]
+public class ArchitectureTests
+{
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        ArchitectureScannerConfig.UseCecilDependencyScanning();
+    }
+
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        ArchitectureScannerConfig.Reset();
+    }
+
+    [Test]
+    public void DomainLayer_ShouldNotDependOnInfrastructure()
+    {
+        // Detects dependencies in method bodies too
+        typeof(DomainService).Test()
+            .NotHaveDependencyOn("MyApp.Infrastructure");
+    }
+
+    [Test]
+    public void DomainLayer_OnlyDependsOnAllowedNamespaces()
+    {
+        // Cecil scanner catches new SqlConnection() inside method bodies
+        typeof(DomainEntity).Test()
+            .OnlyHaveDependenciesOn("MyApp.Domain", "MyApp.SharedKernel");
+    }
+}
+```
+
+No existing test code needs to change. The enhanced scanner is transparent — the same `HaveDependencyOn`, `NotHaveDependencyOn`, and `OnlyHaveDependenciesOn` calls automatically use IL-level detection when Cecil is active.
+
+## Graceful degradation
+
+If an assembly cannot be loaded (dynamic assemblies, single-file apps, NativeAOT), the scanner falls back to reflection-only results. Cecil scanning never makes tests worse — it only makes them more accurate.
+
+## Teardown
+
+Always call `ArchitectureScannerConfig.Reset()` in test teardown to release cached assembly data and restore the default reflection scanner.

--- a/Distributed/JAAvila.FluentOperations/Architecture/DependencyScanner.cs
+++ b/Distributed/JAAvila.FluentOperations/Architecture/DependencyScanner.cs
@@ -1,0 +1,430 @@
+using System.Reflection;
+
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Reflection-based dependency scanner. Scans a <see cref="Type"/> via reflection
+/// to discover all namespaces it depends on.
+/// Inspects: fields, properties, method parameters, method return types,
+/// constructor parameters, base types, interfaces, generic type arguments,
+/// event handler types, and custom attribute types.
+/// </summary>
+/// <remarks>
+/// <para>LIMITATIONS (documented by design):</para>
+/// <list type="bullet">
+///   <item>Does NOT inspect method body IL — local variables, inline <c>new</c> calls,
+///         casts, and typeof() inside method bodies are NOT detected.</item>
+///   <item>Does NOT detect dependencies accessed only through dynamic dispatch or reflection.</item>
+///   <item>Does NOT follow transitive dependencies (only direct type surface).</item>
+/// </list>
+/// For IL-level analysis, install the <c>JAAvila.FluentOperations.Architecture</c> package
+/// and call <c>ArchitectureScannerConfig.UseCecilDependencyScanning()</c>.
+/// </remarks>
+internal sealed class ReflectionDependencyScanner : IDependencyScanner
+{
+    /// <summary>
+    /// The singleton instance of <see cref="ReflectionDependencyScanner"/>.
+    /// </summary>
+    public static readonly ReflectionDependencyScanner Instance = new();
+
+    private ReflectionDependencyScanner() { }
+
+    private const BindingFlags AllMembers =
+        BindingFlags.Public
+        | BindingFlags.NonPublic
+        | BindingFlags.Instance
+        | BindingFlags.Static
+        | BindingFlags.DeclaredOnly;
+
+    /// <summary>
+    /// Returns the set of all namespaces that the given type depends on,
+    /// based on its public API surface and declarations.
+    /// </summary>
+    public HashSet<string> GetReferencedNamespaces(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var namespaces = new HashSet<string>(StringComparer.Ordinal);
+
+        CollectFromBaseType(type, namespaces);
+        CollectFromInterfaces(type, namespaces);
+        CollectFromFields(type, namespaces);
+        CollectFromProperties(type, namespaces);
+        CollectFromConstructors(type, namespaces);
+        CollectFromMethods(type, namespaces);
+        CollectFromEvents(type, namespaces);
+        CollectFromAttributes(type, namespaces);
+
+        // Remove the type's own namespace — a type does not "depend on" itself
+        namespaces.Remove(type.Namespace ?? string.Empty);
+        // NOTE: We do NOT strip System.* by default — the user decides what matters
+
+        return namespaces;
+    }
+
+    /// <summary>
+    /// Checks whether the type has a dependency on ANY namespace that starts
+    /// with the given prefix. Supports both exact match ("MyApp.Domain")
+    /// and prefix match ("MyApp.Domain" matches "MyApp.Domain.Entities").
+    /// </summary>
+    public bool HasDependencyOnNamespace(Type type, string namespacePrefix)
+    {
+        var namespaces = GetReferencedNamespaces(type);
+        return namespaces.Any(
+            ns =>
+                string.Equals(ns, namespacePrefix, StringComparison.Ordinal)
+                || ns.StartsWith(namespacePrefix + ".", StringComparison.Ordinal)
+        );
+    }
+
+    /// <summary>
+    /// Checks whether ALL the type's dependencies fall within the allowed
+    /// namespace list. Each allowed namespace acts as a prefix.
+    /// The type's own namespace is always implicitly allowed.
+    /// System.* and Microsoft.* namespaces are always implicitly allowed (BCL is not a "dependency").
+    /// </summary>
+    public (bool isCompliant, IReadOnlyList<string> violatingNamespaces) CheckOnlyDependenciesOn(
+        Type type,
+        IReadOnlyList<string> allowedNamespaces
+    )
+    {
+        var namespaces = GetReferencedNamespaces(type);
+        var violating = (
+            from ns in namespaces
+            where
+                !ns.StartsWith("System", StringComparison.Ordinal)
+                && !ns.StartsWith("Microsoft", StringComparison.Ordinal)
+            let isAllowed = allowedNamespaces.Any(
+                allowed =>
+                    string.Equals(ns, allowed, StringComparison.Ordinal)
+                    || ns.StartsWith(allowed + ".", StringComparison.Ordinal)
+            )
+            where !isAllowed
+            select ns
+        ).ToList();
+
+        return (violating.Count == 0, violating);
+    }
+
+    /// <summary>
+    /// Returns the set of all fully qualified type names that the given type depends on,
+    /// based on its public API surface and declarations.
+    /// </summary>
+    public HashSet<string> GetReferencedTypes(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        var types = new HashSet<string>(StringComparer.Ordinal);
+
+        CollectTypesFromBaseType(type, types);
+        CollectTypesFromInterfaces(type, types);
+        CollectTypesFromFields(type, types);
+        CollectTypesFromProperties(type, types);
+        CollectTypesFromConstructors(type, types);
+        CollectTypesFromMethods(type, types);
+        CollectTypesFromEvents(type, types);
+        CollectTypesFromAttributes(type, types);
+
+        types.Remove(type.FullName ?? string.Empty);
+        return types;
+    }
+
+    /// <summary>
+    /// Checks whether the type has a dependency on the specific type identified by
+    /// its fully qualified name.
+    /// </summary>
+    public bool HasDependencyOnType(Type type, string fullyQualifiedTypeName)
+    {
+        var referenced = GetReferencedTypes(type);
+        return referenced.Contains(fullyQualifiedTypeName);
+    }
+
+    // --- Private collection methods ---
+
+    private static void CollectFromBaseType(Type type, HashSet<string> namespaces)
+    {
+        var baseType = type.BaseType;
+
+        if (
+            baseType != null
+            && baseType != typeof(object)
+            && baseType != typeof(ValueType)
+            && baseType != typeof(Enum)
+        )
+        {
+            AddTypeNamespace(baseType, namespaces);
+        }
+    }
+
+    private static void CollectFromInterfaces(Type type, HashSet<string> namespaces)
+    {
+        // GetInterfaces() returns ALL interfaces including inherited ones.
+        // For dependency analysis, all interfaces are relevant.
+        foreach (var iface in type.GetInterfaces())
+        {
+            AddTypeNamespace(iface, namespaces);
+        }
+    }
+
+    private static void CollectFromFields(Type type, HashSet<string> namespaces)
+    {
+        foreach (var field in type.GetFields(AllMembers))
+        {
+            AddTypeNamespace(field.FieldType, namespaces);
+        }
+    }
+
+    private static void CollectFromProperties(Type type, HashSet<string> namespaces)
+    {
+        foreach (var prop in type.GetProperties(AllMembers))
+        {
+            AddTypeNamespace(prop.PropertyType, namespaces);
+
+            // Also scan indexer parameters
+            foreach (var param in prop.GetIndexParameters())
+            {
+                AddTypeNamespace(param.ParameterType, namespaces);
+            }
+        }
+    }
+
+    private static void CollectFromConstructors(Type type, HashSet<string> namespaces)
+    {
+        foreach (
+            var param in type.GetConstructors(AllMembers).SelectMany(ctor => ctor.GetParameters())
+        )
+        {
+            AddTypeNamespace(param.ParameterType, namespaces);
+        }
+    }
+
+    private static void CollectFromMethods(Type type, HashSet<string> namespaces)
+    {
+        foreach (var method in type.GetMethods(AllMembers))
+        {
+            // Include return types
+            AddTypeNamespace(method.ReturnType, namespaces);
+            foreach (var param in method.GetParameters())
+            {
+                AddTypeNamespace(param.ParameterType, namespaces);
+            }
+
+            // Generic method type arguments
+            if (!method.IsGenericMethod)
+            {
+                continue;
+            }
+
+            foreach (
+                var constraint in method
+                    .GetGenericArguments()
+                    .SelectMany(genArg => genArg.GetGenericParameterConstraints())
+            )
+            {
+                AddTypeNamespace(constraint, namespaces);
+            }
+        }
+    }
+
+    private static void CollectFromEvents(Type type, HashSet<string> namespaces)
+    {
+        foreach (var evt in type.GetEvents(AllMembers))
+        {
+            if (evt.EventHandlerType != null)
+            {
+                AddTypeNamespace(evt.EventHandlerType, namespaces);
+            }
+        }
+    }
+
+    private static void CollectFromAttributes(Type type, HashSet<string> namespaces)
+    {
+        foreach (var attr in type.GetCustomAttributes(false))
+        {
+            AddTypeNamespace(attr.GetType(), namespaces);
+        }
+    }
+
+    // --- Private collection methods for type-level (FullName) dependency scanning ---
+
+    private static void CollectTypesFromBaseType(Type type, HashSet<string> types)
+    {
+        var baseType = type.BaseType;
+
+        if (
+            baseType != null
+            && baseType != typeof(object)
+            && baseType != typeof(ValueType)
+            && baseType != typeof(Enum)
+        )
+        {
+            AddTypeFullName(baseType, types);
+        }
+    }
+
+    private static void CollectTypesFromInterfaces(Type type, HashSet<string> types)
+    {
+        foreach (var iface in type.GetInterfaces())
+        {
+            AddTypeFullName(iface, types);
+        }
+    }
+
+    private static void CollectTypesFromFields(Type type, HashSet<string> types)
+    {
+        foreach (var field in type.GetFields(AllMembers))
+        {
+            AddTypeFullName(field.FieldType, types);
+        }
+    }
+
+    private static void CollectTypesFromProperties(Type type, HashSet<string> types)
+    {
+        foreach (var prop in type.GetProperties(AllMembers))
+        {
+            AddTypeFullName(prop.PropertyType, types);
+
+            foreach (var param in prop.GetIndexParameters())
+            {
+                AddTypeFullName(param.ParameterType, types);
+            }
+        }
+    }
+
+    private static void CollectTypesFromConstructors(Type type, HashSet<string> types)
+    {
+        foreach (
+            var param in type.GetConstructors(AllMembers).SelectMany(ctor => ctor.GetParameters())
+        )
+        {
+            AddTypeFullName(param.ParameterType, types);
+        }
+    }
+
+    private static void CollectTypesFromMethods(Type type, HashSet<string> types)
+    {
+        foreach (var method in type.GetMethods(AllMembers))
+        {
+            AddTypeFullName(method.ReturnType, types);
+
+            foreach (var param in method.GetParameters())
+            {
+                AddTypeFullName(param.ParameterType, types);
+            }
+
+            if (!method.IsGenericMethod)
+            {
+                continue;
+            }
+
+            foreach (
+                var constraint in method
+                    .GetGenericArguments()
+                    .SelectMany(genArg => genArg.GetGenericParameterConstraints())
+            )
+            {
+                AddTypeFullName(constraint, types);
+            }
+        }
+    }
+
+    private static void CollectTypesFromEvents(Type type, HashSet<string> types)
+    {
+        foreach (var evt in type.GetEvents(AllMembers))
+        {
+            if (evt.EventHandlerType != null)
+            {
+                AddTypeFullName(evt.EventHandlerType, types);
+            }
+        }
+    }
+
+    private static void CollectTypesFromAttributes(Type type, HashSet<string> types)
+    {
+        foreach (var attr in type.GetCustomAttributes(false))
+        {
+            AddTypeFullName(attr.GetType(), types);
+        }
+    }
+
+    /// <summary>
+    /// Adds the fully qualified name of a type and recursively handles generic type arguments,
+    /// arrays, pointers, and by-ref types.
+    /// </summary>
+    private static void AddTypeFullName(Type type, HashSet<string> types)
+    {
+        if (type.IsArray || type.IsByRef || type.IsPointer)
+        {
+            AddTypeFullName(type.GetElementType()!, types);
+            return;
+        }
+
+        if (type.FullName != null)
+        {
+            types.Add(type.FullName);
+        }
+
+        if (!type.IsGenericType)
+        {
+            return;
+        }
+
+        if (!type.IsGenericTypeDefinition)
+        {
+            var genDef = type.GetGenericTypeDefinition();
+
+            if (genDef.FullName != null)
+            {
+                types.Add(genDef.FullName);
+            }
+        }
+
+        foreach (var arg in type.GetGenericArguments().Where(arg => !arg.IsGenericParameter))
+        {
+            AddTypeFullName(arg, types);
+        }
+    }
+
+    /// <summary>
+    /// Adds the namespace of a type and recursively handles generic type arguments,
+    /// arrays, pointers, and by-ref types.
+    /// </summary>
+    private static void AddTypeNamespace(Type type, HashSet<string> namespaces)
+    {
+        // Unwrap an array, pointer, by-ref
+        if (type.IsArray)
+        {
+            AddTypeNamespace(type.GetElementType()!, namespaces);
+            return;
+        }
+
+        if (type.IsByRef || type.IsPointer)
+        {
+            AddTypeNamespace(type.GetElementType()!, namespaces);
+            return;
+        }
+
+        // Add the type's own namespace
+        if (type.Namespace != null)
+        {
+            namespaces.Add(type.Namespace);
+        }
+
+        // Recurse into generic type arguments (e.g., List<MyApp.Domain.Entity>)
+        if (!type.IsGenericType)
+        {
+            return;
+        }
+
+        // Add the generic type definition's namespace
+        if (!type.IsGenericTypeDefinition)
+        {
+            var genDef = type.GetGenericTypeDefinition();
+            if (genDef.Namespace != null)
+                namespaces.Add(genDef.Namespace);
+        }
+
+        foreach (var arg in type.GetGenericArguments().Where(arg => !arg.IsGenericParameter))
+        {
+            AddTypeNamespace(arg, namespaces);
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Architecture/DependencyScannerProvider.cs
+++ b/Distributed/JAAvila.FluentOperations/Architecture/DependencyScannerProvider.cs
@@ -1,0 +1,37 @@
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Static provider that manages the active <see cref="IDependencyScanner"/> instance.
+/// By default, uses the reflection-based <see cref="ReflectionDependencyScanner"/>.
+/// External packages (e.g., JAAvila.FluentOperations.Architecture) can register
+/// an enhanced scanner via <see cref="SetScanner"/>.
+/// </summary>
+public static class DependencyScannerProvider
+{
+    private static IDependencyScanner _scanner = ReflectionDependencyScanner.Instance;
+
+    /// <summary>
+    /// Returns the currently active dependency scanner.
+    /// </summary>
+    public static IDependencyScanner Current => _scanner;
+
+    /// <summary>
+    /// Replaces the active dependency scanner. Used by extension packages
+    /// to provide enhanced scanning capabilities (e.g., IL-level analysis).
+    /// </summary>
+    /// <param name="scanner">The scanner to use. Must not be null.</param>
+    public static void SetScanner(IDependencyScanner scanner)
+    {
+        ArgumentNullException.ThrowIfNull(scanner);
+        _scanner = scanner;
+    }
+
+    /// <summary>
+    /// Resets the scanner to the default reflection-based implementation.
+    /// Intended for test teardown.
+    /// </summary>
+    public static void Reset()
+    {
+        _scanner = ReflectionDependencyScanner.Instance;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Architecture/IDependencyScanner.cs
+++ b/Distributed/JAAvila.FluentOperations/Architecture/IDependencyScanner.cs
@@ -1,0 +1,70 @@
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Contract for dependency scanners that analyze a <see cref="Type"/> and return
+/// the set of namespaces it depends on. Implementations may use reflection,
+/// IL inspection, or other analysis techniques.
+/// </summary>
+/// <remarks>
+/// The default implementation (<see cref="ReflectionDependencyScanner"/>) uses .NET reflection,
+/// which covers type signatures (fields, properties, constructors, methods, base types,
+/// interfaces, attributes, events, generic arguments). For deeper analysis including
+/// method body IL (local variables, inline <c>new</c> calls, casts, <c>typeof</c>),
+/// install the <c>JAAvila.FluentOperations.Architecture</c> package and call
+/// <c>ArchitectureScannerConfig.UseCecilDependencyScanning()</c>.
+/// </remarks>
+public interface IDependencyScanner
+{
+    /// <summary>
+    /// Returns the set of all namespaces that the given type depends on.
+    /// The type's own namespace is excluded from the result.
+    /// </summary>
+    /// <param name="type">The type to scan for dependencies.</param>
+    /// <returns>A set of namespace strings the type depends on.</returns>
+    HashSet<string> GetReferencedNamespaces(Type type);
+
+    /// <summary>
+    /// Checks whether the type has a dependency on any namespace that starts
+    /// with (or exactly matches) the given prefix.
+    /// </summary>
+    /// <param name="type">The type to scan.</param>
+    /// <param name="namespacePrefix">The namespace or namespace prefix to check.</param>
+    /// <returns><c>true</c> if a dependency on the namespace is found.</returns>
+    bool HasDependencyOnNamespace(Type type, string namespacePrefix);
+
+    /// <summary>
+    /// Checks whether all the type's non-BCL dependencies fall within the
+    /// allowed namespace list. Each allowed namespace acts as a prefix.
+    /// The type's own namespace and BCL namespaces (System.*, Microsoft.*) are
+    /// always implicitly allowed.
+    /// </summary>
+    /// <param name="type">The type to scan.</param>
+    /// <param name="allowedNamespaces">The list of allowed namespace prefixes.</param>
+    /// <returns>A tuple: (<c>isCompliant</c>, <c>violatingNamespaces</c>).</returns>
+    (bool isCompliant, IReadOnlyList<string> violatingNamespaces) CheckOnlyDependenciesOn(
+        Type type,
+        IReadOnlyList<string> allowedNamespaces
+    );
+
+    /// <summary>
+    /// Returns the set of all fully qualified type names that the given type depends on.
+    /// Default implementation returns an empty set for backwards compatibility;
+    /// override for precise type-level dependency scanning.
+    /// </summary>
+    /// <param name="type">The type to scan for dependencies.</param>
+    /// <returns>A set of fully qualified type names.</returns>
+    HashSet<string> GetReferencedTypes(Type type) => new HashSet<string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Checks whether the type has a dependency on the specific type identified by
+    /// its fully qualified name (namespace and type name).
+    /// </summary>
+    /// <param name="type">The type to scan.</param>
+    /// <param name="fullyQualifiedTypeName">The fully qualified type name to check for.</param>
+    /// <returns><c>true</c> if the type has a dependency on the specified type.</returns>
+    bool HasDependencyOnType(Type type, string fullyQualifiedTypeName)
+    {
+        var referenced = GetReferencedTypes(type);
+        return referenced.Contains(fullyQualifiedTypeName);
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Architecture/Types.cs
+++ b/Distributed/JAAvila.FluentOperations/Architecture/Types.cs
@@ -1,0 +1,207 @@
+using System.Reflection;
+
+namespace JAAvila.FluentOperations.Architecture;
+
+/// <summary>
+/// Provides static entry points for selecting types from assemblies, enabling architecture test assertions.
+/// Returns <see cref="IEnumerable{Type}"/> that can be piped into <c>.Test()</c> to get a
+/// <c>CollectionOperationsManager&lt;Type&gt;</c> for collection-level assertions, or filtered
+/// with <see cref="That"/> before testing.
+/// </summary>
+/// <example>
+/// <code>
+/// // layer isolation
+/// Types.InAssembly(typeof(Startup).Assembly)
+///     .That(t => t.Namespace?.StartsWith("MyApp.Domain") == true)
+///     .Test()
+///     .AllSatisfy(t => !t.Namespace?.Contains("Infrastructure") == true);
+///
+/// // Naming convention enforcement
+/// Types.InNamespace("MyApp.Controllers")
+///     .Test()
+///     .AllSatisfy(t => t.Name.EndsWith("Controller"));
+/// </code>
+/// </example>
+public static class Types
+{
+    /// <summary>
+    /// Returns all exported (public) types defined in the specified assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan for types.</param>
+    /// <returns>An enumerable of all exported types in the assembly.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assembly"/> is null.</exception>
+    /// <remarks>
+    /// Uses <see cref="Assembly.GetExportedTypes()"/> which returns only publicly visible types.
+    /// For assemblies that contain types with unresolvable dependencies, consider using
+    /// <see cref="InAssemblySafe(Assembly)"/> which handles <see cref="ReflectionTypeLoadException"/>.
+    /// </remarks>
+    public static IEnumerable<Type> InAssembly(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return assembly.GetExportedTypes();
+    }
+
+    /// <summary>
+    /// Returns all exported (public) types in the assembly that match the predicate.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan for types.</param>
+    /// <param name="predicate">A filter applied to each type.</param>
+    /// <returns>An enumerable of matching types.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assembly"/> or <paramref name="predicate"/> is null.</exception>
+    public static IEnumerable<Type> InAssembly(Assembly assembly, Func<Type, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(predicate);
+        return assembly.GetExportedTypes().Where(predicate);
+    }
+
+    /// <summary>
+    /// Returns all types in the assembly, safely handling <see cref="ReflectionTypeLoadException"/>.
+    /// Types that fail to load are silently excluded from the result.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan for types.</param>
+    /// <returns>An enumerable of all loadable types in the assembly.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assembly"/> is null.</exception>
+    public static IEnumerable<Type> InAssemblySafe(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t != null)!;
+        }
+    }
+
+    /// <summary>
+    /// Returns all exported types from all assemblies loaded in the current <see cref="AppDomain"/>
+    /// that reside in the specified namespace (exact match).
+    /// </summary>
+    /// <param name="ns">The namespace to filter by (exact match).</param>
+    /// <returns>An enumerable of types in the specified namespace.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ns"/> is null.</exception>
+    /// <remarks>
+    /// Scans <see cref="AppDomain.CurrentDomain"/> loaded assemblies. Types from dynamic assemblies
+    /// or assemblies that throw on <c>GetExportedTypes()</c> are silently skipped.
+    /// </remarks>
+    public static IEnumerable<Type> InNamespace(string ns)
+    {
+        ArgumentNullException.ThrowIfNull(ns);
+
+        return AppDomain
+            .CurrentDomain.GetAssemblies()
+            .SelectMany(SafeGetExportedTypes)
+            .Where(t => string.Equals(t.Namespace, ns, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Returns all exported types that share the same namespace as <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">A type whose namespace is used as the filter.</typeparam>
+    /// <returns>An enumerable of types in the same namespace as <typeparamref name="T"/>.</returns>
+    public static IEnumerable<Type> InNamespaceOf<T>()
+    {
+        var ns = typeof(T).Namespace;
+
+        return ns is null ? [] : InNamespace(ns);
+    }
+
+    /// <summary>
+    /// Returns all exported types from all assemblies in the current <see cref="AppDomain"/>.
+    /// </summary>
+    /// <returns>An enumerable of all exported types in the current domain.</returns>
+    /// <remarks>
+    /// May return a large number of types. Consider filtering with <see cref="That"/> before calling <c>.Test()</c>.
+    /// </remarks>
+    public static IEnumerable<Type> InCurrentDomain()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies().SelectMany(SafeGetExportedTypes);
+    }
+
+    /// <summary>
+    /// Returns all exported (public) types defined in any of the specified assemblies.
+    /// Duplicate types across assemblies are included only once (by reference equality).
+    /// </summary>
+    /// <param name="assemblies">The assemblies to scan for types.</param>
+    /// <returns>A distinct enumerable of all exported types across all assemblies.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assemblies"/> is null.</exception>
+    public static IEnumerable<Type> InAssemblies(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+        return assemblies.SelectMany(a => a.GetExportedTypes()).Distinct();
+    }
+
+    /// <summary>
+    /// Returns all exported (public) types defined in any of the specified assemblies
+    /// that match the predicate.
+    /// </summary>
+    /// <param name="assemblies">The assemblies to scan for types.</param>
+    /// <param name="predicate">A filter applied to each type.</param>
+    /// <returns>A distinct, filtered enumerable of types.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assemblies"/> or <paramref name="predicate"/> is null.</exception>
+    public static IEnumerable<Type> InAssemblies(Assembly[] assemblies, Func<Type, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+        ArgumentNullException.ThrowIfNull(predicate);
+        return assemblies.SelectMany(a => a.GetExportedTypes()).Distinct().Where(predicate);
+    }
+
+    /// <summary>
+    /// Returns all loadable types from any of the specified assemblies, safely handling
+    /// <see cref="ReflectionTypeLoadException"/>.
+    /// </summary>
+    /// <param name="assemblies">The assemblies to scan.</param>
+    /// <returns>A distinct enumerable of all loadable types.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assemblies"/> is null.</exception>
+    public static IEnumerable<Type> InAssembliesSafe(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+        return assemblies.SelectMany(SafeGetExportedTypes).Distinct();
+    }
+
+    /// <summary>
+    /// Alias for <see cref="InAssembly(Assembly)"/>. Returns all exported types in the assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan.</param>
+    /// <returns>An enumerable of all exported types.</returns>
+    public static IEnumerable<Type> In(Assembly assembly) => InAssembly(assembly);
+
+    /// <summary>
+    /// Filters an enumerable of types by the specified predicate.
+    /// This is an extension method that enables fluent chaining: <c>Types.InAssembly(asm).That(filter)</c>.
+    /// </summary>
+    /// <param name="types">The source type collection.</param>
+    /// <param name="predicate">The filter predicate.</param>
+    /// <returns>A filtered enumerable of types.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="types"/> or <paramref name="predicate"/> is null.</exception>
+    public static IEnumerable<Type> That(this IEnumerable<Type> types, Func<Type, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+        ArgumentNullException.ThrowIfNull(predicate);
+        return types.Where(predicate);
+    }
+
+    /// <summary>
+    /// Safely gets exported types from an assembly, returning an empty array
+    /// if the assembly is dynamic or throws on <c>GetExportedTypes()</c>.
+    /// </summary>
+    private static Type[] SafeGetExportedTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.IsDynamic ? [] : assembly.GetExportedTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(t => t != null).ToArray()!;
+        }
+        catch (NotSupportedException)
+        {
+            // Dynamic assemblies may throw NotSupportedException
+            return [];
+        }
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/AssemblyInfo.cs
+++ b/Distributed/JAAvila.FluentOperations/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Allow the Architecture package to access internal types (e.g., ReflectionDependencyScanner)
+// needed to implement the Cecil scanner that extends the Core scanner.
+[assembly: InternalsVisibleTo("JAAvila.FluentOperations.Architecture")]

--- a/Distributed/JAAvila.FluentOperations/Common/MessageKeys.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/MessageKeys.cs
@@ -46,6 +46,25 @@ public static class MessageKeys
         public const string HaveLengthLessThan = "Array.HaveLengthLessThan";
     }
 
+    /// <summary>Keys for <c>Assembly</c> (reflection) operations.</summary>
+    public static class Assembly
+    {
+        /// <summary>Asserts that the assembly contains the specified type.</summary>
+        public const string ContainType = "Assembly.ContainType";
+        /// <summary>Asserts that the assembly contains a type matching the regex pattern.</summary>
+        public const string ContainTypeMatching = "Assembly.ContainTypeMatching";
+        /// <summary>Asserts that the assembly version is at least the specified minimum.</summary>
+        public const string HaveMinimumVersion = "Assembly.HaveMinimumVersion";
+        /// <summary>Asserts that the assembly is strong-named (has a public key).</summary>
+        public const string HavePublicKey = "Assembly.HavePublicKey";
+        /// <summary>Asserts that the assembly version matches the expected version.</summary>
+        public const string HaveVersion = "Assembly.HaveVersion";
+        /// <summary>Asserts that the assembly does not reference the named assembly.</summary>
+        public const string NotReferenceAssembly = "Assembly.NotReferenceAssembly";
+        /// <summary>Asserts that the assembly has a reference to the named assembly.</summary>
+        public const string ReferenceAssembly = "Assembly.ReferenceAssembly";
+    }
+
     /// <summary>Keys for <c>Boolean</c> operations.</summary>
     public static class Boolean
     {
@@ -1812,6 +1831,137 @@ public static class MessageKeys
         public const string NotBeInRange = "UShort.NotBeInRange";
         /// <summary>Asserts that the value is none of the specified disallowed values.</summary>
         public const string NotBeOneOf = "UShort.NotBeOneOf";
+    }
+
+    /// <summary>Keys for <c>Type</c> (reflection) operations.</summary>
+    public static class ReflectedType
+    {
+        /// <summary>Asserts that the type is abstract (and not an interface).</summary>
+        public const string BeAbstract = "ReflectedType.BeAbstract";
+        /// <summary>Asserts that the type is a class (not interface, not value type).</summary>
+        public const string BeClass = "ReflectedType.BeClass";
+        /// <summary>Asserts that the type is an enum.</summary>
+        public const string BeEnum = "ReflectedType.BeEnum";
+        /// <summary>Asserts that the type is generic.</summary>
+        public const string BeGeneric = "ReflectedType.BeGeneric";
+        /// <summary>Asserts that the type is immutable.</summary>
+        public const string BeImmutable = "ReflectedType.BeImmutable";
+        /// <summary>Asserts that the type resides in the specified namespace.</summary>
+        public const string BeInNamespace = "ReflectedType.BeInNamespace";
+        /// <summary>Asserts that the type resides in a namespace starting with the specified prefix.</summary>
+        public const string BeInNamespaceStartingWith = "ReflectedType.BeInNamespaceStartingWith";
+        /// <summary>Asserts that the type is an interface.</summary>
+        public const string BeInterface = "ReflectedType.BeInterface";
+        /// <summary>Asserts that the type is internal (not public).</summary>
+        public const string BeInternal = "ReflectedType.BeInternal";
+        /// <summary>Asserts that the type is nested inside another type.</summary>
+        public const string BeNested = "ReflectedType.BeNested";
+        /// <summary>Asserts that the type is public.</summary>
+        public const string BePublic = "ReflectedType.BePublic";
+        /// <summary>Asserts that the type is a record.</summary>
+        public const string BeRecord = "ReflectedType.BeRecord";
+        /// <summary>Asserts that the type is sealed.</summary>
+        public const string BeSealed = "ReflectedType.BeSealed";
+        /// <summary>Asserts that the type is static (abstract + sealed).</summary>
+        public const string BeStatic = "ReflectedType.BeStatic";
+        /// <summary>Asserts that the type is a value type.</summary>
+        public const string BeValueType = "ReflectedType.BeValueType";
+        /// <summary>Asserts that the type derives from the specified base type.</summary>
+        public const string DeriveFrom = "ReflectedType.DeriveFrom";
+        /// <summary>Asserts that the type has the specified custom attribute.</summary>
+        public const string HaveAttribute = "ReflectedType.HaveAttribute";
+        /// <summary>Asserts that the type has a constructor with the specified parameters.</summary>
+        public const string HaveConstructorWithParameters = "ReflectedType.HaveConstructorWithParameters";
+        /// <summary>Asserts that the type has a dependency on the specified namespace.</summary>
+        public const string HaveDependencyOn = "ReflectedType.HaveDependencyOn";
+        /// <summary>Asserts that the type has a method with the specified return type.</summary>
+        public const string HaveMethodReturning = "ReflectedType.HaveMethodReturning";
+        /// <summary>Asserts that the type has the specified name.</summary>
+        public const string HaveName = "ReflectedType.HaveName";
+        /// <summary>Asserts that the type name ends with the specified suffix.</summary>
+        public const string HaveNameEndingWith = "ReflectedType.HaveNameEndingWith";
+        /// <summary>Asserts that the type name starts with the specified prefix.</summary>
+        public const string HaveNameStartingWith = "ReflectedType.HaveNameStartingWith";
+        /// <summary>Asserts that the type has a named property of the specified type.</summary>
+        public const string HavePropertyOfType = "ReflectedType.HavePropertyOfType";
+        /// <summary>Asserts that the type has at least one public constructor.</summary>
+        public const string HavePublicConstructor = "ReflectedType.HavePublicConstructor";
+        /// <summary>Asserts that the type implements the specified interface.</summary>
+        public const string ImplementInterface = "ReflectedType.ImplementInterface";
+        /// <summary>Asserts that the type name matches the specified regex.</summary>
+        public const string MatchName = "ReflectedType.MatchName";
+        /// <summary>Asserts that the type namespace matches the specified regex.</summary>
+        public const string MatchNamespace = "ReflectedType.MatchNamespace";
+
+        // --- Negated ---
+        /// <summary>Asserts that the type is NOT abstract.</summary>
+        public const string NotBeAbstract = "ReflectedType.NotBeAbstract";
+        /// <summary>Asserts that the type is NOT a class.</summary>
+        public const string NotBeClass = "ReflectedType.NotBeClass";
+        /// <summary>Asserts that the type is NOT generic.</summary>
+        public const string NotBeGeneric = "ReflectedType.NotBeGeneric";
+        /// <summary>Asserts that the type is NOT immutable.</summary>
+        public const string NotBeImmutable = "ReflectedType.NotBeImmutable";
+        /// <summary>Asserts that the type is NOT in the specified namespace.</summary>
+        public const string NotBeInNamespace = "ReflectedType.NotBeInNamespace";
+        /// <summary>Asserts that the type is NOT internal.</summary>
+        public const string NotBeInternal = "ReflectedType.NotBeInternal";
+        /// <summary>Asserts that the type is NOT an interface.</summary>
+        public const string NotBeInterface = "ReflectedType.NotBeInterface";
+        /// <summary>Asserts that the type is NOT public.</summary>
+        public const string NotBePublic = "ReflectedType.NotBePublic";
+        /// <summary>Asserts that the type is NOT sealed.</summary>
+        public const string NotBeSealed = "ReflectedType.NotBeSealed";
+        /// <summary>Asserts that the type is NOT static.</summary>
+        public const string NotBeStatic = "ReflectedType.NotBeStatic";
+        /// <summary>Asserts that the type does NOT derive from the specified base type.</summary>
+        public const string NotDeriveFrom = "ReflectedType.NotDeriveFrom";
+        /// <summary>Asserts that the type does NOT have the specified attribute.</summary>
+        public const string NotHaveAttribute = "ReflectedType.NotHaveAttribute";
+        /// <summary>Asserts that the type does NOT have a dependency on the specified namespace.</summary>
+        public const string NotHaveDependencyOn = "ReflectedType.NotHaveDependencyOn";
+        /// <summary>Asserts that the type does NOT have the specified name.</summary>
+        public const string NotHaveName = "ReflectedType.NotHaveName";
+        /// <summary>Asserts that the type name does NOT end with the specified suffix.</summary>
+        public const string NotHaveNameEndingWith = "ReflectedType.NotHaveNameEndingWith";
+        /// <summary>Asserts that the type name does NOT start with the specified prefix.</summary>
+        public const string NotHaveNameStartingWith = "ReflectedType.NotHaveNameStartingWith";
+        /// <summary>Asserts that the type does NOT implement the specified interface.</summary>
+        public const string NotImplementInterface = "ReflectedType.NotImplementInterface";
+        /// <summary>Asserts that the type only has dependencies on the specified namespaces.</summary>
+        public const string OnlyHaveDependenciesOn = "ReflectedType.OnlyHaveDependenciesOn";
+        /// <summary>Asserts that the type has a dependency on at least one of the specified namespaces.</summary>
+        public const string HaveDependencyOnAny = "ReflectedType.HaveDependencyOnAny";
+        /// <summary>Asserts that the type does NOT have a dependency on any of the specified namespaces.</summary>
+        public const string NotHaveDependencyOnAny = "ReflectedType.NotHaveDependencyOnAny";
+        /// <summary>Asserts that the type has no public constructors.</summary>
+        public const string NotHavePublicConstructor = "ReflectedType.NotHavePublicConstructor";
+        /// <summary>Asserts that the type has async void methods.</summary>
+        public const string HaveAsyncVoidMethods = "ReflectedType.HaveAsyncVoidMethods";
+        /// <summary>Asserts that the type does not have async void methods.</summary>
+        public const string NotHaveAsyncVoidMethods = "ReflectedType.NotHaveAsyncVoidMethods";
+        /// <summary>Asserts that the type overrides the specified method.</summary>
+        public const string HaveMethodOverride = "ReflectedType.HaveMethodOverride";
+        /// <summary>Asserts that the type does NOT override the specified method.</summary>
+        public const string NotHaveMethodOverride = "ReflectedType.NotHaveMethodOverride";
+        /// <summary>Asserts that the type has at least one protected member.</summary>
+        public const string HaveProtectedMembers = "ReflectedType.HaveProtectedMembers";
+        /// <summary>Asserts that the type has no protected members.</summary>
+        public const string NotHaveProtectedMembers = "ReflectedType.NotHaveProtectedMembers";
+        /// <summary>Asserts that the type has at most N public methods.</summary>
+        public const string HaveMaxPublicMethods = "ReflectedType.HaveMaxPublicMethods";
+        /// <summary>Asserts that the type has at most N fields.</summary>
+        public const string HaveMaxFields = "ReflectedType.HaveMaxFields";
+        /// <summary>Asserts that at least one public method returns a type from the specified namespace.</summary>
+        public const string ReturnTypesFromNamespace = "ReflectedType.ReturnTypesFromNamespace";
+        /// <summary>Asserts that no public methods return types from the specified namespace.</summary>
+        public const string NotReturnTypesFromNamespace = "ReflectedType.NotReturnTypesFromNamespace";
+        /// <summary>Asserts that the type has a private constructor with specified parameter types.</summary>
+        public const string HavePrivateConstructorWithParameters = "ReflectedType.HavePrivateConstructorWithParameters";
+        /// <summary>Asserts that the type has a dependency on the specified type (by fully qualified name).</summary>
+        public const string HaveDependencyOnType = "ReflectedType.HaveDependencyOnType";
+        /// <summary>Asserts that the type does NOT have a dependency on the specified type.</summary>
+        public const string NotHaveDependencyOnType = "ReflectedType.NotHaveDependencyOnType";
     }
 
     /// <summary>Keys for <c>Uri</c> operations.</summary>

--- a/Distributed/JAAvila.FluentOperations/Common/Operations.cs
+++ b/Distributed/JAAvila.FluentOperations/Common/Operations.cs
@@ -2965,4 +2965,300 @@ public struct Operations
         [EnumStringValue("consumememorygreaterthan")]
         ConsumeMemoryGreaterThan,
     }
+
+    /// <summary>
+    /// <summary>
+    /// Operations available for <see cref="System.Reflection.Assembly"/> values,
+    /// covering type containment, references, versioning, and strong naming checks.
+    /// </summary>
+    public enum Assembly
+    {
+        /// <summary>Asserts that the assembly contains the specified type.</summary>
+        [EnumStringValue("containtype")]
+        ContainType,
+
+        /// <summary>Asserts that the assembly contains a type whose full name matches the regex pattern.</summary>
+        [EnumStringValue("containtypematching")]
+        ContainTypeMatching,
+
+        /// <summary>Asserts that the assembly has a reference to the named assembly.</summary>
+        [EnumStringValue("referenceassembly")]
+        ReferenceAssembly,
+
+        /// <summary>Asserts that the assembly does not reference the named assembly.</summary>
+        [EnumStringValue("notreferenceassembly")]
+        NotReferenceAssembly,
+
+        /// <summary>Asserts that the assembly version matches the expected version.</summary>
+        [EnumStringValue("haveversion")]
+        HaveVersion,
+
+        /// <summary>Asserts that the assembly version is at least the specified minimum.</summary>
+        [EnumStringValue("haveminimumversion")]
+        HaveMinimumVersion,
+
+        /// <summary>Asserts that the assembly is strong-named (has a public key).</summary>
+        [EnumStringValue("havepublickey")]
+        HavePublicKey,
+    }
+
+    /// <summary>
+    /// Defines a set of reflection-based type operations as enum values.
+    /// Each value represents a specific condition or characteristic related
+    /// to types that can be evaluated, matched, or asserted in the context
+    /// of fluent operations. Enum values are associated with string representations
+    /// via attributes to facilitate easier identification and configuration.
+    /// </summary>
+    public enum ReflectedType
+    {
+        /// <summary>Asserts that the type is abstract (and not an interface).</summary>
+        [EnumStringValue("beabstract")]
+        BeAbstract,
+
+        /// <summary>Asserts that the type is a class (not interface, not value type).</summary>
+        [EnumStringValue("beclass")]
+        BeClass,
+
+        /// <summary>Asserts that the type is an enum.</summary>
+        [EnumStringValue("beenum")]
+        BeEnum,
+
+        /// <summary>Asserts that the type is generic.</summary>
+        [EnumStringValue("begeneric")]
+        BeGeneric,
+
+        /// <summary>Asserts that the type is immutable (no settable public properties, no public mutable fields).</summary>
+        [EnumStringValue("beimmutable")]
+        BeImmutable,
+
+        /// <summary>Asserts that the type resides in the specified namespace.</summary>
+        [EnumStringValue("beinnamespace")]
+        BeInNamespace,
+
+        /// <summary>Asserts that the type resides in a namespace starting with the specified prefix.</summary>
+        [EnumStringValue("beinnamespacestartingwith")]
+        BeInNamespaceStartingWith,
+
+        /// <summary>Asserts that the type is an interface.</summary>
+        [EnumStringValue("beinterface")]
+        BeInterface,
+
+        /// <summary>Asserts that the type is internal (not public).</summary>
+        [EnumStringValue("beinternal")]
+        BeInternal,
+
+        /// <summary>Asserts that the type is nested inside another type.</summary>
+        [EnumStringValue("benested")]
+        BeNested,
+
+        /// <summary>Asserts that the type is public.</summary>
+        [EnumStringValue("bepublic")]
+        BePublic,
+
+        /// <summary>Asserts that the type is a record (class or struct).</summary>
+        [EnumStringValue("berecord")]
+        BeRecord,
+
+        /// <summary>Asserts that the type is sealed.</summary>
+        [EnumStringValue("besealed")]
+        BeSealed,
+
+        /// <summary>Asserts that the type is static (abstract + sealed).</summary>
+        [EnumStringValue("bestatic")]
+        BeStatic,
+
+        /// <summary>Asserts that the type is a value type.</summary>
+        [EnumStringValue("bevaluetype")]
+        BeValueType,
+
+        /// <summary>Asserts that the type derives from the specified base type.</summary>
+        [EnumStringValue("derivefrom")]
+        DeriveFrom,
+
+        /// <summary>Asserts that the type has the specified custom attribute.</summary>
+        [EnumStringValue("haveattribute")]
+        HaveAttribute,
+
+        /// <summary>Asserts that the type has a constructor with the specified parameter types.</summary>
+        [EnumStringValue("haveconstructorwithparameters")]
+        HaveConstructorWithParameters,
+
+        /// <summary>Asserts that the type has a dependency on the specified namespace.</summary>
+        [EnumStringValue("havedependencyon")]
+        HaveDependencyOn,
+
+        /// <summary>Asserts that the type has a method with the specified name and return type.</summary>
+        [EnumStringValue("havemethodreturning")]
+        HaveMethodReturning,
+
+        /// <summary>Asserts that the type has the specified name.</summary>
+        [EnumStringValue("havename")]
+        HaveName,
+
+        /// <summary>Asserts that the type name ends with the specified suffix.</summary>
+        [EnumStringValue("havenameendingwith")]
+        HaveNameEndingWith,
+
+        /// <summary>Asserts that the type name starts with the specified prefix.</summary>
+        [EnumStringValue("havenamestartingwith")]
+        HaveNameStartingWith,
+
+        /// <summary>Asserts that the type has a named property of the specified type.</summary>
+        [EnumStringValue("havepropertyoftype")]
+        HavePropertyOfType,
+
+        /// <summary>Asserts that the type has at least one public constructor.</summary>
+        [EnumStringValue("havepublicconstructor")]
+        HavePublicConstructor,
+
+        /// <summary>Asserts that the type implements the specified interface.</summary>
+        [EnumStringValue("implementinterface")]
+        ImplementInterface,
+
+        /// <summary>Asserts that the type name matches the specified regex pattern.</summary>
+        [EnumStringValue("matchname")]
+        MatchName,
+
+        /// <summary>Asserts that the type namespace matches the specified regex pattern.</summary>
+        [EnumStringValue("matchnamespace")]
+        MatchNamespace,
+
+        // --- Negated operations ---
+
+        /// <summary>Asserts that the type is NOT abstract.</summary>
+        [EnumStringValue("notbeabstract")]
+        NotBeAbstract,
+
+        /// <summary>Asserts that the type is NOT a class.</summary>
+        [EnumStringValue("notbeclass")]
+        NotBeClass,
+
+        /// <summary>Asserts that the type is NOT generic.</summary>
+        [EnumStringValue("notbegeneric")]
+        NotBeGeneric,
+
+        /// <summary>Asserts that the type is NOT immutable.</summary>
+        [EnumStringValue("notbeimmutable")]
+        NotBeImmutable,
+
+        /// <summary>Asserts that the type is NOT in the specified namespace.</summary>
+        [EnumStringValue("notbeinnamespace")]
+        NotBeInNamespace,
+
+        /// <summary>Asserts that the type is NOT internal.</summary>
+        [EnumStringValue("notbeinternal")]
+        NotBeInternal,
+
+        /// <summary>Asserts that the type is NOT an interface.</summary>
+        [EnumStringValue("notbeinterface")]
+        NotBeInterface,
+
+        /// <summary>Asserts that the type is NOT public.</summary>
+        [EnumStringValue("notbepublic")]
+        NotBePublic,
+
+        /// <summary>Asserts that the type is NOT sealed.</summary>
+        [EnumStringValue("notbesealed")]
+        NotBeSealed,
+
+        /// <summary>Asserts that the type is NOT static.</summary>
+        [EnumStringValue("notbestatic")]
+        NotBeStatic,
+
+        /// <summary>Asserts that the type does NOT derive from the specified base type.</summary>
+        [EnumStringValue("notderivefrom")]
+        NotDeriveFrom,
+
+        /// <summary>Asserts that the type does NOT have the specified custom attribute.</summary>
+        [EnumStringValue("nothaveattribute")]
+        NotHaveAttribute,
+
+        /// <summary>Asserts that the type does NOT have a dependency on the specified namespace.</summary>
+        [EnumStringValue("nothavedependencyon")]
+        NotHaveDependencyOn,
+
+        /// <summary>Asserts that the type does NOT have the specified name.</summary>
+        [EnumStringValue("nothavename")]
+        NotHaveName,
+
+        /// <summary>Asserts that the type name does NOT end with the specified suffix.</summary>
+        [EnumStringValue("nothavenameendingwith")]
+        NotHaveNameEndingWith,
+
+        /// <summary>Asserts that the type name does NOT start with the specified prefix.</summary>
+        [EnumStringValue("nothavenamestartingwith")]
+        NotHaveNameStartingWith,
+
+        /// <summary>Asserts that the type does NOT implement the specified interface.</summary>
+        [EnumStringValue("notimplementinterface")]
+        NotImplementInterface,
+
+        /// <summary>Asserts that the type only has dependencies on the allowed namespaces.</summary>
+        [EnumStringValue("onlyhavedependencieson")]
+        OnlyHaveDependenciesOn,
+
+        /// <summary>Asserts that the type has a dependency on at least one of the specified namespaces.</summary>
+        [EnumStringValue("havedependencyonany")]
+        HaveDependencyOnAny,
+
+        /// <summary>Asserts that the type does NOT have a dependency on any of the specified namespaces.</summary>
+        [EnumStringValue("nothavedependencyonany")]
+        NotHaveDependencyOnAny,
+
+        /// <summary>Asserts that the type has NO public constructors.</summary>
+        [EnumStringValue("nothavepublicconstructor")]
+        NotHavePublicConstructor,
+
+        /// <summary>Asserts that the type has at least one async void method.</summary>
+        [EnumStringValue("haveasyncvoidmethods")]
+        HaveAsyncVoidMethods,
+
+        /// <summary>Asserts that the type does NOT have any async void methods.</summary>
+        [EnumStringValue("nothaveasyncvoidmethods")]
+        NotHaveAsyncVoidMethods,
+
+        /// <summary>Asserts that the type overrides the specified method.</summary>
+        [EnumStringValue("havemethodoverride")]
+        HaveMethodOverride,
+
+        /// <summary>Asserts that the type does NOT override the specified method.</summary>
+        [EnumStringValue("nothavemethodoverride")]
+        NotHaveMethodOverride,
+
+        /// <summary>Asserts that the type has at least one protected member.</summary>
+        [EnumStringValue("haveprotectedmembers")]
+        HaveProtectedMembers,
+
+        /// <summary>Asserts that the type does NOT have any protected members.</summary>
+        [EnumStringValue("nothaveprotectedmembers")]
+        NotHaveProtectedMembers,
+
+        /// <summary>Asserts that the type has at most N public methods.</summary>
+        [EnumStringValue("havemaxpublicmethods")]
+        HaveMaxPublicMethods,
+
+        /// <summary>Asserts that the type has at most N fields.</summary>
+        [EnumStringValue("havemaxfields")]
+        HaveMaxFields,
+
+        /// <summary>Asserts that at least one public method returns a type from the specified namespace.</summary>
+        [EnumStringValue("returntypesfromnamespace")]
+        ReturnTypesFromNamespace,
+
+        /// <summary>Asserts that NO public methods return types from the specified namespace.</summary>
+        [EnumStringValue("notreturntypesfromnamespace")]
+        NotReturnTypesFromNamespace,
+
+        /// <summary>Asserts that the type has a private constructor with the specified parameter types.</summary>
+        [EnumStringValue("haveprivateconstructorwithparameters")]
+        HavePrivateConstructorWithParameters,
+
+        /// <summary>Asserts that the type has a dependency on the specified type (by fully qualified name).</summary>
+        [EnumStringValue("havedependencyontype")]
+        HaveDependencyOnType,
+
+        /// <summary>Asserts that the type does NOT have a dependency on the specified type.</summary>
+        [EnumStringValue("nothavedependencyontype")]
+        NotHaveDependencyOnType,
+    }
 }

--- a/Distributed/JAAvila.FluentOperations/Manager/AssemblyOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/AssemblyOperationsManager.cs
@@ -1,0 +1,366 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <see cref="Assembly"/> values.
+/// Supports type containment, assembly reference checks, versioning, and strong-naming assertions.
+/// </summary>
+public class AssemblyOperationsManager
+    : BaseOperationsManager<AssemblyOperationsManager, Assembly?>,
+        ITestManager<AssemblyOperationsManager, Assembly?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<Assembly?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public AssemblyOperationsManager(Assembly? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<Assembly?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        base.SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the assembly contains the specified type.
+    /// </summary>
+    /// <typeparam name="TExpected">The type that the assembly is expected to contain.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager ContainType<TExpected>(Reason? reason = null) =>
+        ContainType(typeof(TExpected), reason);
+
+    /// <summary>
+    /// Asserts that the assembly contains the specified type.
+    /// </summary>
+    /// <param name="expectedType">The type that the assembly is expected to contain.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager ContainType(Type expectedType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.ContainType))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyContainTypeValidator.New(PrincipalChain, expectedType))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedType.FullName ?? expectedType.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(ContainType)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly contains a type whose full name matches the specified regex pattern.
+    /// </summary>
+    /// <param name="pattern">The regular expression pattern to match against type full names.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager ContainTypeMatching(string pattern, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.ContainTypeMatching))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyContainTypeMatchingValidator.New(PrincipalChain, pattern))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation, pattern)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(ContainTypeMatching)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        pattern.IsNull(),
+                        Fail.New(
+                            $"The {nameof(ContainTypeMatching)} operation failed because the pattern was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly has a reference to the named assembly.
+    /// </summary>
+    /// <param name="assemblyName">The name of the referenced assembly.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager ReferenceAssembly(string assemblyName, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.ReferenceAssembly))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyReferenceAssemblyValidator.New(PrincipalChain, assemblyName))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation, assemblyName)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(ReferenceAssembly)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        assemblyName.IsNull(),
+                        Fail.New(
+                            $"The {nameof(ReferenceAssembly)} operation failed because the assembly name was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly does NOT reference the named assembly.
+    /// </summary>
+    /// <param name="assemblyName">The name of the assembly that must not be referenced.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager NotReferenceAssembly(
+        string assemblyName,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.NotReferenceAssembly))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyNotReferenceAssemblyValidator.New(PrincipalChain, assemblyName))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation, assemblyName)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotReferenceAssembly)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        assemblyName.IsNull(),
+                        Fail.New(
+                            $"The {nameof(NotReferenceAssembly)} operation failed because the assembly name was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly version matches the expected version exactly.
+    /// </summary>
+    /// <param name="expectedVersion">The exact version the assembly is expected to have.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager HaveVersion(Version expectedVersion, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.HaveVersion))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyHaveVersionValidator.New(PrincipalChain, expectedVersion))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedVersion.ToString(),
+                            PrincipalChain.GetValue()!.GetName().Version?.ToString() ?? "<null>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveVersion)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        expectedVersion.IsNull(),
+                        Fail.New(
+                            $"The {nameof(HaveVersion)} operation failed because the expected version was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly version is at least the specified minimum.
+    /// </summary>
+    /// <param name="minimumVersion">The minimum version the assembly must have.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager HaveMinimumVersion(
+        Version minimumVersion,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.HaveMinimumVersion))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyHaveMinimumVersionValidator.New(PrincipalChain, minimumVersion))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            minimumVersion.ToString(),
+                            PrincipalChain.GetValue()!.GetName().Version?.ToString() ?? "<null>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveMinimumVersion)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .FailIf(
+                _ =>
+                    (
+                        minimumVersion.IsNull(),
+                        Fail.New(
+                            $"The {nameof(HaveMinimumVersion)} operation failed because the minimum version was <null>."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the assembly is strong-named (has a public key).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public AssemblyOperationsManager HavePublicKey(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.Assembly.HavePublicKey))
+        {
+            return this;
+        }
+
+        ExecutionEngine<AssemblyOperationsManager, Assembly?>
+            .New(this)
+            .WithOperation(AssemblyHavePublicKeyValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HavePublicKey)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Manager/TypeOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/TypeOperationsManager.cs
@@ -1,0 +1,2685 @@
+using JAAvila.FluentOperations.Common;
+using JAAvila.FluentOperations.Config;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.FluentOperations.Model;
+using JAAvila.FluentOperations.Utils;
+using JAAvila.FluentOperations.Validators;
+
+namespace JAAvila.FluentOperations.Manager;
+
+/// <summary>
+/// Provides fluent validation operations for <see cref="Type"/> values.
+/// Supports type classification, inheritance checks, attribute detection, naming, and namespace assertions.
+/// </summary>
+public class TypeOperationsManager
+    : BaseOperationsManager<TypeOperationsManager, Type?>,
+        ITestManager<TypeOperationsManager, Type?>
+{
+    /// <inheritdoc />
+    public PrincipalChain<Type?> PrincipalChain { get; }
+
+    /// <summary>
+    /// Initializes a new instance for testing the specified value.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <param name="caller">The caller expression name, captured automatically.</param>
+    public TypeOperationsManager(Type? value, string caller)
+    {
+        PrincipalChain = PrincipalChain<Type?>.Get(value, caller);
+        GlobalConfig.Initialize();
+        base.SetManager(this);
+    }
+
+    /// <summary>
+    /// Asserts that the type is a class (not interface, not value type).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeClass(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeClass))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeClassValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeClass)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is an interface.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeInterface(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeInterface))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeInterfaceValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInterface)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is abstract (and not an interface).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeAbstract(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeAbstract))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeAbstractValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeAbstract)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is sealed.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeSealed(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeSealed))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeSealedValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeSealed)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is static (abstract and sealed in CLR metadata).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeStatic(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeStatic))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeStaticValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeStatic)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is public.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BePublic(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BePublic))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBePublicValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BePublic)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is internal (not public).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeInternal(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeInternal))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeInternalValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInternal)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is generic.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeGeneric(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeGeneric))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeGenericValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeGeneric)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type resides in the specified namespace.
+    /// </summary>
+    /// <param name="expectedNamespace">The expected namespace (e.g., <c>"System.Collections.Generic"</c>).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeInNamespace(string expectedNamespace, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeInNamespace))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeBeInNamespaceValidator.New(PrincipalChain, expectedNamespace)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedNamespace,
+                            PrincipalChain.GetValue()!.Namespace ?? "<global namespace>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInNamespace)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type implements the specified interface.
+    /// </summary>
+    /// <typeparam name="TInterface">The interface type to check for.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager ImplementInterface<TInterface>(Reason? reason = null) =>
+        ImplementInterface(typeof(TInterface), reason);
+
+    /// <summary>
+    /// Asserts that the type implements the specified interface.
+    /// </summary>
+    /// <param name="interfaceType">The interface type to check for.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager ImplementInterface(Type interfaceType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.ImplementInterface))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeImplementInterfaceValidator.New(PrincipalChain, interfaceType)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            interfaceType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(ImplementInterface)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type derives from the specified base type.
+    /// </summary>
+    /// <typeparam name="TBase">The base type to check for.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager DeriveFrom<TBase>(Reason? reason = null) =>
+        DeriveFrom(typeof(TBase), reason);
+
+    /// <summary>
+    /// Asserts that the type derives from the specified base type.
+    /// </summary>
+    /// <param name="baseType">The base type to check for.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager DeriveFrom(Type baseType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.DeriveFrom))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeDeriveFromValidator.New(PrincipalChain, baseType))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            baseType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(DeriveFrom)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has the specified custom attribute.
+    /// </summary>
+    /// <typeparam name="TAttribute">The attribute type to check for.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveAttribute<TAttribute>(Reason? reason = null)
+        where TAttribute : Attribute => HaveAttribute(typeof(TAttribute), reason);
+
+    /// <summary>
+    /// Asserts that the type has the specified custom attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type to check for.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveAttribute(Type attributeType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveAttribute))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveAttributeValidator.New(PrincipalChain, attributeType))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            attributeType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveAttribute)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has the specified name.
+    /// </summary>
+    /// <param name="expectedName">The expected type name (e.g., <c>"MyService"</c>).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveName(string expectedName, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveName))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveNameValidator.New(PrincipalChain, expectedName))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedName,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveName)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type name ends with the specified suffix.
+    /// </summary>
+    /// <param name="suffix">The expected name suffix (e.g., <c>"Service"</c>).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveNameEndingWith(string suffix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveNameEndingWith))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveNameEndingWithValidator.New(PrincipalChain, suffix))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            suffix,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveNameEndingWith)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type name starts with the specified prefix.
+    /// </summary>
+    /// <param name="prefix">The expected name prefix (e.g., <c>"My"</c>).</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveNameStartingWith(string prefix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveNameStartingWith))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveNameStartingWithValidator.New(PrincipalChain, prefix))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            prefix,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveNameStartingWith)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    // =====================================================================
+    // Phase 3: Advanced positive operations
+    // =====================================================================
+
+    /// <summary>
+    /// Asserts that the type is a record (class or struct).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeRecord(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeRecord))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeRecordValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeRecord)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is a value type (struct or enum).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeValueType(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeValueType))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeValueTypeValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeValueType)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is an enum.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeEnum(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeEnum))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeEnumValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeEnum)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is nested inside another type.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeNested(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeNested))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeNestedValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeNested)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type resides in a namespace starting with the specified prefix.
+    /// Matches both exact namespace and child namespaces (e.g., "MyApp" matches "MyApp" and "MyApp.Services").
+    /// </summary>
+    /// <param name="prefix">The namespace prefix to match.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeInNamespaceStartingWith(string prefix, Reason? reason = null)
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(
+                Operations.ReflectedType.BeInNamespaceStartingWith
+            )
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeInNamespacePrefixValidator.New(PrincipalChain, prefix))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            prefix,
+                            PrincipalChain.GetValue()!.Namespace ?? "<global namespace>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeInNamespaceStartingWith)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type name matches the specified regular expression pattern.
+    /// </summary>
+    /// <param name="pattern">The regex pattern to match against the type name.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager MatchName(string pattern, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.MatchName))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeMatchNameValidator.New(PrincipalChain, pattern))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            pattern,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(MatchName)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type namespace matches the specified regular expression pattern.
+    /// </summary>
+    /// <param name="pattern">The regex pattern to match against the type namespace.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager MatchNamespace(string pattern, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.MatchNamespace))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeMatchNamespaceValidator.New(PrincipalChain, pattern))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            pattern,
+                            PrincipalChain.GetValue()!.Namespace ?? "<global namespace>"
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(MatchNamespace)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a public constructor with the specified parameter types.
+    /// Pass no arguments to check for a parameterless constructor.
+    /// </summary>
+    /// <param name="parameterTypes">The expected parameter types (in order).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveConstructorWithParameters(params Type[] parameterTypes) =>
+        HaveConstructorWithParametersCore(null, parameterTypes);
+
+    /// <summary>
+    /// Asserts that the type has a public constructor with the specified parameter types.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="parameterTypes">The expected parameter types (in order).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveConstructorWithParameters(
+        Reason? reason,
+        params Type[] parameterTypes
+    ) => HaveConstructorWithParametersCore(reason, parameterTypes);
+
+    private TypeOperationsManager HaveConstructorWithParametersCore(
+        Reason? reason,
+        Type[] parameterTypes
+    )
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(
+                Operations.ReflectedType.HaveConstructorWithParameters
+            )
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHaveConstructorWithParametersValidator.New(
+                    PrincipalChain,
+                    parameterTypes
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveConstructorWithParameters)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at least one public constructor.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HavePublicConstructor(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HavePublicConstructor))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHavePublicConstructorValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HavePublicConstructor)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a public property with the specified name and type.
+    /// </summary>
+    /// <typeparam name="TProperty">The expected property type.</typeparam>
+    /// <param name="propertyName">The expected property name.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HavePropertyOfType<TProperty>(
+        string propertyName,
+        Reason? reason = null
+    ) => HavePropertyOfType(propertyName, typeof(TProperty), reason);
+
+    /// <summary>
+    /// Asserts that the type has a public property with the specified name and type.
+    /// </summary>
+    /// <param name="propertyName">The expected property name.</param>
+    /// <param name="propertyType">The expected property type.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HavePropertyOfType(
+        string propertyName,
+        Type propertyType,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HavePropertyOfType))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHavePropertyOfTypeValidator.New(
+                    PrincipalChain,
+                    propertyName,
+                    propertyType
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HavePropertyOfType)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a public method with the specified name and return type.
+    /// </summary>
+    /// <typeparam name="TReturn">The expected method return type.</typeparam>
+    /// <param name="methodName">The expected method name.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveMethodReturning<TReturn>(
+        string methodName,
+        Reason? reason = null
+    ) => HaveMethodReturning(methodName, typeof(TReturn), reason);
+
+    /// <summary>
+    /// Asserts that the type has a public method with the specified name and return type.
+    /// </summary>
+    /// <param name="methodName">The expected method name.</param>
+    /// <param name="returnType">The expected return type.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveMethodReturning(
+        string methodName,
+        Type returnType,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveMethodReturning))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHaveMethodReturningValidator.New(
+                    PrincipalChain,
+                    methodName,
+                    returnType
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveMethodReturning)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is immutable (no public settable properties, no public mutable fields).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager BeImmutable(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.BeImmutable))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeBeImmutableValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(BeImmutable)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a dependency on the specified namespace.
+    /// Checks field types, property types, constructor parameters, method parameters,
+    /// return types, base types, interfaces, and generic type arguments.
+    /// </summary>
+    /// <param name="namespacePrefix">
+    /// The namespace to check for. Matches both exact namespace and child namespaces
+    /// (e.g., "MyApp.Domain" matches "MyApp.Domain" and "MyApp.Domain.Entities").
+    /// </param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveDependencyOn(string namespacePrefix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveDependencyOn))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHaveDependencyOnValidator.New(PrincipalChain, namespacePrefix)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveDependencyOn)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type only has dependencies on the specified namespaces (whitelist).
+    /// System.* and Microsoft.* namespaces are always implicitly allowed.
+    /// The type's own namespace is always implicitly allowed.
+    /// </summary>
+    /// <param name="allowedNamespaces">The allowed namespace prefixes.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager OnlyHaveDependenciesOn(params string[] allowedNamespaces) =>
+        OnlyHaveDependenciesOnCore(null, allowedNamespaces);
+
+    /// <summary>
+    /// Asserts that the type only has dependencies on the specified namespaces (whitelist).
+    /// System.* and Microsoft.* namespaces are always implicitly allowed.
+    /// The type's own namespace is always implicitly allowed.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="allowedNamespaces">The allowed namespace prefixes.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager OnlyHaveDependenciesOn(
+        Reason? reason,
+        params string[] allowedNamespaces
+    ) => OnlyHaveDependenciesOnCore(reason, allowedNamespaces);
+
+    private TypeOperationsManager OnlyHaveDependenciesOnCore(
+        Reason? reason,
+        string[] allowedNamespaces
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.OnlyHaveDependenciesOn))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeOnlyHaveDependenciesOnValidator.New(PrincipalChain, allowedNamespaces)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(OnlyHaveDependenciesOn)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    // =====================================================================
+    // Phase 3: Negated operations
+    // =====================================================================
+
+    /// <summary>
+    /// Asserts that the type is NOT a class.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeClass(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeClass))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeClassValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeClass)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT an interface.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeInterface(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeInterface))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeInterfaceValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInterface)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT abstract.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeAbstract(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeAbstract))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeAbstractValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeAbstract)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT sealed.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeSealed(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeSealed))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeSealedValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeSealed)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT static.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeStatic(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeStatic))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeStaticValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeStatic)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT public.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBePublic(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBePublic))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBePublicValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBePublic)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT internal.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeInternal(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeInternal))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeInternalValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInternal)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT generic.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeGeneric(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeGeneric))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeGenericValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeGeneric)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT immutable (has at least one public mutable member).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeImmutable(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeImmutable))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotBeImmutableValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeImmutable)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type is NOT in the specified namespace.
+    /// </summary>
+    /// <param name="expectedNamespace">The namespace that the type should NOT be in.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotBeInNamespace(string expectedNamespace, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotBeInNamespace))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotBeInNamespaceValidator.New(PrincipalChain, expectedNamespace)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            expectedNamespace
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotBeInNamespace)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT implement the specified interface.
+    /// </summary>
+    /// <typeparam name="TInterface">The interface type that the type should NOT implement.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotImplementInterface<TInterface>(Reason? reason = null) =>
+        NotImplementInterface(typeof(TInterface), reason);
+
+    /// <summary>
+    /// Asserts that the type does NOT implement the specified interface.
+    /// </summary>
+    /// <param name="interfaceType">The interface type that the type should NOT implement.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotImplementInterface(Type interfaceType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotImplementInterface))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotImplementInterfaceValidator.New(PrincipalChain, interfaceType)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            interfaceType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotImplementInterface)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT derive from the specified base type.
+    /// </summary>
+    /// <typeparam name="TBase">The base type that the type should NOT derive from.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotDeriveFrom<TBase>(Reason? reason = null) =>
+        NotDeriveFrom(typeof(TBase), reason);
+
+    /// <summary>
+    /// Asserts that the type does NOT derive from the specified base type.
+    /// </summary>
+    /// <param name="baseType">The base type that the type should NOT derive from.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotDeriveFrom(Type baseType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotDeriveFrom))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotDeriveFromValidator.New(PrincipalChain, baseType))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            baseType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotDeriveFrom)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have the specified custom attribute.
+    /// </summary>
+    /// <typeparam name="TAttribute">The attribute type that the type should NOT have.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveAttribute<TAttribute>(Reason? reason = null)
+        where TAttribute : Attribute => NotHaveAttribute(typeof(TAttribute), reason);
+
+    /// <summary>
+    /// Asserts that the type does NOT have the specified custom attribute.
+    /// </summary>
+    /// <param name="attributeType">The attribute type that the type should NOT have.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveAttribute(Type attributeType, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveAttribute))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveAttributeValidator.New(PrincipalChain, attributeType)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            attributeType.Name,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveAttribute)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have a dependency on the specified namespace.
+    /// </summary>
+    /// <param name="namespacePrefix">The namespace that the type should NOT reference.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveDependencyOn(string namespacePrefix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveDependencyOn))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveDependencyOnValidator.New(PrincipalChain, namespacePrefix)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            namespacePrefix,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveDependencyOn)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have the specified name.
+    /// </summary>
+    /// <param name="expectedName">The name that the type should NOT have.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveName(string expectedName, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveName))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotHaveNameValidator.New(PrincipalChain, expectedName))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation, expectedName)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveName)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type name does NOT end with the specified suffix.
+    /// </summary>
+    /// <param name="suffix">The suffix that the type name should NOT end with.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveNameEndingWith(string suffix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveNameEndingWith))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotHaveNameEndingWithValidator.New(PrincipalChain, suffix))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            suffix,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveNameEndingWith)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type name does NOT start with the specified prefix.
+    /// </summary>
+    /// <param name="prefix">The prefix that the type name should NOT start with.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveNameStartingWith(string prefix, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveNameStartingWith))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveNameStartingWithValidator.New(PrincipalChain, prefix)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(
+                            operation.MessageKey,
+                            operation.ResultValidation,
+                            prefix,
+                            PrincipalChain.GetValue()!.Name
+                        )
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveNameStartingWith)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a dependency on at least one of the specified namespaces.
+    /// </summary>
+    /// <param name="namespacePrefixes">The namespace prefixes to check (OR semantics).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveDependencyOnAny(params string[] namespacePrefixes) =>
+        HaveDependencyOnAny(null, namespacePrefixes);
+
+    /// <summary>
+    /// Asserts that the type has a dependency on at least one of the specified namespaces.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="namespacePrefixes">The namespace prefixes to check (OR semantics).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveDependencyOnAny(
+        Reason? reason,
+        params string[] namespacePrefixes
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveDependencyOnAny))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHaveDependencyOnAnyValidator.New(PrincipalChain, namespacePrefixes)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveDependencyOnAny)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have a dependency on any of the specified namespaces.
+    /// </summary>
+    /// <param name="namespacePrefixes">The namespace prefixes to check (NONE must match).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveDependencyOnAny(params string[] namespacePrefixes) =>
+        NotHaveDependencyOnAny(null, namespacePrefixes);
+
+    /// <summary>
+    /// Asserts that the type does NOT have a dependency on any of the specified namespaces.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="namespacePrefixes">The namespace prefixes to check (NONE must match).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveDependencyOnAny(
+        Reason? reason,
+        params string[] namespacePrefixes
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveDependencyOnAny))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveDependencyOnAnyValidator.New(PrincipalChain, namespacePrefixes)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveDependencyOnAny)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have any public constructors.
+    /// Useful for enforcing smart enum or singleton patterns where construction
+    /// must be restricted to factory methods or internal logic.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHavePublicConstructor(Reason? reason = null)
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHavePublicConstructor)
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotHavePublicConstructorValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHavePublicConstructor)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have any async void methods.
+    /// Async void methods are fire-and-forget and swallow unhandled exceptions,
+    /// making them a common source of bugs. Use <c>async Task</c> instead.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveAsyncVoidMethods(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveAsyncVoidMethods))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotHaveAsyncVoidMethodsValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveAsyncVoidMethods)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at least one async void method.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveAsyncVoidMethods(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveAsyncVoidMethods))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveAsyncVoidMethodsValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveAsyncVoidMethods)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type overrides the specified method from a base type.
+    /// Commonly used to enforce that value objects override <c>Equals</c> and <c>GetHashCode</c>.
+    /// </summary>
+    /// <param name="methodName">The name of the method that must be overridden.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveMethodOverride(string methodName, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveMethodOverride))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveMethodOverrideValidator.New(PrincipalChain, methodName))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveMethodOverride)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT override the specified method.
+    /// </summary>
+    /// <param name="methodName">The name of the method that must NOT be overridden.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveMethodOverride(string methodName, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveMethodOverride))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveMethodOverrideValidator.New(PrincipalChain, methodName)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveMethodOverride)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at least one protected (or protected internal) member.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveProtectedMembers(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveProtectedMembers))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveProtectedMembersValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveProtectedMembers)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have any protected (or protected internal) members.
+    /// Useful for enforcing that sealed classes have no protected members (which would be dead code).
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveProtectedMembers(Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveProtectedMembers))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeNotHaveProtectedMembersValidator.New(PrincipalChain))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveProtectedMembers)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at most <paramref name="maxCount"/> public methods (declared only).
+    /// Property/event accessors and operators are excluded from the count.
+    /// Useful for detecting "god classes" that violate the Single Responsibility Principle.
+    /// </summary>
+    /// <param name="maxCount">The maximum number of public methods allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveMaxPublicMethods(int maxCount, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveMaxPublicMethods))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveMaxPublicMethodsValidator.New(PrincipalChain, maxCount))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveMaxPublicMethods)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at most <paramref name="maxCount"/> fields (declared only).
+    /// Compiler-generated backing fields are excluded.
+    /// </summary>
+    /// <param name="maxCount">The maximum number of fields allowed.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveMaxFields(int maxCount, Reason? reason = null)
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveMaxFields))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(ReflectedTypeHaveMaxFieldsValidator.New(PrincipalChain, maxCount))
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveMaxFields)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has at least one public method returning a type from the specified namespace.
+    /// </summary>
+    /// <param name="namespacePrefix">The namespace prefix to check return types against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager ReturnTypesFromNamespace(
+        string namespacePrefix,
+        Reason? reason = null
+    )
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(Operations.ReflectedType.ReturnTypesFromNamespace)
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeReturnTypesFromNamespaceValidator.New(PrincipalChain, namespacePrefix)
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(ReturnTypesFromNamespace)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that none of the type's public methods return types from the specified namespace.
+    /// This is the "leaky abstraction" detector.
+    /// </summary>
+    /// <param name="namespacePrefix">The namespace prefix to check return types against.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotReturnTypesFromNamespace(
+        string namespacePrefix,
+        Reason? reason = null
+    )
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(
+                Operations.ReflectedType.NotReturnTypesFromNamespace
+            )
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotReturnTypesFromNamespaceValidator.New(
+                    PrincipalChain,
+                    namespacePrefix
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotReturnTypesFromNamespace)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a private (or internal) constructor with the specified parameter types.
+    /// When called with no parameters, asserts a private parameterless constructor exists.
+    /// Commonly used to verify Entity Framework entity configuration or DDD aggregate persistence patterns.
+    /// </summary>
+    /// <param name="parameterTypes">The expected constructor parameter types (empty = parameterless).</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HavePrivateConstructorWithParameters(
+        params Type[] parameterTypes
+    ) => HavePrivateConstructorWithParametersCore(null, parameterTypes);
+
+    /// <summary>
+    /// Asserts that the type has a private constructor with the specified parameter types.
+    /// </summary>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <param name="parameterTypes">The expected constructor parameter types.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HavePrivateConstructorWithParameters(
+        Reason? reason,
+        params Type[] parameterTypes
+    ) => HavePrivateConstructorWithParametersCore(reason, parameterTypes);
+
+    private TypeOperationsManager HavePrivateConstructorWithParametersCore(
+        Reason? reason,
+        Type[] parameterTypes
+    )
+    {
+        if (
+            !OperationUtils.CheckOperationAllowed(
+                Operations.ReflectedType.HavePrivateConstructorWithParameters
+            )
+        )
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHavePrivateConstructorWithParametersValidator.New(
+                    PrincipalChain,
+                    parameterTypes
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HavePrivateConstructorWithParameters)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type has a dependency on the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type that must be referenced.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveDependencyOnType<T>(Reason? reason = null) =>
+        HaveDependencyOnType(typeof(T).FullName!, reason);
+
+    /// <summary>
+    /// Asserts that the type has a dependency on the specified type (by fully qualified name).
+    /// </summary>
+    /// <param name="fullyQualifiedTypeName">The fully qualified name of the type that must be referenced.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager HaveDependencyOnType(
+        string fullyQualifiedTypeName,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.HaveDependencyOnType))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeHaveDependencyOnTypeValidator.New(
+                    PrincipalChain,
+                    fullyQualifiedTypeName
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(HaveDependencyOnType)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+
+    /// <summary>
+    /// Asserts that the type does NOT have a dependency on the specified type.
+    /// </summary>
+    /// <typeparam name="T">The type that must NOT be referenced.</typeparam>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveDependencyOnType<T>(Reason? reason = null) =>
+        NotHaveDependencyOnType(typeof(T).FullName!, reason);
+
+    /// <summary>
+    /// Asserts that the type does NOT have a dependency on the specified type (by fully qualified name).
+    /// </summary>
+    /// <param name="fullyQualifiedTypeName">The fully qualified name of the type that must NOT be referenced.</param>
+    /// <param name="reason">An optional reason providing context for the assertion.</param>
+    /// <returns>The current manager instance for method chaining.</returns>
+    public TypeOperationsManager NotHaveDependencyOnType(
+        string fullyQualifiedTypeName,
+        Reason? reason = null
+    )
+    {
+        if (!OperationUtils.CheckOperationAllowed(Operations.ReflectedType.NotHaveDependencyOnType))
+        {
+            return this;
+        }
+
+        ExecutionEngine<TypeOperationsManager, Type?>
+            .New(this)
+            .WithOperation(
+                ReflectedTypeNotHaveDependencyOnTypeValidator.New(
+                    PrincipalChain,
+                    fullyQualifiedTypeName
+                )
+            )
+            .WithTemplate(
+                (template, operation) =>
+                    template
+                        .WithSubject(PrincipalChain.GetSubject())
+                        .WithResult(operation.MessageKey, operation.ResultValidation)
+                        .WithReason(reason?.ToString())
+            )
+            .FailIf(
+                m =>
+                    (
+                        m.PrincipalChain.GetValue() is null,
+                        Fail.New(
+                            $"The {nameof(NotHaveDependencyOnType)} operation failed because the value was <null>, use {nameof(NotBeNull)} to cover all possible scenarios."
+                        )
+                    )
+            )
+            .Execute();
+
+        return this;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
+++ b/Distributed/JAAvila.FluentOperations/PropertyProxy.cs
@@ -248,6 +248,16 @@ internal class PropertyProxy<TProp, TManager>(
             return (TManager)(object)new UriOperationsManager(null, propertyName);
         }
 
+        if (typeof(TManager) == typeof(TypeOperationsManager))
+        {
+            return (TManager)(object)new TypeOperationsManager(null, propertyName);
+        }
+
+        if (typeof(TManager) == typeof(AssemblyOperationsManager))
+        {
+            return (TManager)(object)new AssemblyOperationsManager(null, propertyName);
+        }
+
         if (typeof(TManager) == typeof(DateTimeOffsetOperationsManager))
         {
             return (TManager)(object)new DateTimeOffsetOperationsManager(default, propertyName);

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.For.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Reflection;
 using JAAvila.FluentOperations.Manager;
 using JAAvila.FluentOperations.Model;
 
@@ -1087,6 +1088,56 @@ public abstract partial class QualityBlueprint<T>
         Expression<Func<T, Uri?>> propertyExpression,
         RuleConfig config
     ) => For<Uri?, UriOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="Type"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access Type assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the Type property to validate (e.g., <c>x =&gt; x.ServiceType</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> For(
+        Expression<Func<T, Type?>> propertyExpression
+    ) => For<Type?, TypeOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for a <see cref="Type"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the Type property to validate (e.g., <c>x =&gt; x.ServiceType</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> For(
+        Expression<Func<T, Type?>> propertyExpression,
+        RuleConfig config
+    ) => For<Type?, TypeOperationsManager>(propertyExpression, config);
+
+    /// <summary>
+    /// Defines a validation rule for an <see cref="Assembly"/> property of the model.
+    /// Call <see cref="IPropertyProxy{TManager}.Test"/> on the result to access Assembly assertions.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the Assembly property to validate (e.g., <c>x =&gt; x.TargetAssembly</c>).
+    /// </param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> For(
+        Expression<Func<T, Assembly?>> propertyExpression
+    ) => For<Assembly?, AssemblyOperationsManager>(propertyExpression);
+
+    /// <summary>
+    /// Defines a validation rule for an <see cref="Assembly"/> property of the model, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">
+    /// An expression selecting the Assembly property to validate (e.g., <c>x =&gt; x.TargetAssembly</c>).
+    /// </param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> For(
+        Expression<Func<T, Assembly?>> propertyExpression,
+        RuleConfig config
+    ) => For<Assembly?, AssemblyOperationsManager>(propertyExpression, config);
 
     /// <summary>
     /// Defines a validation rule for a <see cref="DateTimeOffset"/> property of the model.

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.ForTransform.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Reflection;
 using JAAvila.FluentOperations.Manager;
 using JAAvila.FluentOperations.Model;
 
@@ -848,6 +849,58 @@ public abstract partial class QualityBlueprint<T>
         RuleConfig config
     ) => ForTransform<Uri?, UriOperationsManager>(propertyExpression, transform, config);
 
+    // Type? -> Type? transformation
+
+    /// <summary>
+    /// Registers a <see cref="Type"/> property with a same-type transformation applied before validation.
+    /// </summary>
+    /// <param name="propertyExpression">An expression selecting the property to transform and validate.</param>
+    /// <param name="transform">A function that transforms the value before validation.</param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> ForTransform(
+        Expression<Func<T, Type?>> propertyExpression,
+        Func<Type?, Type?> transform
+    ) => ForTransform<Type?, TypeOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a <see cref="Type"/> property with a same-type transformation applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">An expression selecting the property to transform and validate.</param>
+    /// <param name="transform">A function that transforms the value before validation.</param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> ForTransform(
+        Expression<Func<T, Type?>> propertyExpression,
+        Func<Type?, Type?> transform,
+        RuleConfig config
+    ) => ForTransform<Type?, TypeOperationsManager>(propertyExpression, transform, config);
+
+    // Assembly? -> Assembly? transformation
+
+    /// <summary>
+    /// Registers an <see cref="Assembly"/> property with a same-type transformation applied before validation.
+    /// </summary>
+    /// <param name="propertyExpression">An expression selecting the property to transform and validate.</param>
+    /// <param name="transform">A function that transforms the value before validation.</param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> ForTransform(
+        Expression<Func<T, Assembly?>> propertyExpression,
+        Func<Assembly?, Assembly?> transform
+    ) => ForTransform<Assembly?, AssemblyOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers an <see cref="Assembly"/> property with a same-type transformation applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <param name="propertyExpression">An expression selecting the property to transform and validate.</param>
+    /// <param name="transform">A function that transforms the value before validation.</param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> ForTransform(
+        Expression<Func<T, Assembly?>> propertyExpression,
+        Func<Assembly?, Assembly?> transform,
+        RuleConfig config
+    ) => ForTransform<Assembly?, AssemblyOperationsManager>(propertyExpression, transform, config);
+
     // ActionStats? -> ActionStats? transformation
     /// <summary>
     /// Registers an <see cref="ActionStats"/> property with a same-type transformation applied before validation.
@@ -1543,6 +1596,64 @@ public abstract partial class QualityBlueprint<T>
         Func<TProp, Uri?> transform,
         RuleConfig config
     ) => ForTransform<TProp, Uri?, UriOperationsManager>(propertyExpression, transform, config);
+
+    // any -> Type? cross-type transformation
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="Type"/> applied before validation.
+    /// The source type <typeparamref name="TProp"/> is inferred from the property expression.
+    /// </summary>
+    /// <typeparam name="TProp">The source property type (inferred by the compiler).</typeparam>
+    /// <param name="propertyExpression">An expression selecting the property to transform.</param>
+    /// <param name="transform">A function that maps the property value to <see cref="Type"/>.</param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, Type?> transform
+    ) => ForTransform<TProp, Type?, TypeOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="Type"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <typeparam name="TProp">The source property type (inferred by the compiler).</typeparam>
+    /// <param name="propertyExpression">An expression selecting the property to transform.</param>
+    /// <param name="transform">A function that maps the property value to <see cref="Type"/>.</param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="TypeOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<TypeOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, Type?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, Type?, TypeOperationsManager>(propertyExpression, transform, config);
+
+    // any -> Assembly? cross-type transformation
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="Assembly"/> applied before validation.
+    /// The source type <typeparamref name="TProp"/> is inferred from the property expression.
+    /// </summary>
+    /// <typeparam name="TProp">The source property type (inferred by the compiler).</typeparam>
+    /// <param name="propertyExpression">An expression selecting the property to transform.</param>
+    /// <param name="transform">A function that maps the property value to <see cref="Assembly"/>.</param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, Assembly?> transform
+    ) => ForTransform<TProp, Assembly?, AssemblyOperationsManager>(propertyExpression, transform);
+
+    /// <summary>
+    /// Registers a property with a cross-type transformation to <see cref="Assembly"/> applied before validation, with a <see cref="RuleConfig"/>.
+    /// </summary>
+    /// <typeparam name="TProp">The source property type (inferred by the compiler).</typeparam>
+    /// <param name="propertyExpression">An expression selecting the property to transform.</param>
+    /// <param name="transform">A function that maps the property value to <see cref="Assembly"/>.</param>
+    /// <param name="config">Configuration for this rule (severity, error code, cascade mode).</param>
+    /// <returns>A property proxy that exposes <see cref="AssemblyOperationsManager"/> via <c>.Test()</c>.</returns>
+    protected IPropertyProxy<AssemblyOperationsManager> ForTransform<TProp>(
+        Expression<Func<T, TProp>> propertyExpression,
+        Func<TProp, Assembly?> transform,
+        RuleConfig config
+    ) => ForTransform<TProp, Assembly?, AssemblyOperationsManager>(propertyExpression, transform, config);
 
     // any -> ActionStats? cross-type transformation
     /// <summary>

--- a/Distributed/JAAvila.FluentOperations/TestExtension.SpecialTypes.cs
+++ b/Distributed/JAAvila.FluentOperations/TestExtension.SpecialTypes.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.Contracts;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using JAAvila.FluentOperations.Manager;
 
@@ -126,5 +127,53 @@ public static partial class TestExtension
     )
     {
         return new UriOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="Type"/> value.
+    /// </summary>
+    /// <param name="value">The Type value to test. Can be null.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>A <see cref="TypeOperationsManager"/> for chaining Type-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// typeof(MyService).Test().BeClass().BeSealed().BePublic();
+    /// </code>
+    /// </example>
+    [Pure]
+    public static TypeOperationsManager Test(
+        this Type? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new TypeOperationsManager(value, callerName);
+    }
+
+    /// <summary>
+    /// Begins a fluent assertion chain for the specified <see cref="Assembly"/> value.
+    /// </summary>
+    /// <param name="value">The Assembly value to test. Can be null.</param>
+    /// <param name="callerName">
+    /// Automatically captured expression name of the variable being tested.
+    /// Used in failure messages for contextual reporting.
+    /// </param>
+    /// <returns>An <see cref="AssemblyOperationsManager"/> for chaining Assembly-specific assertions.</returns>
+    /// <example>
+    /// <code>
+    /// typeof(MyService).Assembly.Test()
+    ///     .ContainType&lt;MyService&gt;()
+    ///     .NotReferenceAssembly("Newtonsoft.Json");
+    /// </code>
+    /// </example>
+    [Pure]
+    public static AssemblyOperationsManager Test(
+        this Assembly? value,
+        [CallerArgumentExpression("value")] string callerName = ""
+    )
+    {
+        return new AssemblyOperationsManager(value, callerName);
     }
 }

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyContainTypeMatchingValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyContainTypeMatchingValidator.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly contains a type whose full name matches the specified regex pattern.
+/// </summary>
+internal class AssemblyContainTypeMatchingValidator(PrincipalChain<Assembly?> chain, string pattern)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static AssemblyContainTypeMatchingValidator New(
+        PrincipalChain<Assembly?> chain,
+        string pattern
+    ) => new(chain, pattern);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.ContainTypeMatching";
+    string IRuleDescriptor.OperationName => "ContainTypeMatching";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["pattern"] = pattern };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var regex = new Regex(pattern, RegexOptions.Compiled);
+
+        // Use GetTypes() to scan all types; catch ReflectionTypeLoadException for partial loads
+        Type[] types;
+
+        try
+        {
+            types = asm.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(t => t != null).ToArray()!;
+        }
+
+        if (types.Any(t => regex.IsMatch(t.FullName ?? t.Name)))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The assembly was expected to contain a type matching pattern \"{0}\", but no match was found.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyContainTypeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyContainTypeValidator.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly contains the specified type.
+/// </summary>
+internal class AssemblyContainTypeValidator(PrincipalChain<Assembly?> chain, Type expectedType)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static AssemblyContainTypeValidator New(
+        PrincipalChain<Assembly?> chain,
+        Type expectedType
+    ) => new(chain, expectedType);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.ContainType";
+    string IRuleDescriptor.OperationName => "ContainType";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["type"] = expectedType };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+
+        if (expectedType.Assembly == asm)
+        {
+            return true;
+        }
+
+        ResultValidation = "The assembly was expected to contain type '{0}', but it does not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyHaveMinimumVersionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyHaveMinimumVersionValidator.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly version is greater than or equal to the specified minimum.
+/// </summary>
+internal class AssemblyHaveMinimumVersionValidator(
+    PrincipalChain<Assembly?> chain,
+    Version minimumVersion
+) : IValidator, IRuleDescriptor
+{
+    public static AssemblyHaveMinimumVersionValidator New(
+        PrincipalChain<Assembly?> chain,
+        Version minimumVersion
+    ) => new(chain, minimumVersion);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.HaveMinimumVersion";
+    string IRuleDescriptor.OperationName => "HaveMinimumVersion";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["minimumVersion"] = minimumVersion };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var actualVersion = asm.GetName().Version;
+
+        if (actualVersion != null && actualVersion >= minimumVersion)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The assembly was expected to have version >= \"{0}\", but the actual version is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyHavePublicKeyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyHavePublicKeyValidator.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly is strong-named (has a public key).
+/// </summary>
+internal class AssemblyHavePublicKeyValidator(PrincipalChain<Assembly?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static AssemblyHavePublicKeyValidator New(PrincipalChain<Assembly?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.HavePublicKey";
+    string IRuleDescriptor.OperationName => "HavePublicKey";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var publicKey = asm.GetName().GetPublicKey();
+
+        if (!publicKey.IsNullOrEmpty())
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The assembly was expected to be strong-named (have a public key), but it is not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyHaveVersionValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyHaveVersionValidator.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly version matches the expected version exactly.
+/// </summary>
+internal class AssemblyHaveVersionValidator(
+    PrincipalChain<Assembly?> chain,
+    Version expectedVersion
+) : IValidator, IRuleDescriptor
+{
+    public static AssemblyHaveVersionValidator New(
+        PrincipalChain<Assembly?> chain,
+        Version expectedVersion
+    ) => new(chain, expectedVersion);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.HaveVersion";
+    string IRuleDescriptor.OperationName => "HaveVersion";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["version"] = expectedVersion };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var actualVersion = asm.GetName().Version;
+
+        if (actualVersion != null && actualVersion.Equals(expectedVersion))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The assembly was expected to have version \"{0}\", but the actual version is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyNotReferenceAssemblyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyNotReferenceAssemblyValidator.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly does NOT reference the named assembly.
+/// </summary>
+internal class AssemblyNotReferenceAssemblyValidator(
+    PrincipalChain<Assembly?> chain,
+    string assemblyName
+) : IValidator, IRuleDescriptor
+{
+    public static AssemblyNotReferenceAssemblyValidator New(
+        PrincipalChain<Assembly?> chain,
+        string assemblyName
+    ) => new(chain, assemblyName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.NotReferenceAssembly";
+    string IRuleDescriptor.OperationName => "NotReferenceAssembly";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["assemblyName"] = assemblyName };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var references = asm.GetReferencedAssemblies();
+
+        if (
+            !references.Any(
+                r =>
+                    r.Name != null
+                    && r.Name.Equals(assemblyName, StringComparison.OrdinalIgnoreCase)
+            )
+        )
+        {
+            return true;
+        }
+
+        ResultValidation = "The assembly was expected NOT to reference '{0}', but it does.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/AssemblyReferenceAssemblyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/AssemblyReferenceAssemblyValidator.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the assembly has a reference to the named assembly.
+/// </summary>
+internal class AssemblyReferenceAssemblyValidator(
+    PrincipalChain<Assembly?> chain,
+    string assemblyName
+) : IValidator, IRuleDescriptor
+{
+    public static AssemblyReferenceAssemblyValidator New(
+        PrincipalChain<Assembly?> chain,
+        string assemblyName
+    ) => new(chain, assemblyName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "Assembly.ReferenceAssembly";
+    string IRuleDescriptor.OperationName => "ReferenceAssembly";
+    Type IRuleDescriptor.SubjectType => typeof(Assembly);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["assemblyName"] = assemblyName };
+
+    public bool Validate()
+    {
+        var asm = chain.GetValue()!;
+        var references = asm.GetReferencedAssemblies();
+
+        if (
+            references.Any(
+                r =>
+                    r.Name != null
+                    && r.Name.Equals(assemblyName, StringComparison.OrdinalIgnoreCase)
+            )
+        )
+        {
+            return true;
+        }
+
+        ResultValidation = "The assembly was expected to reference '{0}', but it does not.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeAbstractValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeAbstractValidator.cs
@@ -1,0 +1,39 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is abstract (and not an interface).
+/// </summary>
+internal class ReflectedTypeBeAbstractValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeAbstractValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeAbstract";
+    string IRuleDescriptor.OperationName => "BeAbstract";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Abstract and NOT an interface (interfaces are always abstract in CLR)
+        if (type is { IsAbstract: true, IsInterface: false })
+        {
+            return true;
+        }
+
+        ResultValidation = type.IsInterface
+            ? $"The type was expected to be abstract, but '{type.Name}' is an interface (use BeInterface instead)."
+            : $"The type was expected to be abstract, but '{type.Name}' is not abstract.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeClassValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeClassValidator.cs
@@ -1,0 +1,46 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is a class (not interface, not value type).
+/// </summary>
+internal class ReflectedTypeBeClassValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeClassValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeClass";
+    string IRuleDescriptor.OperationName => "BeClass";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsClass)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be a class, but '{type.Name}' is {GetTypeKind(type)}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+
+    private static string GetTypeKind(Type t) =>
+        t.IsInterface
+            ? "an interface"
+            : t.IsEnum
+                ? "an enum"
+                : t.IsValueType
+                    ? "a value type"
+                    : "not a class";
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeEnumValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeEnumValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is an enum.
+/// </summary>
+internal class ReflectedTypeBeEnumValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeEnumValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeEnum";
+    string IRuleDescriptor.OperationName => "BeEnum";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsEnum)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be an enum, but '{type.Name}' is not an enum.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeGenericValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeGenericValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is generic.
+/// </summary>
+internal class ReflectedTypeBeGenericValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeGenericValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeGeneric";
+    string IRuleDescriptor.OperationName => "BeGeneric";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsGenericType)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be generic, but '{type.Name}' is not generic.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeImmutableValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeImmutableValidator.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is immutable (no public settable properties, no public mutable fields).
+/// </summary>
+internal class ReflectedTypeBeImmutableValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeImmutableValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeImmutable";
+    string IRuleDescriptor.OperationName => "BeImmutable";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Check public fields: all must be readonly
+        var mutableFields = type.GetFields(BindingFlags.Public | BindingFlags.Instance)
+            .Where(f => f is { IsInitOnly: false, IsLiteral: false })
+            .ToList();
+
+        if (mutableFields.Count > 0)
+        {
+            var fieldNames = string.Join(", ", mutableFields.Select(f => f.Name));
+            ResultValidation =
+                $"The type was expected to be immutable, "
+                + $"but '{type.Name}' has public mutable fields: {fieldNames}.";
+            return false;
+        }
+
+        // Check public properties: must NOT have a public non-init setter
+        var mutableProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(HasPublicNonInitSetter)
+            .ToList();
+
+        if (mutableProperties.Count > 0)
+        {
+            var propNames = string.Join(", ", mutableProperties.Select(p => p.Name));
+            ResultValidation =
+                $"The type was expected to be immutable, "
+                + $"but '{type.Name}' has public settable properties: {propNames}.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+
+    private static bool HasPublicNonInitSetter(PropertyInfo property)
+    {
+        var setter = property.SetMethod;
+
+        if (setter == null || !setter.IsPublic)
+        {
+            return false;
+        }
+
+        // Check for init-only: init setters have IsExternalInit as a required modifier
+        var requiredMods = setter.ReturnParameter.GetRequiredCustomModifiers();
+        return requiredMods.All(
+            m => m.FullName != "System.Runtime.CompilerServices.IsExternalInit"
+        );
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInNamespacePrefixValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInNamespacePrefixValidator.cs
@@ -1,0 +1,47 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type resides in a namespace starting with the specified prefix.
+/// </summary>
+internal class ReflectedTypeBeInNamespacePrefixValidator(PrincipalChain<Type?> chain, string prefix)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeInNamespacePrefixValidator New(
+        PrincipalChain<Type?> chain,
+        string prefix
+    ) => new(chain, prefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeInNamespaceStartingWith";
+    string IRuleDescriptor.OperationName => "BeInNamespaceStartingWith";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["prefix"] = prefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var ns = type.Namespace;
+
+        if (
+            ns != null
+            && (
+                ns.Equals(prefix, StringComparison.Ordinal)
+                || ns.StartsWith(prefix + ".", StringComparison.Ordinal)
+            )
+        )
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to be in a namespace starting with \"{0}\", but it is in \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInNamespaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInNamespaceValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type resides in the specified namespace.
+/// </summary>
+internal class ReflectedTypeBeInNamespaceValidator(
+    PrincipalChain<Type?> chain,
+    string expectedNamespace
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeBeInNamespaceValidator New(
+        PrincipalChain<Type?> chain,
+        string expectedNamespace
+    ) => new(chain, expectedNamespace);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeInNamespace";
+    string IRuleDescriptor.OperationName => "BeInNamespace";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespace"] = expectedNamespace };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (string.Equals(type.Namespace, expectedNamespace, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to be in namespace \"{0}\", but it is in \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInterfaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInterfaceValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is an interface.
+/// </summary>
+internal class ReflectedTypeBeInterfaceValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeInterfaceValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeInterface";
+    string IRuleDescriptor.OperationName => "BeInterface";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsInterface)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be an interface, but '{type.Name}' is {(type.IsClass ? "a class" : type.IsValueType ? "a value type" : "not an interface")}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInternalValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeInternalValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is internal (not public).
+/// </summary>
+internal class ReflectedTypeBeInternalValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeInternalValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeInternal";
+    string IRuleDescriptor.OperationName => "BeInternal";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Top-level internal: IsNotPublic. Nested internal: IsNestedAssembly or IsNestedFamORAssem.
+        if (type.IsNotPublic || type.IsNestedAssembly || type.IsNestedFamORAssem)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be internal, but '{type.Name}' is not internal.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeNestedValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeNestedValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is nested inside another type.
+/// </summary>
+internal class ReflectedTypeBeNestedValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeNestedValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeNested";
+    string IRuleDescriptor.OperationName => "BeNested";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsNested)
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to be nested, but '{type.Name}' is not nested.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBePublicValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBePublicValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is public.
+/// </summary>
+internal class ReflectedTypeBePublicValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBePublicValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BePublic";
+    string IRuleDescriptor.OperationName => "BePublic";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsPublic || type.IsNestedPublic)
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to be public, but '{type.Name}' is not public.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeRecordValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeRecordValidator.cs
@@ -1,0 +1,80 @@
+using System.Text;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is a record (class or struct).
+/// </summary>
+internal class ReflectedTypeBeRecordValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeRecordValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeRecord";
+    string IRuleDescriptor.OperationName => "BeRecord";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (IsRecord(type))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be a record, but '{type.Name}' is not a record.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+
+    private static bool IsRecord(Type type)
+    {
+        if (type.IsClass)
+        {
+            var hasClone =
+                type.GetMethod(
+                    "<Clone>$",
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance
+                ) != null;
+            var hasEqualityContract =
+                type.GetProperty(
+                    "EqualityContract",
+                    System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Instance
+                ) != null;
+            return hasClone && hasEqualityContract;
+        }
+
+        if (type is { IsValueType: true, IsEnum: false })
+        {
+            var hasPrintMembers =
+                type.GetMethod(
+                    "PrintMembers",
+                    System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Instance,
+                    null,
+                    [typeof(StringBuilder)],
+                    null
+                ) != null;
+
+            if (!hasPrintMembers)
+            {
+                return false;
+            }
+
+            var equatableInterface = typeof(IEquatable<>).MakeGenericType(type);
+            return equatableInterface.IsAssignableFrom(type);
+        }
+
+        return false;
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeSealedValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeSealedValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is sealed.
+/// </summary>
+internal class ReflectedTypeBeSealedValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeSealedValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeSealed";
+    string IRuleDescriptor.OperationName => "BeSealed";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsSealed)
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to be sealed, but '{type.Name}' is not sealed.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeStaticValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeStaticValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is static (abstract and sealed in CLR metadata).
+/// </summary>
+internal class ReflectedTypeBeStaticValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeStaticValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeStatic";
+    string IRuleDescriptor.OperationName => "BeStatic";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Static classes are both abstract and sealed in CLR metadata
+        if (type is { IsAbstract: true, IsSealed: true })
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to be static, but '{type.Name}' is not static.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeValueTypeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeBeValueTypeValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is a value type (struct or enum).
+/// </summary>
+internal class ReflectedTypeBeValueTypeValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeBeValueTypeValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.BeValueType";
+    string IRuleDescriptor.OperationName => "BeValueType";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.IsValueType)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to be a value type, but '{type.Name}' is not a value type.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeDeriveFromValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeDeriveFromValidator.cs
@@ -1,0 +1,58 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type derives from the specified base type.
+/// </summary>
+internal class ReflectedTypeDeriveFromValidator(PrincipalChain<Type?> chain, Type expectedBase)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeDeriveFromValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedBase
+    ) => new(chain, expectedBase);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.DeriveFrom";
+    string IRuleDescriptor.OperationName => "DeriveFrom";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["baseType"] = expectedBase };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Support open generics: typeof(List<>) derives from typeof(IEnumerable<>)
+        if (expectedBase.IsGenericTypeDefinition)
+        {
+            var current = type.BaseType;
+
+            while (current != null)
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == expectedBase)
+                {
+                    return true;
+                }
+
+                current = current.BaseType;
+            }
+        }
+        else
+        {
+            if (expectedBase.IsAssignableFrom(type) && type != expectedBase)
+            {
+                return true;
+            }
+        }
+
+        ResultValidation =
+            "The type was expected to derive from '{0}', but '{1}' does not derive from it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveAsyncVoidMethodsValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveAsyncVoidMethodsValidator.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type HAS at least one async void method.
+/// Primarily used as the positive counterpart of <see cref="ReflectedTypeNotHaveAsyncVoidMethodsValidator"/>.
+/// </summary>
+internal class ReflectedTypeHaveAsyncVoidMethodsValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveAsyncVoidMethodsValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveAsyncVoidMethods";
+    string IRuleDescriptor.OperationName => "HaveAsyncVoidMethods";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var hasAsyncVoid = type.GetMethods(
+                BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.DeclaredOnly
+            )
+            .Any(
+                m =>
+                    m.ReturnType == typeof(void)
+                    && m.GetCustomAttribute<AsyncStateMachineAttribute>() != null
+            );
+
+        if (hasAsyncVoid)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have at least one async void method, "
+            + $"but '{type.Name}' has none.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveAttributeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveAttributeValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has the specified custom attribute.
+/// </summary>
+internal class ReflectedTypeHaveAttributeValidator(
+    PrincipalChain<Type?> chain,
+    Type expectedAttribute
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveAttributeValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedAttribute
+    ) => new(chain, expectedAttribute);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveAttribute";
+    string IRuleDescriptor.OperationName => "HaveAttribute";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["attribute"] = expectedAttribute };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (Attribute.IsDefined(type, expectedAttribute, inherit: true))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to have attribute '{0}', but '{1}' does not have it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveConstructorWithParametersValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveConstructorWithParametersValidator.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a public constructor with the specified parameter types.
+/// </summary>
+internal class ReflectedTypeHaveConstructorWithParametersValidator(
+    PrincipalChain<Type?> chain,
+    Type[] expectedParameters
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveConstructorWithParametersValidator New(
+        PrincipalChain<Type?> chain,
+        params Type[] expectedParameters
+    ) => new(chain, expectedParameters);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveConstructorWithParameters";
+    string IRuleDescriptor.OperationName => "HaveConstructorWithParameters";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["parameterTypes"] = expectedParameters };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Search all public constructors for one that matches the exact parameter list
+        var ctors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        if (
+            ctors
+                .Select(ctor => ctor.GetParameters().Select(p => p.ParameterType).ToArray())
+                .Any(
+                    paramTypes =>
+                        paramTypes.Length == expectedParameters.Length
+                        && paramTypes.SequenceEqual(expectedParameters)
+                )
+        )
+        {
+            return true;
+        }
+
+        var expectedStr =
+            expectedParameters.Length == 0
+                ? "(parameterless)"
+                : $"({string.Join(", ", expectedParameters.Select(t => t.Name))})";
+
+        ResultValidation =
+            $"The type was expected to have a constructor with parameters {expectedStr}, "
+            + $"but '{type.Name}' does not have a matching constructor.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnAnyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnAnyValidator.cs
@@ -1,0 +1,45 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a dependency on at least one of the specified namespaces.
+/// </summary>
+internal class ReflectedTypeHaveDependencyOnAnyValidator(
+    PrincipalChain<Type?> chain,
+    string[] namespacePrefixes
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveDependencyOnAnyValidator New(
+        PrincipalChain<Type?> chain,
+        string[] namespacePrefixes
+    ) => new(chain, namespacePrefixes);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveDependencyOnAny";
+    string IRuleDescriptor.OperationName => "HaveDependencyOnAny";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespaces"] = namespacePrefixes };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var scanner = DependencyScannerProvider.Current;
+
+        if (namespacePrefixes.Any(ns => scanner.HasDependencyOnNamespace(type, ns)))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have a dependency on at least one of "
+            + $"[{string.Join(", ", namespacePrefixes.Select(n => $"'{n}'"))}], "
+            + $"but '{type.Name}' does not reference any of them.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnTypeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnTypeValidator.cs
@@ -1,0 +1,43 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a dependency on the specified type (by fully qualified name).
+/// </summary>
+internal class ReflectedTypeHaveDependencyOnTypeValidator(
+    PrincipalChain<Type?> chain,
+    string fullyQualifiedTypeName
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveDependencyOnTypeValidator New(
+        PrincipalChain<Type?> chain,
+        string fullyQualifiedTypeName
+    ) => new(chain, fullyQualifiedTypeName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveDependencyOnType";
+    string IRuleDescriptor.OperationName => "HaveDependencyOnType";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["typeName"] = fullyQualifiedTypeName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (DependencyScannerProvider.Current.HasDependencyOnType(type, fullyQualifiedTypeName))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have a dependency on type '{fullyQualifiedTypeName}', "
+            + $"but '{type.Name}' does not reference that type.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveDependencyOnValidator.cs
@@ -1,0 +1,43 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a dependency on the specified namespace.
+/// </summary>
+internal class ReflectedTypeHaveDependencyOnValidator(
+    PrincipalChain<Type?> chain,
+    string namespacePrefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveDependencyOnValidator New(
+        PrincipalChain<Type?> chain,
+        string namespacePrefix
+    ) => new(chain, namespacePrefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveDependencyOn";
+    string IRuleDescriptor.OperationName => "HaveDependencyOn";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespace"] = namespacePrefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (DependencyScannerProvider.Current.HasDependencyOnNamespace(type, namespacePrefix))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have a dependency on '{namespacePrefix}', "
+            + $"but '{type.Name}' does not reference that namespace.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMaxFieldsValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMaxFieldsValidator.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has at most the specified number of fields
+/// (instance + static, all visibilities, declared only, excluding compiler-generated backing fields).
+/// </summary>
+internal class ReflectedTypeHaveMaxFieldsValidator(PrincipalChain<Type?> chain, int maxCount)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveMaxFieldsValidator New(
+        PrincipalChain<Type?> chain,
+        int maxCount
+    ) => new(chain, maxCount);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveMaxFields";
+    string IRuleDescriptor.OperationName => "HaveMaxFields";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["maxCount"] = maxCount };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var count = type.GetFields(
+                BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.DeclaredOnly
+            )
+            .Count(f => !f.Name.StartsWith('<')); // Exclude compiler-generated backing fields
+
+        if (count <= maxCount)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have at most {maxCount} fields, "
+            + $"but '{type.Name}' has {count}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMaxPublicMethodsValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMaxPublicMethodsValidator.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has at most the specified number of public methods (declared only, excluding
+/// property accessors, event accessors, and methods inherited from <see cref="object"/>).
+/// </summary>
+internal class ReflectedTypeHaveMaxPublicMethodsValidator(PrincipalChain<Type?> chain, int maxCount)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveMaxPublicMethodsValidator New(
+        PrincipalChain<Type?> chain,
+        int maxCount
+    ) => new(chain, maxCount);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveMaxPublicMethods";
+    string IRuleDescriptor.OperationName => "HaveMaxPublicMethods";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["maxCount"] = maxCount };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var count = type.GetMethods(
+                BindingFlags.Public
+                    | BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.DeclaredOnly
+            )
+            .Count(m => !m.IsSpecialName); // Excludes property/event accessors, operators
+
+        if (count <= maxCount)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have at most {maxCount} public methods, "
+            + $"but '{type.Name}' has {count}.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMethodOverrideValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMethodOverrideValidator.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type overrides the specified method (declared in a base type).
+/// </summary>
+internal class ReflectedTypeHaveMethodOverrideValidator(
+    PrincipalChain<Type?> chain,
+    string methodName
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveMethodOverrideValidator New(
+        PrincipalChain<Type?> chain,
+        string methodName
+    ) => new(chain, methodName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveMethodOverride";
+    string IRuleDescriptor.OperationName => "HaveMethodOverride";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["methodName"] = methodName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Search instance methods (overrides are always instance, not static)
+        var methods = type.GetMethods(
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Instance
+                | BindingFlags.DeclaredOnly
+        );
+
+        if (
+            (
+                from method in methods
+                where method.Name == methodName
+                select method.GetBaseDefinition()
+            ).Any(baseDefinition => baseDefinition.DeclaringType != type)
+        )
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to override method '{methodName}', "
+            + $"but '{type.Name}' does not override it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMethodReturningValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveMethodReturningValidator.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a public method with the specified name and return type.
+/// </summary>
+internal class ReflectedTypeHaveMethodReturningValidator(
+    PrincipalChain<Type?> chain,
+    string methodName,
+    Type expectedReturnType
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveMethodReturningValidator New(
+        PrincipalChain<Type?> chain,
+        string methodName,
+        Type expectedReturnType
+    ) => new(chain, methodName, expectedReturnType);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveMethodReturning";
+    string IRuleDescriptor.OperationName => "HaveMethodReturning";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["methodName"] = methodName,
+            ["returnType"] = expectedReturnType
+        };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var methods = type.GetMethods(
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
+        );
+        var match = methods.FirstOrDefault(
+            m => m.Name == methodName && m.ReturnType == expectedReturnType
+        );
+
+        if (match != null)
+        {
+            return true;
+        }
+
+        var existing = methods.FirstOrDefault(m => m.Name == methodName);
+
+        if (existing == null)
+        {
+            ResultValidation =
+                $"The type was expected to have a method '{methodName}' "
+                + $"returning '{expectedReturnType.Name}', but '{type.Name}' has no method named '{methodName}'.";
+        }
+        else
+        {
+            ResultValidation =
+                $"The type was expected to have a method '{methodName}' "
+                + $"returning '{expectedReturnType.Name}', but the actual return type is '{existing.ReturnType.Name}'.";
+        }
+
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameEndingWithValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameEndingWithValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type name ends with the specified suffix.
+/// </summary>
+internal class ReflectedTypeHaveNameEndingWithValidator(PrincipalChain<Type?> chain, string suffix)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveNameEndingWithValidator New(
+        PrincipalChain<Type?> chain,
+        string suffix
+    ) => new(chain, suffix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveNameEndingWith";
+    string IRuleDescriptor.OperationName => "HaveNameEndingWith";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["suffix"] = suffix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.Name.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type name was expected to end with \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameStartingWithValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameStartingWithValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type name starts with the specified prefix.
+/// </summary>
+internal class ReflectedTypeHaveNameStartingWithValidator(
+    PrincipalChain<Type?> chain,
+    string prefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHaveNameStartingWithValidator New(
+        PrincipalChain<Type?> chain,
+        string prefix
+    ) => new(chain, prefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveNameStartingWith";
+    string IRuleDescriptor.OperationName => "HaveNameStartingWith";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["prefix"] = prefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type.Name.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type name was expected to start with \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveNameValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has the specified name.
+/// </summary>
+internal class ReflectedTypeHaveNameValidator(PrincipalChain<Type?> chain, string expectedName)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveNameValidator New(
+        PrincipalChain<Type?> chain,
+        string expectedName
+    ) => new(chain, expectedName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveName";
+    string IRuleDescriptor.OperationName => "HaveName";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["name"] = expectedName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (string.Equals(type.Name, expectedName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to have name \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePrivateConstructorWithParametersValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePrivateConstructorWithParametersValidator.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a private (or internal) constructor with the specified parameter types.
+/// If no parameter types are specified, checks for a private parameterless constructor.
+/// </summary>
+internal class ReflectedTypeHavePrivateConstructorWithParametersValidator(
+    PrincipalChain<Type?> chain,
+    Type[] expectedParameters
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHavePrivateConstructorWithParametersValidator New(
+        PrincipalChain<Type?> chain,
+        params Type[] expectedParameters
+    ) => new(chain, expectedParameters);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HavePrivateConstructorWithParameters";
+    string IRuleDescriptor.OperationName => "HavePrivateConstructorWithParameters";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["parameterTypes"] = expectedParameters };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Search non-public constructors (private, protected, internal)
+        var ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
+
+        if (
+            (
+                from ctor in ctors
+                where ctor is not { IsPrivate: false, IsAssembly: false }
+                select ctor.GetParameters().Select(p => p.ParameterType).ToArray()
+            ).Any(
+                paramTypes =>
+                    paramTypes.Length == expectedParameters.Length
+                    && paramTypes.SequenceEqual(expectedParameters)
+            )
+        )
+        {
+            return true;
+        }
+
+        var expectedStr =
+            expectedParameters.Length == 0
+                ? "(parameterless)"
+                : $"({string.Join(", ", expectedParameters.Select(t => t.Name))})";
+
+        ResultValidation =
+            $"The type was expected to have a private constructor with parameters {expectedStr}, "
+            + $"but '{type.Name}' does not have a matching private constructor.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePropertyOfTypeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePropertyOfTypeValidator.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has a public property with the specified name and type.
+/// </summary>
+internal class ReflectedTypeHavePropertyOfTypeValidator(
+    PrincipalChain<Type?> chain,
+    string propertyName,
+    Type expectedPropertyType
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeHavePropertyOfTypeValidator New(
+        PrincipalChain<Type?> chain,
+        string propertyName,
+        Type expectedPropertyType
+    ) => new(chain, propertyName, expectedPropertyType);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HavePropertyOfType";
+    string IRuleDescriptor.OperationName => "HavePropertyOfType";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>
+        {
+            ["propertyName"] = propertyName,
+            ["propertyType"] = expectedPropertyType
+        };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var prop = type.GetProperty(
+            propertyName,
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
+        );
+
+        if (prop != null && prop.PropertyType == expectedPropertyType)
+        {
+            return true;
+        }
+
+        if (prop == null)
+        {
+            ResultValidation =
+                $"The type was expected to have a property named '{propertyName}' "
+                + $"of type '{expectedPropertyType.Name}', but '{type.Name}' has no property named '{propertyName}'.";
+        }
+        else
+        {
+            ResultValidation =
+                $"The type was expected to have a property '{propertyName}' "
+                + $"of type '{expectedPropertyType.Name}', but the actual property type is '{prop.PropertyType.Name}'.";
+        }
+
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveProtectedMembersValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHaveProtectedMembersValidator.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type HAS at least one protected (or protected internal) member.
+/// </summary>
+internal class ReflectedTypeHaveProtectedMembersValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHaveProtectedMembersValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HaveProtectedMembers";
+    string IRuleDescriptor.OperationName => "HaveProtectedMembers";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    private const BindingFlags DeclaredMembers =
+        BindingFlags.Public
+        | BindingFlags.NonPublic
+        | BindingFlags.Instance
+        | BindingFlags.Static
+        | BindingFlags.DeclaredOnly;
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Check fields
+        if (type.GetFields(DeclaredMembers).Any(f => f.IsFamily || f.IsFamilyOrAssembly))
+        {
+            return true;
+        }
+
+        // Check methods
+        if (type.GetMethods(DeclaredMembers).Any(m => m.IsFamily || m.IsFamilyOrAssembly))
+        {
+            return true;
+        }
+
+        // Check properties (via accessor visibility)
+        if (
+            (
+                from prop in type.GetProperties(DeclaredMembers)
+                let getter = prop.GetGetMethod(true)
+                let setter = prop.GetSetMethod(true)
+                where
+                    (getter != null && (getter.IsFamily || getter.IsFamilyOrAssembly))
+                    || (setter != null && (setter.IsFamily || setter.IsFamilyOrAssembly))
+                select getter
+            ).Any()
+        )
+        {
+            return true;
+        }
+
+        // Check events
+        if (
+            type.GetEvents(DeclaredMembers)
+                .Select(evt => evt.GetAddMethod(true))
+                .OfType<MethodInfo>()
+                .Any(adder => adder.IsFamily || adder.IsFamilyOrAssembly)
+        )
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have at least one protected member, "
+            + $"but '{type.Name}' has none.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePublicConstructorValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeHavePublicConstructorValidator.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type has at least one public constructor.
+/// </summary>
+internal class ReflectedTypeHavePublicConstructorValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeHavePublicConstructorValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.HavePublicConstructor";
+    string IRuleDescriptor.OperationName => "HavePublicConstructor";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var publicCtors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        if (publicCtors.Length > 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have at least one public constructor, "
+            + $"but '{type.Name}' has no public constructors.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeImplementInterfaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeImplementInterfaceValidator.cs
@@ -1,0 +1,55 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type implements the specified interface.
+/// </summary>
+internal class ReflectedTypeImplementInterfaceValidator(
+    PrincipalChain<Type?> chain,
+    Type expectedInterface
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeImplementInterfaceValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedInterface
+    ) => new(chain, expectedInterface);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.ImplementInterface";
+    string IRuleDescriptor.OperationName => "ImplementInterface";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["interface"] = expectedInterface };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Support open generics: typeof(IRepository<>) should match IRepository<Customer>
+        if (expectedInterface.IsGenericTypeDefinition)
+        {
+            if (
+                type.GetInterfaces()
+                    .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == expectedInterface)
+            )
+            {
+                return true;
+            }
+        }
+        else
+        {
+            if (expectedInterface.IsAssignableFrom(type))
+            {
+                return true;
+            }
+        }
+
+        ResultValidation =
+            "The type was expected to implement '{0}', but '{1}' does not implement it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeMatchNameValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeMatchNameValidator.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type name matches the specified regular expression pattern.
+/// </summary>
+internal class ReflectedTypeMatchNameValidator(PrincipalChain<Type?> chain, string pattern)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeMatchNameValidator New(
+        PrincipalChain<Type?> chain,
+        string pattern
+    ) => new(chain, pattern);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.MatchName";
+    string IRuleDescriptor.OperationName => "MatchName";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["pattern"] = pattern };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (Regex.IsMatch(type.Name, pattern))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type name was expected to match pattern \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeMatchNamespaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeMatchNamespaceValidator.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type namespace matches the specified regular expression pattern.
+/// </summary>
+internal class ReflectedTypeMatchNamespaceValidator(PrincipalChain<Type?> chain, string pattern)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeMatchNamespaceValidator New(
+        PrincipalChain<Type?> chain,
+        string pattern
+    ) => new(chain, pattern);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.MatchNamespace";
+    string IRuleDescriptor.OperationName => "MatchNamespace";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["pattern"] = pattern };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var ns = type.Namespace ?? string.Empty;
+
+        if (Regex.IsMatch(ns, pattern))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type namespace was expected to match pattern \"{0}\", but the actual namespace is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeAbstractValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeAbstractValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT abstract (and not an interface).
+/// </summary>
+internal class ReflectedTypeNotBeAbstractValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeAbstractValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeAbstract";
+    string IRuleDescriptor.OperationName => "NotBeAbstract";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type is not { IsAbstract: true, IsInterface: false })
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be abstract, but '{type.Name}' is abstract.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeClassValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeClassValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT a class.
+/// </summary>
+internal class ReflectedTypeNotBeClassValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeClassValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeClass";
+    string IRuleDescriptor.OperationName => "NotBeClass";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.IsClass)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be a class, but '{type.Name}' is a class.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeGenericValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeGenericValidator.cs
@@ -1,0 +1,37 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT generic.
+/// </summary>
+internal class ReflectedTypeNotBeGenericValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeGenericValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeGeneric";
+    string IRuleDescriptor.OperationName => "NotBeGeneric";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.IsGenericType)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be generic, but '{type.Name}' is generic.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeImmutableValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeImmutableValidator.cs
@@ -1,0 +1,67 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT immutable (has at least one public mutable member).
+/// </summary>
+internal class ReflectedTypeNotBeImmutableValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeImmutableValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeImmutable";
+    string IRuleDescriptor.OperationName => "NotBeImmutable";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Returns true (passes) if the type HAS public mutable fields or settable properties
+        var hasMutableFields = type.GetFields(BindingFlags.Public | BindingFlags.Instance)
+            .Any(f => f is { IsInitOnly: false, IsLiteral: false });
+
+        if (hasMutableFields)
+        {
+            return true;
+        }
+
+        var hasMutableProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Any(HasPublicNonInitSetter);
+
+        if (hasMutableProperties)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be immutable, but '{type.Name}' appears immutable (no public mutable members).";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+
+    private static bool HasPublicNonInitSetter(PropertyInfo property)
+    {
+        var setter = property.SetMethod;
+
+        if (setter == null || !setter.IsPublic)
+        {
+            return false;
+        }
+
+        // Check for init-only: init setters have IsExternalInit as a required modifier
+        var requiredMods = setter.ReturnParameter.GetRequiredCustomModifiers();
+        return requiredMods.All(
+            m => m.FullName != "System.Runtime.CompilerServices.IsExternalInit"
+        );
+    }
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInNamespaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInNamespaceValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT in the specified namespace.
+/// </summary>
+internal class ReflectedTypeNotBeInNamespaceValidator(
+    PrincipalChain<Type?> chain,
+    string expectedNamespace
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotBeInNamespaceValidator New(
+        PrincipalChain<Type?> chain,
+        string expectedNamespace
+    ) => new(chain, expectedNamespace);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeInNamespace";
+    string IRuleDescriptor.OperationName => "NotBeInNamespace";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["expectedNamespace"] = expectedNamespace };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!string.Equals(type.Namespace, expectedNamespace, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation = "The type was expected to NOT be in namespace \"{0}\", but it is.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInterfaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInterfaceValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT an interface.
+/// </summary>
+internal class ReflectedTypeNotBeInterfaceValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeInterfaceValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeInterface";
+    string IRuleDescriptor.OperationName => "NotBeInterface";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.IsInterface)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be an interface, but '{type.Name}' is an interface.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInternalValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeInternalValidator.cs
@@ -1,0 +1,38 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT internal.
+/// </summary>
+internal class ReflectedTypeNotBeInternalValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeInternalValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeInternal";
+    string IRuleDescriptor.OperationName => "NotBeInternal";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!(type.IsNotPublic || type.IsNestedAssembly || type.IsNestedFamORAssem))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT be internal, but '{type.Name}' is internal.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBePublicValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBePublicValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT public.
+/// </summary>
+internal class ReflectedTypeNotBePublicValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBePublicValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBePublic";
+    string IRuleDescriptor.OperationName => "NotBePublic";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!(type.IsPublic || type.IsNestedPublic))
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to NOT be public, but '{type.Name}' is public.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeSealedValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeSealedValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT sealed.
+/// </summary>
+internal class ReflectedTypeNotBeSealedValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeSealedValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeSealed";
+    string IRuleDescriptor.OperationName => "NotBeSealed";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.IsSealed)
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to NOT be sealed, but '{type.Name}' is sealed.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeStaticValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotBeStaticValidator.cs
@@ -1,0 +1,36 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type is NOT static (abstract and sealed).
+/// </summary>
+internal class ReflectedTypeNotBeStaticValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotBeStaticValidator New(PrincipalChain<Type?> chain) => new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotBeStatic";
+    string IRuleDescriptor.OperationName => "NotBeStatic";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (type is not { IsAbstract: true, IsSealed: true })
+        {
+            return true;
+        }
+
+        ResultValidation = $"The type was expected to NOT be static, but '{type.Name}' is static.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotDeriveFromValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotDeriveFromValidator.cs
@@ -1,0 +1,64 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT derive from the specified base type.
+/// </summary>
+internal class ReflectedTypeNotDeriveFromValidator(PrincipalChain<Type?> chain, Type expectedBase)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotDeriveFromValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedBase
+    ) => new(chain, expectedBase);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotDeriveFrom";
+    string IRuleDescriptor.OperationName => "NotDeriveFrom";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["baseType"] = expectedBase };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Support open generics
+        bool derives;
+
+        if (expectedBase.IsGenericTypeDefinition)
+        {
+            var current = type.BaseType;
+            derives = false;
+
+            while (current != null)
+            {
+                if (current.IsGenericType && current.GetGenericTypeDefinition() == expectedBase)
+                {
+                    derives = true;
+                    break;
+                }
+
+                current = current.BaseType;
+            }
+        }
+        else
+        {
+            derives = expectedBase.IsAssignableFrom(type) && type != expectedBase;
+        }
+
+        if (!derives)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to NOT derive from '{0}', but '{1}' does derive from it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveAsyncVoidMethodsValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveAsyncVoidMethodsValidator.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have any async void methods.
+/// An async void method is a method with return type <c>void</c> that carries
+/// <see cref="AsyncStateMachineAttribute"/>.
+/// </summary>
+internal class ReflectedTypeNotHaveAsyncVoidMethodsValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveAsyncVoidMethodsValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveAsyncVoidMethods";
+    string IRuleDescriptor.OperationName => "NotHaveAsyncVoidMethods";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var asyncVoidMethods = type.GetMethods(
+                BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.DeclaredOnly
+            )
+            .Where(
+                m =>
+                    m.ReturnType == typeof(void)
+                    && m.GetCustomAttribute<AsyncStateMachineAttribute>() != null
+            )
+            .ToList();
+
+        if (asyncVoidMethods.Count == 0)
+        {
+            return true;
+        }
+
+        var names = string.Join(", ", asyncVoidMethods.Select(m => m.Name));
+        ResultValidation =
+            $"The type was expected to have no async void methods, "
+            + $"but '{type.Name}' has {asyncVoidMethods.Count}: [{names}].";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveAttributeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveAttributeValidator.cs
@@ -1,0 +1,40 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have the specified custom attribute.
+/// </summary>
+internal class ReflectedTypeNotHaveAttributeValidator(
+    PrincipalChain<Type?> chain,
+    Type expectedAttribute
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveAttributeValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedAttribute
+    ) => new(chain, expectedAttribute);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveAttribute";
+    string IRuleDescriptor.OperationName => "NotHaveAttribute";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["attributeType"] = expectedAttribute };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!Attribute.IsDefined(type, expectedAttribute, inherit: true))
+        {
+            return true;
+        }
+
+        ResultValidation = "The type was expected to NOT have attribute '{0}', but '{1}' has it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnAnyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnAnyValidator.cs
@@ -1,0 +1,48 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have a dependency on any of the specified namespaces.
+/// </summary>
+internal class ReflectedTypeNotHaveDependencyOnAnyValidator(
+    PrincipalChain<Type?> chain,
+    string[] namespacePrefixes
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveDependencyOnAnyValidator New(
+        PrincipalChain<Type?> chain,
+        string[] namespacePrefixes
+    ) => new(chain, namespacePrefixes);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveDependencyOnAny";
+    string IRuleDescriptor.OperationName => "NotHaveDependencyOnAny";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespaces"] = namespacePrefixes };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var scanner = DependencyScannerProvider.Current;
+        var matched = namespacePrefixes
+            .Where(ns => scanner.HasDependencyOnNamespace(type, ns))
+            .ToList();
+
+        if (matched.Count == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to NOT have a dependency on any of "
+            + $"[{string.Join(", ", namespacePrefixes.Select(n => $"'{n}'"))}], "
+            + $"but '{type.Name}' references: [{string.Join(", ", matched.Select(n => $"'{n}'"))}].";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnTypeValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnTypeValidator.cs
@@ -1,0 +1,43 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have a dependency on the specified type (by fully qualified name).
+/// </summary>
+internal class ReflectedTypeNotHaveDependencyOnTypeValidator(
+    PrincipalChain<Type?> chain,
+    string fullyQualifiedTypeName
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveDependencyOnTypeValidator New(
+        PrincipalChain<Type?> chain,
+        string fullyQualifiedTypeName
+    ) => new(chain, fullyQualifiedTypeName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveDependencyOnType";
+    string IRuleDescriptor.OperationName => "NotHaveDependencyOnType";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["typeName"] = fullyQualifiedTypeName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!DependencyScannerProvider.Current.HasDependencyOnType(type, fullyQualifiedTypeName))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT have a dependency on type '{fullyQualifiedTypeName}', "
+            + $"but '{type.Name}' references that type.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveDependencyOnValidator.cs
@@ -1,0 +1,42 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have a dependency on the specified namespace.
+/// </summary>
+internal class ReflectedTypeNotHaveDependencyOnValidator(
+    PrincipalChain<Type?> chain,
+    string namespacePrefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveDependencyOnValidator New(
+        PrincipalChain<Type?> chain,
+        string namespacePrefix
+    ) => new(chain, namespacePrefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveDependencyOn";
+    string IRuleDescriptor.OperationName => "NotHaveDependencyOn";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespace"] = namespacePrefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!DependencyScannerProvider.Current.HasDependencyOnNamespace(type, namespacePrefix))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to NOT have a dependency on '{0}', but '{1}' references that namespace.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveMethodOverrideValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveMethodOverrideValidator.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT override the specified method.
+/// </summary>
+internal class ReflectedTypeNotHaveMethodOverrideValidator(
+    PrincipalChain<Type?> chain,
+    string methodName
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveMethodOverrideValidator New(
+        PrincipalChain<Type?> chain,
+        string methodName
+    ) => new(chain, methodName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveMethodOverride";
+    string IRuleDescriptor.OperationName => "NotHaveMethodOverride";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["methodName"] = methodName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var methods = type.GetMethods(
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Instance
+                | BindingFlags.DeclaredOnly
+        );
+
+        foreach (var method in methods)
+        {
+            if (method.Name != methodName)
+            {
+                continue;
+            }
+
+            var baseDefinition = method.GetBaseDefinition();
+
+            if (baseDefinition.DeclaringType != type)
+            {
+                ResultValidation =
+                    $"The type was expected to NOT override method '{methodName}', "
+                    + $"but '{type.Name}' overrides it (base: '{baseDefinition.DeclaringType!.Name}').";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameEndingWithValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameEndingWithValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type name does NOT end with the specified suffix.
+/// </summary>
+internal class ReflectedTypeNotHaveNameEndingWithValidator(
+    PrincipalChain<Type?> chain,
+    string suffix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveNameEndingWithValidator New(
+        PrincipalChain<Type?> chain,
+        string suffix
+    ) => new(chain, suffix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveNameEndingWith";
+    string IRuleDescriptor.OperationName => "NotHaveNameEndingWith";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["suffix"] = suffix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.Name.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type name was expected to NOT end with \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameStartingWithValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameStartingWithValidator.cs
@@ -1,0 +1,41 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type name does NOT start with the specified prefix.
+/// </summary>
+internal class ReflectedTypeNotHaveNameStartingWithValidator(
+    PrincipalChain<Type?> chain,
+    string prefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveNameStartingWithValidator New(
+        PrincipalChain<Type?> chain,
+        string prefix
+    ) => new(chain, prefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveNameStartingWith";
+    string IRuleDescriptor.OperationName => "NotHaveNameStartingWith";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["prefix"] = prefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!type.Name.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type name was expected to NOT start with \"{0}\", but the actual name is \"{1}\".";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveNameValidator.cs
@@ -1,0 +1,39 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have the specified name.
+/// </summary>
+internal class ReflectedTypeNotHaveNameValidator(PrincipalChain<Type?> chain, string expectedName)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveNameValidator New(
+        PrincipalChain<Type?> chain,
+        string expectedName
+    ) => new(chain, expectedName);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveName";
+    string IRuleDescriptor.OperationName => "NotHaveName";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["expectedName"] = expectedName };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (!string.Equals(type.Name, expectedName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        ResultValidation = "The type was expected to NOT have name \"{0}\", but it does.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveProtectedMembersValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHaveProtectedMembersValidator.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+using JAAvila.SafeTypes.Extension;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have any protected (or protected internal) members.
+/// </summary>
+internal class ReflectedTypeNotHaveProtectedMembersValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotHaveProtectedMembersValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHaveProtectedMembers";
+    string IRuleDescriptor.OperationName => "NotHaveProtectedMembers";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    private const BindingFlags DeclaredMembers =
+        BindingFlags.Public
+        | BindingFlags.NonPublic
+        | BindingFlags.Instance
+        | BindingFlags.Static
+        | BindingFlags.DeclaredOnly;
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var protectedMembers = (
+            from field in type.GetFields(DeclaredMembers)
+            where field.IsFamily || field.IsFamilyOrAssembly
+            select $"field '{field.Name}'"
+        ).ToList();
+        protectedMembers.AddRange(
+            from method in type.GetMethods(DeclaredMembers)
+            where method.IsFamily || method.IsFamilyOrAssembly
+            select $"method '{method.Name}'"
+        );
+
+        protectedMembers.AddRange(
+            from prop in type.GetProperties(DeclaredMembers)
+            let getter = prop.GetGetMethod(true)
+            let setter = prop.GetSetMethod(true)
+            where
+                (getter != null && (getter.IsFamily || getter.IsFamilyOrAssembly))
+                || (setter != null && (setter.IsFamily || setter.IsFamilyOrAssembly))
+            select $"property '{prop.Name}'"
+        );
+
+        protectedMembers.AddRange(
+            from adder in from evt in type.GetEvents(DeclaredMembers)
+            let adder = evt.GetAddMethod(true)
+            select adder
+            where !adder.IsNull() && (adder.IsFamily || adder.IsFamilyOrAssembly)
+            select $"event '{adder.Name}'"
+        );
+
+        if (protectedMembers.Count == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have no protected members, "
+            + $"but '{type.Name}' has {protectedMembers.Count}: [{string.Join(", ", protectedMembers)}].";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHavePublicConstructorValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotHavePublicConstructorValidator.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT have any public constructors.
+/// </summary>
+internal class ReflectedTypeNotHavePublicConstructorValidator(PrincipalChain<Type?> chain)
+    : IValidator,
+        IRuleDescriptor
+{
+    public static ReflectedTypeNotHavePublicConstructorValidator New(PrincipalChain<Type?> chain) =>
+        new(chain);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotHavePublicConstructor";
+    string IRuleDescriptor.OperationName => "NotHavePublicConstructor";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object>();
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var publicCtors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+
+        if (publicCtors.Length == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to have no public constructors, "
+            + $"but '{type.Name}' has {publicCtors.Length} public constructor(s).";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotImplementInterfaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotImplementInterfaceValidator.cs
@@ -1,0 +1,54 @@
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type does NOT implement the specified interface.
+/// </summary>
+internal class ReflectedTypeNotImplementInterfaceValidator(
+    PrincipalChain<Type?> chain,
+    Type expectedInterface
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotImplementInterfaceValidator New(
+        PrincipalChain<Type?> chain,
+        Type expectedInterface
+    ) => new(chain, expectedInterface);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotImplementInterface";
+    string IRuleDescriptor.OperationName => "NotImplementInterface";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["interface"] = expectedInterface };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        // Support open generics: typeof(IRepository<>) should match IRepository<Customer>
+        bool implements;
+
+        if (expectedInterface.IsGenericTypeDefinition)
+        {
+            implements = type.GetInterfaces()
+                .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == expectedInterface);
+        }
+        else
+        {
+            implements = expectedInterface.IsAssignableFrom(type);
+        }
+
+        if (!implements)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            "The type was expected to NOT implement '{0}', but '{1}' does implement it.";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotReturnTypesFromNamespaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeNotReturnTypesFromNamespaceValidator.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that none of the type's public methods return types from the specified namespace.
+/// Also inspects generic type arguments of return types (e.g., <c>Task&lt;DbConnection&gt;</c>).
+/// </summary>
+internal class ReflectedTypeNotReturnTypesFromNamespaceValidator(
+    PrincipalChain<Type?> chain,
+    string namespacePrefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeNotReturnTypesFromNamespaceValidator New(
+        PrincipalChain<Type?> chain,
+        string namespacePrefix
+    ) => new(chain, namespacePrefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.NotReturnTypesFromNamespace";
+    string IRuleDescriptor.OperationName => "NotReturnTypesFromNamespace";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespace"] = namespacePrefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var violations = (
+            from method in type.GetMethods(
+                BindingFlags.Public
+                    | BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.DeclaredOnly
+            )
+            where !method.IsSpecialName
+            where TypeMatchesNamespace(method.ReturnType, namespacePrefix)
+            select $"'{method.Name}' returns '{method.ReturnType.Name}'"
+        ).ToList();
+
+        if (violations.Count == 0)
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to NOT return types from namespace '{namespacePrefix}', "
+            + $"but '{type.Name}' has violations: [{string.Join(", ", violations)}].";
+        return false;
+    }
+
+    /// <summary>
+    /// Recursively checks if a type or any of its generic arguments belongs to the namespace.
+    /// </summary>
+    private static bool TypeMatchesNamespace(Type returnType, string ns)
+    {
+        // Direct match
+        if (
+            returnType.Namespace != null
+            && (
+                string.Equals(returnType.Namespace, ns, StringComparison.Ordinal)
+                || returnType.Namespace.StartsWith(ns + ".", StringComparison.Ordinal)
+            )
+        )
+        {
+            return true;
+        }
+
+        // Check generic arguments (e.g., Task<DbConnection>, IEnumerable<EfEntity>)
+        if (returnType.IsGenericType)
+        {
+            if (
+                returnType
+                    .GetGenericArguments()
+                    .Any(arg => !arg.IsGenericParameter && TypeMatchesNamespace(arg, ns))
+            )
+            {
+                return true;
+            }
+        }
+
+        // Check array element type
+        if (returnType.IsArray && returnType.GetElementType() is { } elemType)
+        {
+            return TypeMatchesNamespace(elemType, ns);
+        }
+
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeOnlyHaveDependenciesOnValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeOnlyHaveDependenciesOnValidator.cs
@@ -1,0 +1,49 @@
+using JAAvila.FluentOperations.Architecture;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type only has dependencies on the specified namespaces (whitelist).
+/// </summary>
+internal class ReflectedTypeOnlyHaveDependenciesOnValidator(
+    PrincipalChain<Type?> chain,
+    string[] allowedNamespaces
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeOnlyHaveDependenciesOnValidator New(
+        PrincipalChain<Type?> chain,
+        params string[] allowedNamespaces
+    ) => new(chain, allowedNamespaces);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.OnlyHaveDependenciesOn";
+    string IRuleDescriptor.OperationName => "OnlyHaveDependenciesOn";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["allowedNamespaces"] = allowedNamespaces };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+        var (isCompliant, violating) = DependencyScannerProvider.Current.CheckOnlyDependenciesOn(
+            type,
+            allowedNamespaces
+        );
+
+        if (isCompliant)
+        {
+            return true;
+        }
+
+        var allowedStr = string.Join(", ", allowedNamespaces);
+        var violatingStr = string.Join(", ", violating);
+        ResultValidation =
+            $"The type was expected to only have dependencies on [{allowedStr}], "
+            + $"but '{type.Name}' also depends on: [{violatingStr}].";
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeReturnTypesFromNamespaceValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/ReflectedTypeReturnTypesFromNamespaceValidator.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using JAAvila.FluentOperations.Contract;
+
+namespace JAAvila.FluentOperations.Validators;
+
+/// <summary>
+/// Validates that the type HAS at least one public method that returns a type from the specified namespace.
+/// </summary>
+internal class ReflectedTypeReturnTypesFromNamespaceValidator(
+    PrincipalChain<Type?> chain,
+    string namespacePrefix
+) : IValidator, IRuleDescriptor
+{
+    public static ReflectedTypeReturnTypesFromNamespaceValidator New(
+        PrincipalChain<Type?> chain,
+        string namespacePrefix
+    ) => new(chain, namespacePrefix);
+
+    public string Expected { get; } = null!;
+    public string ResultValidation { get; set; } = null!;
+    public string MessageKey => "ReflectedType.ReturnTypesFromNamespace";
+    string IRuleDescriptor.OperationName => "ReturnTypesFromNamespace";
+    Type IRuleDescriptor.SubjectType => typeof(Type);
+    IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
+        new Dictionary<string, object> { ["namespace"] = namespacePrefix };
+
+    public bool Validate()
+    {
+        var type = chain.GetValue()!;
+
+        if (
+            type.GetMethods(
+                    BindingFlags.Public
+                        | BindingFlags.Instance
+                        | BindingFlags.Static
+                        | BindingFlags.DeclaredOnly
+                )
+                .Where(method => !method.IsSpecialName)
+                .Any(method => TypeMatchesNamespace(method.ReturnType, namespacePrefix))
+        )
+        {
+            return true;
+        }
+
+        ResultValidation =
+            $"The type was expected to return types from namespace '{namespacePrefix}', "
+            + $"but '{type.Name}' has no public methods returning types from that namespace.";
+        return false;
+    }
+
+    private static bool TypeMatchesNamespace(Type returnType, string ns)
+    {
+        if (
+            returnType.Namespace != null
+            && (
+                string.Equals(returnType.Namespace, ns, StringComparison.Ordinal)
+                || returnType.Namespace.StartsWith(ns + ".", StringComparison.Ordinal)
+            )
+        )
+            return true;
+
+        if (returnType.IsGenericType)
+        {
+            foreach (var arg in returnType.GetGenericArguments())
+            {
+                if (!arg.IsGenericParameter && TypeMatchesNamespace(arg, ns))
+                    return true;
+            }
+        }
+
+        if (returnType.IsArray && returnType.GetElementType() is { } elemType)
+            return TypeMatchesNamespace(elemType, ns);
+
+        return false;
+    }
+
+    public Task<bool> ValidateAsync() => Task.FromResult(Validate());
+}

--- a/JAAvila.FluentOperations.sln
+++ b/JAAvila.FluentOperations.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Gr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.DataAnnotations", "Distributed\JAAvila.FluentOperations.DataAnnotations\JAAvila.FluentOperations.DataAnnotations.csproj", "{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JAAvila.FluentOperations.Architecture", "Distributed\JAAvila.FluentOperations.Architecture\JAAvila.FluentOperations.Architecture.csproj", "{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,18 @@ Global
 		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x64.Build.0 = Release|Any CPU
 		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F}.Release|x86.Build.0 = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|x64.Build.0 = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Debug|x86.Build.0 = Debug|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|x64.Build.0 = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -152,5 +166,6 @@ Global
 		{E7DF8B17-5526-46C7-AE99-1E8C4E26D727} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{856C3FD8-F8C6-4399-9733-8D4089BA60AD} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 		{E30EC8CC-41B3-4A46-8F55-01B77DD5BF3F} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
+		{FA3D63E2-484F-4E4F-8D1E-E63412A47EA5} = {13A139BD-5932-41F1-96B3-EC6BB0C219B9}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A fluent validation and testing library for .NET that unifies inline assertions 
 | `JAAvila.FluentOperations.OpenApi` | Swashbuckle schema filter that enriches OpenAPI schemas with blueprint constraints |
 | `JAAvila.FluentOperations.Grpc` | gRPC server interceptor for automatic request validation |
 | `JAAvila.FluentOperations.DataAnnotations` | DataAnnotations bridge — generate blueprint rules from attributes |
+| `JAAvila.FluentOperations.Architecture` | Deep dependency detection via Mono.Cecil (opt-in IL-level scanning for architecture tests) |
 
 ```bash
 dotnet add package JAAvila.FluentOperations
@@ -96,6 +97,8 @@ if (!report.IsValid)
 | **Special** | `Guid`, `Guid?`, `Enum<T>`, `Uri?` | Be, BeEmpty, BeDefined, HaveFlag, HaveScheme, BeAbsolute... |
 | **Object** | `object?` | BeNull, NotBeNull, BeSameAs, BeOfType, BeAssignableTo, BeEquivalentTo (with builder options) |
 | **Action** | `Action`, `Func<Task>` | Throw, ThrowExactly, NotThrow, NotThrowAfter, CompleteWithinAsync |
+| **Type** | `Type` | 77 ops: BeClass, BeInterface, BeAbstract, BeSealed, BeStatic, BePublic, BeInternal, BeGeneric, BeRecord, BeValueType, BeEnum, BeNested, BeImmutable, BeInNamespace, ImplementInterface, DeriveFrom, HaveAttribute, HaveConstructorWithParameters, HavePropertyOfType, HaveMethodReturning, HaveMethodOverride, HaveMaxPublicMethods, HaveMaxFields, NotHaveAsyncVoidMethods, HaveDependencyOn, OnlyHaveDependenciesOn, HaveDependencyOnType, MatchName, MatchNamespace... |
+| **Assembly** | `Assembly` | 8 ops: ContainType, ContainTypeMatching, ReferenceAssembly, NotReferenceAssembly, HaveVersion, HaveMinimumVersion, HavePublicKey |
 
 ## Blueprint Features
 
@@ -375,6 +378,92 @@ using (new AssertionScope())
 var report = blueprint.Check(user);
 ```
 
+## Architecture Testing
+
+Validate code structure, naming conventions, dependency rules, and design constraints at test time.
+
+### Type Assertions
+
+```csharp
+using JAAvila.FluentOperations;
+
+// Structural rules
+typeof(MyService).Test()
+    .BeClass()
+    .BePublic()
+    .NotBeAbstract()
+    .ImplementInterface<IMyService>()
+    .NotHaveAsyncVoidMethods();
+
+// Naming conventions
+typeof(UserRepository).Test()
+    .HaveNameEndingWith("Repository")
+    .BeInNamespaceStartingWith("MyApp.Infrastructure");
+
+// Dependency rules
+typeof(DomainEntity).Test()
+    .NotHaveDependencyOn("MyApp.Infrastructure")
+    .NotHaveDependencyOn("Microsoft.EntityFrameworkCore")
+    .OnlyHaveDependenciesOn("MyApp.Domain", "MyApp.Shared");
+
+// Constructor and member rules
+typeof(MyController).Test()
+    .HavePublicConstructor()
+    .HaveMaxPublicMethods(10)
+    .HaveMaxFields(5);
+```
+
+### Assembly Assertions
+
+```csharp
+typeof(MyService).Assembly.Test()
+    .ContainType<MyService>()
+    .ContainTypeMatching(@".*Controller$")
+    .NotReferenceAssembly("Newtonsoft.Json")
+    .HaveMinimumVersion(new Version(1, 0));
+```
+
+### Batch Type Selection
+
+Use the `Types` utility to select and filter types, then validate each one:
+
+```csharp
+using JAAvila.FluentOperations.Architecture;
+
+// All services in an assembly must implement their interface
+var serviceTypes = Types.InAssembly(typeof(MyService).Assembly)
+    .That(t => t.IsClass && t.Name.EndsWith("Service"));
+
+foreach (var type in serviceTypes)
+    type.Test().ImplementInterface<IService>();
+
+// Domain types must not depend on infrastructure
+var domainTypes = Types.InNamespace("MyApp.Domain");
+
+foreach (var type in domainTypes)
+    type.Test().NotHaveDependencyOn("MyApp.Infrastructure");
+```
+
+### Deep Dependency Scanning (Optional)
+
+For IL-level dependency detection (method bodies, lambdas, async state machines), install the optional package:
+
+```bash
+dotnet add package JAAvila.FluentOperations.Architecture
+```
+
+```csharp
+using JAAvila.FluentOperations.Architecture;
+
+[OneTimeSetUp]
+public void SetUp() => ArchitectureScannerConfig.UseCecilDependencyScanning();
+
+[OneTimeTearDown]
+public void TearDown() => ArchitectureScannerConfig.Reset();
+```
+
+See [API Reference — Architecture Testing](./docs/API.md#architecture-testing) for the complete list of 85+ operations.
+
 ## Framework Integration
 
 ### ASP.NET Core
@@ -593,9 +682,9 @@ FluentOperationsConfig.Configure(c =>
 ## Project Stats
 
 - **6528+ tests** across NUnit test projects
-- **730+ validators** covering 20+ data types
-- **37+ operation managers** with fluent chaining
-- **9 NuGet packages** (core + integrations + analyzers + tooling)
+- **800+ validators** covering 20+ data types including architecture testing
+- **39+ operation managers** with fluent chaining
+- **10 NuGet packages** (core + integrations + analyzers + architecture + tooling)
 - **Performance optimized** with lazy initialization, caching, and zero-allocation patterns
 
 ## License

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,6 +30,9 @@ Complete API documentation for JAAvila.FluentOperations.
   - [Custom Validator Operations](#custom-validator-operations)
   - [Action / Async Action](#action-validations)
   - [ActionStats (Execution Statistics)](#actionstats-execution-statistics)
+  - [Type (Architecture Testing)](#type-validations)
+  - [Assembly (Architecture Testing)](#assembly-validations)
+- [Types Utility (Type Selection)](#types-utility-type-selection)
 - [Reusable Rule Builders](#reusable-rule-builders)
 - [Quality Blueprints](#quality-blueprints)
   - [QualityBlueprint&lt;T&gt;](#qualityblueprintt)
@@ -1057,6 +1060,227 @@ asyncStats.Test().CompleteWithinMilliseconds(500);
 var info = action.Stats();
 Console.WriteLine($"Took {info.ElapsedMilliseconds}ms, Memory: {info.MemoryDelta} bytes");
 ```
+
+---
+
+## Architecture Testing
+
+FluentOperations supports architecture-level assertions on `Type` and `Assembly` values, plus a `Types` utility for selecting and filtering types from assemblies and namespaces.
+
+### Type Validations
+
+Manager: `TypeOperationsManager` (via `.Test()` on `Type`)
+
+All methods support an optional `Reason? reason` parameter and return `TypeOperationsManager` for chaining.
+
+#### Type Classification
+
+| Method | Description |
+|--------|-------------|
+| `BeClass()` | The type is a class (not interface, not value type) |
+| `NotBeClass()` | The type is not a class |
+| `BeInterface()` | The type is an interface |
+| `NotBeInterface()` | The type is not an interface |
+| `BeAbstract()` | The type is abstract (excludes interfaces) |
+| `NotBeAbstract()` | The type is not abstract |
+| `BeSealed()` | The type is sealed |
+| `NotBeSealed()` | The type is not sealed |
+| `BeStatic()` | The type is static (abstract + sealed) |
+| `NotBeStatic()` | The type is not static |
+| `BePublic()` | The type is public |
+| `NotBePublic()` | The type is not public |
+| `BeInternal()` | The type is internal (not public) |
+| `NotBeInternal()` | The type is not internal |
+| `BeGeneric()` | The type is a generic type definition |
+| `NotBeGeneric()` | The type is not generic |
+| `BeRecord()` | The type is a record (class or struct) |
+| `BeValueType()` | The type is a value type (struct or enum) |
+| `BeEnum()` | The type is an enum |
+| `BeNested()` | The type is nested inside another type |
+| `BeImmutable()` | The type has no public settable properties and no public mutable fields |
+| `NotBeImmutable()` | The type is not immutable |
+
+#### Namespace and Naming
+
+| Method | Description |
+|--------|-------------|
+| `BeInNamespace(string)` | The type resides in the exact namespace |
+| `NotBeInNamespace(string)` | The type does not reside in the namespace |
+| `BeInNamespaceStartingWith(string)` | The type's namespace starts with the prefix (matches exact and child namespaces) |
+| `HaveName(string)` | The type has the exact name |
+| `NotHaveName(string)` | The type does not have the name |
+| `HaveNameEndingWith(string)` | The type name ends with the suffix |
+| `NotHaveNameEndingWith(string)` | The type name does not end with the suffix |
+| `HaveNameStartingWith(string)` | The type name starts with the prefix |
+| `NotHaveNameStartingWith(string)` | The type name does not start with the prefix |
+| `MatchName(string)` | The type name matches the regex pattern |
+| `MatchNamespace(string)` | The type namespace matches the regex pattern |
+
+#### Inheritance and Interfaces
+
+| Method | Description |
+|--------|-------------|
+| `ImplementInterface<T>()` | The type implements the specified interface |
+| `ImplementInterface(Type)` | The type implements the specified interface |
+| `NotImplementInterface<T>()` | The type does not implement the interface |
+| `NotImplementInterface(Type)` | The type does not implement the interface |
+| `DeriveFrom<T>()` | The type derives from the base type |
+| `DeriveFrom(Type)` | The type derives from the base type |
+| `NotDeriveFrom<T>()` | The type does not derive from the base type |
+| `NotDeriveFrom(Type)` | The type does not derive from the base type |
+
+#### Attributes
+
+| Method | Description |
+|--------|-------------|
+| `HaveAttribute<T>()` | The type has the specified custom attribute |
+| `HaveAttribute(Type)` | The type has the specified custom attribute |
+| `NotHaveAttribute<T>()` | The type does not have the attribute |
+| `NotHaveAttribute(Type)` | The type does not have the attribute |
+
+#### Constructors
+
+| Method | Description |
+|--------|-------------|
+| `HavePublicConstructor()` | The type has at least one public constructor |
+| `NotHavePublicConstructor()` | The type has no public constructors |
+| `HaveConstructorWithParameters(params Type[])` | The type has a public constructor with the specified parameter types |
+| `HaveConstructorWithParameters(Reason?, params Type[])` | Same, with reason |
+| `HavePrivateConstructorWithParameters(params Type[])` | The type has a private/internal constructor with the specified parameter types |
+| `HavePrivateConstructorWithParameters(Reason?, params Type[])` | Same, with reason |
+
+#### Members
+
+| Method | Description |
+|--------|-------------|
+| `HavePropertyOfType<T>(string)` | The type has a public property with the given name and type |
+| `HavePropertyOfType(string, Type)` | The type has a public property with the given name and type |
+| `HaveMethodReturning<T>(string)` | The type has a public method with the given name and return type |
+| `HaveMethodReturning(string, Type)` | The type has a public method with the given name and return type |
+| `HaveMethodOverride(string)` | The type overrides a method from its base type |
+| `NotHaveMethodOverride(string)` | The type does not override the method |
+| `HaveProtectedMembers()` | The type has at least one protected/protected internal member |
+| `NotHaveProtectedMembers()` | The type has no protected members |
+| `HaveMaxPublicMethods(int)` | The type has at most N public methods (god class detection) |
+| `HaveMaxFields(int)` | The type has at most N fields (excludes compiler-generated backing fields) |
+
+#### Method Body Analysis
+
+| Method | Description |
+|--------|-------------|
+| `HaveAsyncVoidMethods()` | The type has at least one `async void` method |
+| `NotHaveAsyncVoidMethods()` | The type has no `async void` methods (fire-and-forget antipattern detection) |
+| `ReturnTypesFromNamespace(string)` | At least one public method returns a type from the namespace |
+| `NotReturnTypesFromNamespace(string)` | No public methods return types from the namespace (leaky abstraction detection) |
+
+#### Dependency Analysis
+
+Dependency operations scan field types, property types, constructor parameters, method parameters, return types, base types, interfaces, generic arguments, and attributes. With the optional `JAAvila.FluentOperations.Architecture` package, they also scan IL method bodies (local variables, `new` calls, `typeof()`, casts, method calls, field access, catch blocks).
+
+| Method | Description |
+|--------|-------------|
+| `HaveDependencyOn(string)` | The type depends on the namespace (prefix match) |
+| `NotHaveDependencyOn(string)` | The type does not depend on the namespace |
+| `HaveDependencyOnAny(params string[])` | The type depends on at least one of the namespaces (OR) |
+| `HaveDependencyOnAny(Reason?, params string[])` | Same, with reason |
+| `NotHaveDependencyOnAny(params string[])` | The type does not depend on any of the namespaces |
+| `NotHaveDependencyOnAny(Reason?, params string[])` | Same, with reason |
+| `OnlyHaveDependenciesOn(params string[])` | All non-BCL dependencies are within the whitelist (`System.*` and `Microsoft.*` are implicitly allowed) |
+| `OnlyHaveDependenciesOn(Reason?, params string[])` | Same, with reason |
+| `HaveDependencyOnType<T>()` | The type depends on the specific type |
+| `HaveDependencyOnType(string)` | The type depends on the fully qualified type name |
+| `NotHaveDependencyOnType<T>()` | The type does not depend on the specific type |
+| `NotHaveDependencyOnType(string)` | The type does not depend on the fully qualified type name |
+
+### Assembly Validations
+
+Manager: `AssemblyOperationsManager` (via `.Test()` on `Assembly`)
+
+All methods support an optional `Reason? reason` parameter and return `AssemblyOperationsManager` for chaining.
+
+| Method | Description |
+|--------|-------------|
+| `ContainType<T>()` | The assembly contains the specified type |
+| `ContainType(Type)` | The assembly contains the specified type |
+| `ContainTypeMatching(string)` | The assembly contains a type whose full name matches the regex pattern |
+| `ReferenceAssembly(string)` | The assembly references the named assembly |
+| `NotReferenceAssembly(string)` | The assembly does not reference the named assembly |
+| `HaveVersion(Version)` | The assembly version matches exactly |
+| `HaveMinimumVersion(Version)` | The assembly version is at least the minimum |
+| `HavePublicKey()` | The assembly is strong-named (has a public key) |
+
+### Types Utility (Type Selection)
+
+The `Types` static class (in `JAAvila.FluentOperations.Architecture` namespace within the core package) provides methods for selecting and filtering types from assemblies and namespaces.
+
+#### Assembly Selection
+
+```csharp
+// All public types in an assembly
+IEnumerable<Type> types = Types.InAssembly(typeof(MyService).Assembly);
+
+// Filtered types
+IEnumerable<Type> services = Types.InAssembly(assembly, t => t.Name.EndsWith("Service"));
+
+// Safe loading (handles ReflectionTypeLoadException)
+IEnumerable<Type> safe = Types.InAssemblySafe(assembly);
+
+// Multiple assemblies
+IEnumerable<Type> all = Types.InAssemblies(assembly1, assembly2);
+IEnumerable<Type> filtered = Types.InAssemblies(new[] { assembly1, assembly2 }, t => t.IsPublic);
+IEnumerable<Type> allSafe = Types.InAssembliesSafe(assembly1, assembly2);
+
+// Shorthand alias
+IEnumerable<Type> types = Types.In(assembly);
+```
+
+#### Namespace and Domain Selection
+
+```csharp
+// All public types in a namespace (across all loaded assemblies)
+IEnumerable<Type> domainTypes = Types.InNamespace("MyApp.Domain");
+
+// Types sharing the same namespace as a given type
+IEnumerable<Type> peers = Types.InNamespaceOf<MyService>();
+
+// All public types in the current AppDomain
+IEnumerable<Type> everything = Types.InCurrentDomain();
+```
+
+#### Fluent Filtering
+
+```csharp
+// Chain .That() for fluent predicate filtering
+Types.InAssembly(assembly)
+    .That(t => t.IsClass && !t.IsAbstract)
+    .ToList()
+    .ForEach(t => t.Test().ImplementInterface<IService>());
+```
+
+### Deep Dependency Scanning (Mono.Cecil)
+
+Install the optional `JAAvila.FluentOperations.Architecture` package for IL-level dependency detection:
+
+```bash
+dotnet add package JAAvila.FluentOperations.Architecture
+```
+
+Activate in test setup:
+
+```csharp
+using JAAvila.FluentOperations.Architecture;
+
+[OneTimeSetUp]
+public void SetUp() => ArchitectureScannerConfig.UseCecilDependencyScanning();
+
+[OneTimeTearDown]
+public void TearDown() => ArchitectureScannerConfig.Reset();
+```
+
+When active, `HaveDependencyOn`, `NotHaveDependencyOn`, `OnlyHaveDependenciesOn`, `HaveDependencyOnType`, and `NotHaveDependencyOnType` detect dependencies inside method bodies:
+- Local variables, `new` calls, `typeof()`, casts, method calls, field access, catch blocks, lambdas, async state machines.
+
+Without this package, these operations use reflection-only scanning (type signatures, fields, properties, constructors, inheritance, interfaces, attributes).
 
 ---
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -12,6 +12,7 @@ Guide for integrating Quality Blueprints with ASP.NET Core and MediatR.
 - [gRPC Integration](#grpc-integration)
 - [OpenAPI Integration](#openapi-integration)
 - [DataAnnotations Bridge](#dataannotations-bridge)
+- [Architecture Testing](#architecture-testing)
 - [Assembly Scanning](#assembly-scanning)
 - [AOT Compatibility](#aot-compatibility)
 - [Combined Example](#combined-example)
@@ -34,6 +35,7 @@ The library is split into focused packages with minimal dependencies:
 | `JAAvila.FluentOperations.OpenApi` | Swashbuckle.AspNetCore.SwaggerGen | Schema filter that enriches OpenAPI schemas from blueprints |
 | `JAAvila.FluentOperations.Grpc` | Grpc.Core.Api, Grpc.AspNetCore | Server interceptor for automatic gRPC request validation |
 | `JAAvila.FluentOperations.DataAnnotations` | (none — ships with core only) | Generate blueprint rules from DataAnnotations attributes |
+| `JAAvila.FluentOperations.Architecture` | Mono.Cecil >= 0.11.6 | IL-level dependency scanning for architecture tests |
 
 > **Note on MediatR version:** The MediatR package is pinned to `[12.4.1, 13.0.0)` because MediatR v13+ changed its license to RPL-1.5, which is incompatible with Apache 2.0.
 
@@ -511,6 +513,124 @@ DataAnnotationsBlueprint<User>.FromAnnotations(new AnnotationOptions
 ```
 
 > **Note on `UseAnnotationErrorMessages`:** When multiple validation attributes are present on a property and more than one has a custom `ErrorMessage`, the first attribute (in declaration order) with a non-empty `ErrorMessage` is used as the `CustomMessage` for all rules on that property. This is a limitation of the engine's single `RuleConfig` per `For()` block design.
+
+---
+
+## Architecture Testing
+
+Architecture testing validates structural rules, naming conventions, dependency boundaries, and design constraints in your codebase at test time.
+
+### Core Package (No Additional Dependencies)
+
+The core `JAAvila.FluentOperations` package includes `TypeOperationsManager`, `AssemblyOperationsManager`, and the `Types` utility class. These use **reflection-based** dependency scanning — sufficient for most architecture tests.
+
+```csharp
+using JAAvila.FluentOperations;
+using JAAvila.FluentOperations.Architecture;
+
+// Type assertions
+typeof(UserService).Test()
+    .BeClass()
+    .BePublic()
+    .ImplementInterface<IUserService>()
+    .HaveNameEndingWith("Service")
+    .NotHaveDependencyOn("MyApp.Infrastructure");
+
+// Assembly assertions
+typeof(UserService).Assembly.Test()
+    .ContainType<UserService>()
+    .NotReferenceAssembly("Newtonsoft.Json");
+
+// Batch validation with Types utility
+var domainTypes = Types.InNamespace("MyApp.Domain");
+foreach (var type in domainTypes)
+    type.Test().NotHaveDependencyOn("MyApp.Infrastructure");
+```
+
+Reflection-based scanning covers: field types, property types, constructor parameters, method parameters, return types, base types, interfaces, generic arguments, and custom attributes.
+
+### IL-Level Scanning (Optional Package)
+
+For deeper dependency detection that inspects method body IL, install the optional package:
+
+```bash
+dotnet add package JAAvila.FluentOperations.Architecture
+```
+
+| | Reflection (default) | Cecil (opt-in) |
+|---|---|---|
+| **Dependencies** | None (core only) | Mono.Cecil >= 0.11.6 |
+| **Scans** | Type signatures, fields, properties, constructors, inheritance, interfaces, attributes | All of reflection + local variables, `new` calls, `typeof()`, casts, method calls, field access, catch blocks, lambdas, async state machines |
+| **Performance** | Fast (metadata only) | Slower (reads IL from disk) |
+| **Use case** | Structural rules, naming, classification | Strict dependency boundary enforcement |
+
+### Setup
+
+Activate Cecil scanning in your test fixture:
+
+```csharp
+using JAAvila.FluentOperations.Architecture;
+
+[OneTimeSetUp]
+public void SetUp() => ArchitectureScannerConfig.UseCecilDependencyScanning();
+
+[OneTimeTearDown]
+public void TearDown() => ArchitectureScannerConfig.Reset();
+```
+
+Once activated, all dependency operations (`HaveDependencyOn`, `NotHaveDependencyOn`, `OnlyHaveDependenciesOn`, `HaveDependencyOnType`, `NotHaveDependencyOnType`, and their `*Any` variants) automatically use IL-level scanning. No code changes needed — the same assertions gain deeper detection.
+
+### Architecture Test Patterns
+
+#### Layer Isolation
+
+```csharp
+// Domain layer must not reference infrastructure
+var domainTypes = Types.InNamespace("MyApp.Domain");
+foreach (var type in domainTypes)
+    type.Test()
+        .NotHaveDependencyOn("MyApp.Infrastructure")
+        .NotHaveDependencyOn("Microsoft.EntityFrameworkCore");
+
+// Controllers must only depend on domain and application layers
+var controllers = Types.InAssembly(assembly)
+    .That(t => t.Name.EndsWith("Controller"));
+foreach (var type in controllers)
+    type.Test()
+        .OnlyHaveDependenciesOn("MyApp.Domain", "MyApp.Application", "Microsoft.AspNetCore");
+```
+
+#### Naming and Structure Conventions
+
+```csharp
+var repos = Types.InAssembly(assembly)
+    .That(t => t.Name.EndsWith("Repository"));
+foreach (var type in repos)
+    type.Test()
+        .BeClass()
+        .NotBeAbstract()
+        .ImplementInterface<IRepository>()
+        .BeInNamespaceStartingWith("MyApp.Infrastructure.Persistence");
+```
+
+#### Design Constraints
+
+```csharp
+// Value objects must be immutable and sealed
+var valueObjects = Types.InNamespace("MyApp.Domain.ValueObjects");
+foreach (var type in valueObjects)
+    type.Test()
+        .BeSealed()
+        .BeImmutable()
+        .NotHavePublicConstructor(); // use factory methods
+
+// No async void anywhere
+var allTypes = Types.InAssembly(assembly);
+foreach (var type in allTypes)
+    type.Test().NotHaveAsyncVoidMethods();
+```
+
+See [API Reference — Architecture Testing](./API.md#architecture-testing) for the complete list of 85+ operations.
 
 ---
 


### PR DESCRIPTION
  Add TypeOperationsManager (77 operations) and AssemblyOperationsManager
  (8 operations) for validating code structure, naming conventions,
  dependency boundaries, and design constraints at test time.

  - TypeOperationsManager: classification (class, interface, abstract, sealed, static, public, internal, generic, record, value type, enum, nested, immutable), namespace/naming (exact, prefix, regex), inheritance, attributes, constructors, members, method body analysis (async void, return types), and dependency analysis (namespace, type, whitelist)
  - AssemblyOperationsManager: type containment, regex matching, assembly references, version checks, and strong naming
  - Types utility: InAssembly, InNamespace, InCurrentDomain, That filtering
  - IDependencyScanner with reflection-based default implementation
  - Optional JAAvila.FluentOperations.Architecture package with Mono.Cecil IL-level dependency scanning (CecilDependencyScanner)
  - 70+ validators following one-validator-per-operation pattern
  - PropertyProxy, QualityBlueprint.For/ForTransform, TestExtension wiring
  - Full documentation in README.md, API.md, and INTEGRATION.md