### PR TITLE
Resolve 3 concurrency bugs in singleton blueprint execution

### DIFF
--- a/Distributed/JAAvila.FluentOperations/CapturedRule.cs
+++ b/Distributed/JAAvila.FluentOperations/CapturedRule.cs
@@ -20,7 +20,7 @@ internal class CapturedRule(
 ) : IQualityRule, IModelAwareRule
 {
     /// <summary>Transient model reference — set per-Check() call, never persisted across evaluations.</summary>
-    private object? _currentModel;
+    private readonly AsyncLocal<object?> _currentModel = new();
 
     /// <summary>Gets the name of the model property this rule is bound to.</summary>
     public string PropertyName { get; } = propertyName;
@@ -39,7 +39,7 @@ internal class CapturedRule(
 
     void IModelAwareRule.SetModelInstance(object model)
     {
-        _currentModel = model;
+        _currentModel.Value = model;
 
         // Propagate to the inner rule if it also requires model access
         if (Inner is IModelAwareRule modelAware)
@@ -63,9 +63,9 @@ internal class CapturedRule(
     public string? GetCustomMessage()
     {
         // Priority: MessageFactory > CustomMessage > Inner.GetCustomMessage()
-        if (Config?.MessageFactory is { } factory && _currentModel is not null)
+        if (Config?.MessageFactory is { } factory && _currentModel.Value is not null)
         {
-            return factory(_currentModel);
+            return factory(_currentModel.Value);
         }
 
         return Config?.CustomMessage ?? Inner.GetCustomMessage();

--- a/Distributed/JAAvila.FluentOperations/ConditionGroup.cs
+++ b/Distributed/JAAvila.FluentOperations/ConditionGroup.cs
@@ -1,4 +1,37 @@
+using System.Collections.Concurrent;
+
+// ReSharper disable InconsistentNaming
+
 namespace JAAvila.FluentOperations;
+
+/// <summary>
+/// Holds the per-Check() condition result cache and model instance as AsyncLocal values so that
+/// each concurrent Check() invocation gets its own isolated slot. Parallel tasks spawned within
+/// the same Check() call inherit the parent's values, ensuring they share the same cache and model
+/// (correct behavior: same Check() call, same condition results, and model instance).
+/// </summary>
+internal static class ConditionCacheContext
+{
+    private static readonly AsyncLocal<ConcurrentDictionary<object, bool>?> _current = new();
+    private static readonly AsyncLocal<object?> _modelInstance = new();
+
+    public static ConcurrentDictionary<object, bool>? Current
+    {
+        get => _current.Value;
+        set => _current.Value = value;
+    }
+
+    /// <summary>
+    /// The root model instance for the current Check() call.
+    /// Used by <see cref="ConditionGroup{TModel}.GetResult"/> to evaluate the condition
+    /// without relying on mutable instance fields on shared singleton rule wrappers.
+    /// </summary>
+    public static object? ModelInstance
+    {
+        get => _modelInstance.Value;
+        set => _modelInstance.Value = value;
+    }
+}
 
 /// <summary>
 /// Caches the result of a condition function so it is evaluated at most once per Check() invocation.
@@ -7,7 +40,6 @@ namespace JAAvila.FluentOperations;
 internal sealed class ConditionGroup<TModel>
 {
     private readonly Func<TModel, bool> _condition;
-    private bool? _cachedResult;
 
     public ConditionGroup(Func<TModel, bool> condition)
     {
@@ -15,24 +47,23 @@ internal sealed class ConditionGroup<TModel>
     }
 
     /// <summary>
-    /// Returns the cached condition result, evaluating it on first call per Check() cycle.
+    /// Returns the cached condition result, evaluating and storing it on the first call per Check() cycle.
+    /// The cache is read from <see cref="ConditionCacheContext.Current"/>, which is set at the start
+    /// of each Check() / CheckAsync() call and is isolated per concurrent invocation via AsyncLocal.
     /// </summary>
-    public bool GetResult(TModel instance)
+    /// <param name="fallbackInstance">
+    /// The model instance to use when <see cref="ConditionCacheContext.ModelInstance"/> is not set.
+    /// In the normal singleton-blueprint and concurrent-Check() flow, the context carries the model.
+    /// </param>
+    public bool GetResult(TModel fallbackInstance)
     {
-        if (_cachedResult.HasValue)
-        {
-            return _cachedResult.Value;
-        }
+        // Prefer the context-carried model instance to avoid races on the caller's field.
+        var modelInstance = ConditionCacheContext.ModelInstance is TModel contextModel
+            ? contextModel
+            : fallbackInstance;
 
-        _cachedResult = _condition(instance);
-        return _cachedResult.Value;
-    }
+        var cache = ConditionCacheContext.Current;
 
-    /// <summary>
-    /// Clears the cached result so the condition will be re-evaluated on the next Check() call.
-    /// </summary>
-    public void Reset()
-    {
-        _cachedResult = null;
+        return cache?.GetOrAdd(this, _ => _condition(modelInstance)) ?? _condition(modelInstance);
     }
 }

--- a/Distributed/JAAvila.FluentOperations/ConditionalRuleWrapper.cs
+++ b/Distributed/JAAvila.FluentOperations/ConditionalRuleWrapper.cs
@@ -35,6 +35,8 @@ internal class ConditionalRuleWrapper<TModel>(
             return false;
         }
 
+        // Use the shared ConditionGroup — reads from ConditionCacheContext (AsyncLocal),
+        // ensuring the condition is evaluated at most once per Check() call per group.
         var result = conditionGroup?.GetResult(_modelInstance) ?? condition(_modelInstance);
 
         return isOtherwise ? !result : result;

--- a/Distributed/JAAvila.FluentOperations/PrincipalChain.cs
+++ b/Distributed/JAAvila.FluentOperations/PrincipalChain.cs
@@ -88,17 +88,28 @@ public class PrincipalChain<T> : IDisposable
     /// <param name="value">The value to place on the re-initialized chain.</param>
     internal void ReInitialize(T value)
     {
-        Contexts.Value ??= new ConcurrentDictionary<Guid, Stack<BaseChain<T>>>();
-
         var chain = BaseChain<T>.Create(BaseValue<T>.Create(value), GetSubjectSafe());
-
-        // Always create a fresh single-element stack for this chain ID.
-        // This is safe in concurrent scenarios because each async context has its own
-        // Contexts.Value (AsyncLocal isolates per-context), and within one context we
-        // only need one stack entry per _chainId during Blueprint validation.
         var stack = new Stack<BaseChain<T>>();
         stack.Push(chain);
-        Contexts.Value[_chainId] = stack;
+
+        if (Contexts.Value is null)
+        {
+            // No inherited context — create a fresh dict and assign to trigger AsyncLocal isolation.
+            var dict = new ConcurrentDictionary<Guid, Stack<BaseChain<T>>> { [_chainId] = stack };
+            Contexts.Value = dict;
+        }
+        else
+        {
+            // There is an existing dict (possibly inherited from a parent async context).
+            // Create a new dict by copying all existing entries, then add/update our entry.
+            // Assigning to Contexts.Value triggers AsyncLocal copy-on-write isolation so that
+            // this child context gets its own independent dict and won't interfere with other tasks.
+            var dict = new ConcurrentDictionary<Guid, Stack<BaseChain<T>>>(Contexts.Value)
+            {
+                [_chainId] = stack
+            };
+            Contexts.Value = dict;
+        }
     }
 
     /// <summary>
@@ -126,6 +137,10 @@ public class PrincipalChain<T> : IDisposable
         return GetStack().Peek().BaseSubject.ToString();
     }
 
+    /// <summary>
+    /// Retrieves the current value stored in the chain as a string representation.
+    /// </summary>
+    /// <returns>A string representation of the current value, or null if the value is not set.</returns>
     public string? GetValueAsString()
     {
         return GetValue()?.ToString();
@@ -152,6 +167,12 @@ public class PrincipalChain<T> : IDisposable
         }
     }
 
+    /// <summary>
+    /// Retrieves the unique <see cref="Guid"/> identifier associated with the current
+    /// <see cref="PrincipalChain{T}"/> instance. This identifier is used to track and isolate
+    /// individual chains within an async or nested context.
+    /// </summary>
+    /// <returns>The <see cref="Guid"/> representing the unique identifier for the active chain.</returns>
     protected Guid GetCurrentChainId()
     {
         return _chainId;
@@ -162,6 +183,12 @@ public class PrincipalChain<T> : IDisposable
         GetStack().Push(value);
     }
 
+    /// <summary>
+    /// Clears the current active instance of the <see cref="PrincipalChain{T}"/> in the async context.
+    /// This method ensures that the static storage for the chain is reset, allowing for proper cleanup
+    /// or reinitialization of the chain when needed. Should be invoked to prevent retaining stale chain
+    /// instances in <see cref="AsyncLocal{T}"/> storage.
+    /// </summary>
     protected void CleanInstance()
     {
         Instance.Value = null;

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.Conditional.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.Conditional.cs
@@ -14,7 +14,6 @@ public abstract partial class QualityBlueprint<T>
     {
         // Create a shared ConditionGroup for all rules in this When() group
         var group = new ConditionGroup<T>(condition);
-        _conditionGroups.Add(group);
 
         // Save previously captured rules
         var previousCollected = _capturedDuringDefinition.ToList();

--- a/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
+++ b/Distributed/JAAvila.FluentOperations/QualityBlueprint.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using JAAvila.FluentOperations.Common;
 using JAAvila.FluentOperations.Config;
@@ -89,7 +90,6 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
     private readonly Dictionary<string, Func<object, bool>?> _forEachFilters = new();
 
     private readonly List<IQualityRule> _capturedDuringDefinition = [];
-    private readonly List<object> _conditionGroups = []; // ConditionGroup<T> instances for reset
     private Type? _currentScenario;
     private string? _currentRuleSet;
 
@@ -305,17 +305,6 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
         }
     }
 
-    private void ResetConditionGroups()
-    {
-        foreach (var groupObj in _conditionGroups)
-        {
-            if (groupObj is ConditionGroup<T> group)
-            {
-                group.Reset();
-            }
-        }
-    }
-
     /// <summary>
     /// Returns <see langword="true"/> when the definition should be skipped given the active
     /// scenario and the requested rule sets.
@@ -443,7 +432,7 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
             var innerRule = rule is CapturedRule cr ? cr.Inner : rule;
 
             // Inject a root model for model-aware rules (dynamic messages via MessageFactory,
-            // cross-property conditions, etc.). CapturedRule.SetModelInstance propagates to inner.
+            // cross-property conditions, etc.). CapturedRule.SetModelInstance propagates to the inner.
             if (rule is IModelAwareRule modelAware)
             {
                 modelAware.SetModelInstance(instance);
@@ -552,7 +541,7 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
             var innerRule = rule is CapturedRule cr ? cr.Inner : rule;
 
             // Inject a root model for model-aware rules (dynamic messages via MessageFactory,
-            // cross-property conditions, etc.). CapturedRule.SetModelInstance propagates to inner.
+            // cross-property conditions, etc.). CapturedRule.SetModelInstance propagates to the inner.
             if (rule is IModelAwareRule modelAware)
             {
                 modelAware.SetModelInstance(instance);
@@ -733,7 +722,8 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
             telemetryEnabled && telemetryConfig!.TrackBlueprintExecutionTime
         );
 
-        ResetConditionGroups();
+        ConditionCacheContext.Current = new ConcurrentDictionary<object, bool>();
+        ConditionCacheContext.ModelInstance = instance;
         var report = new QualityReport();
 
         using (
@@ -1187,7 +1177,8 @@ public abstract partial class QualityBlueprint<T> : IBlueprintValidator
             telemetryEnabled && telemetryConfig!.TrackBlueprintExecutionTime
         );
 
-        ResetConditionGroups();
+        ConditionCacheContext.Current = new ConcurrentDictionary<object, bool>();
+        ConditionCacheContext.ModelInstance = instance;
         var report = new QualityReport();
 
         using (

--- a/llms.txt
+++ b/llms.txt
@@ -4,7 +4,7 @@
 
 ## Overview
 
-JAAvila.FluentOperations is a NuGet package family of 9 packages. The core library targets .NET 8.0 and C# 13.0.
+JAAvila.FluentOperations is a NuGet package family of 10 packages. The core library targets .NET 8.0 and C# 13.0.
 
 **Two validation approaches:**
 1. **Inline assertions** — `value.Test().Operation()` chains that throw immediately on failure
@@ -39,7 +39,7 @@ User-defined asynchronous validator.
 - Methods: `Task<bool> IsValidAsync(T)`, `string GetFailureMessage(T)`
 
 ### IRuleDescriptor
-Introspection metadata. All 730+ validators implement this.
+Introspection metadata. All 800+ validators implement this.
 - Properties: `string OperationName`, `Type SubjectType`, `IReadOnlyDictionary<string, object> Parameters`
 
 ### IMessageProvider
@@ -179,6 +179,12 @@ Async variants of ActionOperationsManager operations.
 ### ActionStatsOperationsManager (`ActionStats?`)
 Operations: `TakeLongerThan(TimeSpan)`, `TakeShorterThan(TimeSpan)`, `HaveElapsedTimeBetween(TimeSpan,TimeSpan)`, `CompleteWithin(TimeSpan)`, `Succeed()`, `NotSucceed()`, `HaveException()`, `HaveException(Type)`, `ConsumeMemoryGreaterThan(long)`, `ConsumeMemoryLessThan(long)`
 
+### TypeOperationsManager (`Type`)
+Operations: `BeClass()`, `NotBeClass()`, `BeInterface()`, `NotBeInterface()`, `BeAbstract()`, `NotBeAbstract()`, `BeSealed()`, `NotBeSealed()`, `BeStatic()`, `NotBeStatic()`, `BePublic()`, `NotBePublic()`, `BeInternal()`, `NotBeInternal()`, `BeGeneric()`, `NotBeGeneric()`, `BeRecord()`, `BeValueType()`, `BeEnum()`, `BeNested()`, `BeImmutable()`, `NotBeImmutable()`, `BeInNamespace(string)`, `NotBeInNamespace(string)`, `BeInNamespaceStartingWith(string)`, `HaveName(string)`, `NotHaveName(string)`, `HaveNameEndingWith(string)`, `NotHaveNameEndingWith(string)`, `HaveNameStartingWith(string)`, `NotHaveNameStartingWith(string)`, `MatchName(string)`, `MatchNamespace(string)`, `ImplementInterface<T>()`, `ImplementInterface(Type)`, `NotImplementInterface<T>()`, `NotImplementInterface(Type)`, `DeriveFrom<T>()`, `DeriveFrom(Type)`, `NotDeriveFrom<T>()`, `NotDeriveFrom(Type)`, `HaveAttribute<T>()`, `HaveAttribute(Type)`, `NotHaveAttribute<T>()`, `NotHaveAttribute(Type)`, `HavePublicConstructor()`, `NotHavePublicConstructor()`, `HaveConstructorWithParameters(params Type[])`, `HavePrivateConstructorWithParameters(params Type[])`, `HavePropertyOfType<T>(string)`, `HavePropertyOfType(string, Type)`, `HaveMethodReturning<T>(string)`, `HaveMethodReturning(string, Type)`, `HaveMethodOverride(string)`, `NotHaveMethodOverride(string)`, `HaveProtectedMembers()`, `NotHaveProtectedMembers()`, `HaveMaxPublicMethods(int)`, `HaveMaxFields(int)`, `HaveAsyncVoidMethods()`, `NotHaveAsyncVoidMethods()`, `ReturnTypesFromNamespace(string)`, `NotReturnTypesFromNamespace(string)`, `HaveDependencyOn(string)`, `NotHaveDependencyOn(string)`, `HaveDependencyOnAny(params string[])`, `NotHaveDependencyOnAny(params string[])`, `OnlyHaveDependenciesOn(params string[])`, `HaveDependencyOnType<T>()`, `HaveDependencyOnType(string)`, `NotHaveDependencyOnType<T>()`, `NotHaveDependencyOnType(string)`
+
+### AssemblyOperationsManager (`Assembly`)
+Operations: `ContainType<T>()`, `ContainType(Type)`, `ContainTypeMatching(string)`, `ReferenceAssembly(string)`, `NotReferenceAssembly(string)`, `HaveVersion(Version)`, `HaveMinimumVersion(Version)`, `HavePublicKey()`
+
 ### CrossPropertyOperationsManager<T>
 Used for cross-property validation within blueprints.
 
@@ -198,7 +204,7 @@ All types expose a `.Test()` extension method that returns the corresponding man
 
 **Date/Time:** `DateTime.Test()`, `DateTime?.Test()`, `DateOnly.Test()`, `DateOnly?.Test()`, `TimeOnly.Test()`, `TimeOnly?.Test()`, `TimeSpan.Test()`, `TimeSpan?.Test()`, `DateTimeOffset.Test()`, `DateTimeOffset?.Test()`
 
-**Other:** `Guid.Test()`, `Guid?.Test()`, `Uri.Test()`, `Action.Test()`, `Func<Task>.Test()`, `ActionStats?.Test()`
+**Other:** `Guid.Test()`, `Guid?.Test()`, `Uri.Test()`, `Action.Test()`, `Func<Task>.Test()`, `ActionStats?.Test()`, `Type.Test()`, `Assembly.Test()`
 
 **Collections:** `IEnumerable<T>.Test()`, `T[].Test()`, `IDictionary<TKey,TValue>.Test()`
 
@@ -240,6 +246,26 @@ Composes N blueprints validating the same model type. Merges all `QualityReport`
 - `CompositeBlueprint(params QualityBlueprint<T>[] blueprints)`
 - `Check(T)`, `CheckAsync(T)` — execute all blueprints and merge reports
 
+### Types (static utility)
+Selects and filters types from assemblies and namespaces for batch architecture testing.
+- `InAssembly(Assembly)`, `InAssembly(Assembly, Func<Type, bool>)` — exported types from one assembly
+- `InAssemblySafe(Assembly)` — handles `ReflectionTypeLoadException`
+- `InAssemblies(params Assembly[])`, `InAssembliesSafe(params Assembly[])` — multiple assemblies
+- `InNamespace(string)` — exported types in a namespace across all loaded assemblies
+- `InNamespaceOf<T>()` — types sharing the same namespace as T
+- `InCurrentDomain()` — all exported types in the AppDomain
+- `That(this IEnumerable<Type>, Func<Type, bool>)` — fluent predicate filtering extension
+
+### IDependencyScanner (interface)
+Abstraction for dependency analysis used by `TypeOperationsManager`.
+- `HashSet<string> GetReferencedNamespaces(Type)`, `bool HasDependencyOnNamespace(Type, string)`, `HashSet<string> GetReferencedTypes(Type)`, `bool HasDependencyOnType(Type, string)`, `CheckOnlyDependenciesOn(Type, IReadOnlyList<string>)`
+
+### DependencyScannerProvider (static)
+Manages the active `IDependencyScanner` instance.
+- `IDependencyScanner Current` — returns active scanner (default: reflection-based)
+- `SetScanner(IDependencyScanner)` — replaces active scanner
+- `Reset()` — reverts to reflection-based default
+
 ### AssertionScope
 Batches inline assertion failures and throws a combined exception on Dispose.
 - Constructors: `AssertionScope()`, `AssertionScope(string name)`
@@ -275,7 +301,7 @@ Single validation failure entry in a `QualityReport`.
 - `CascadeMode CascadeMode`
 - `CascadeSeverityMode CascadeSeverityMode`
 - `string? CustomMessage`
-- `Func<string>? MessageFactory`
+- `Func<object, string>? MessageFactory` — receives root model instance, invoked only on failure during Blueprint Check
 
 **Reason** — Record for contextual failure messages. `Reason.New("because {0}", arg)`
 
@@ -388,6 +414,7 @@ Each integration package is a separate NuGet package with namespace `JAAvila.Flu
 | `JAAvila.FluentOperations.OpenApi` | Swagger/OpenAPI schema generation (Swashbuckle 6.x) | — |
 | `JAAvila.FluentOperations.Grpc` | gRPC server interceptor | `GrpcBlueprintInterceptor` |
 | `JAAvila.FluentOperations.DataAnnotations` | Bridge to `System.ComponentModel.Annotations` | — |
+| `JAAvila.FluentOperations.Architecture` | IL-level dependency scanning via Mono.Cecil (opt-in for architecture tests) | `ArchitectureScannerConfig`, `CecilDependencyScanner` |
 
 All DI-registered blueprints are automatically registered as both `QualityBlueprint<T>` and `IBlueprintValidator`. Integration filters resolve blueprints via `IEnumerable<IBlueprintValidator>` — no reflection or `MakeGenericType` is used (AOT-safe).
 
@@ -621,6 +648,44 @@ public class LoggingInterceptor : IBlueprintInterceptor, IOrderedBlueprintInterc
         return report;
     }
 }
+```
+
+### Architecture Testing
+
+```csharp
+using JAAvila.FluentOperations;
+using JAAvila.FluentOperations.Architecture;
+
+// Type assertions
+typeof(MyService).Test()
+    .BeClass()
+    .BePublic()
+    .NotBeAbstract()
+    .ImplementInterface<IMyService>()
+    .NotHaveDependencyOn("MyApp.Infrastructure")
+    .NotHaveAsyncVoidMethods();
+
+// Assembly assertions
+typeof(MyService).Assembly.Test()
+    .ContainType<MyService>()
+    .NotReferenceAssembly("Newtonsoft.Json")
+    .HaveMinimumVersion(new Version(1, 0));
+
+// Batch type selection with Types utility
+var domainTypes = Types.InNamespace("MyApp.Domain");
+foreach (var type in domainTypes)
+    type.Test().NotHaveDependencyOn("MyApp.Infrastructure");
+
+// Filtered selection
+Types.InAssembly(typeof(MyService).Assembly)
+    .That(t => t.IsClass && t.Name.EndsWith("Service"))
+    .ToList()
+    .ForEach(t => t.Test().ImplementInterface<IService>());
+
+// Optional: IL-level dependency scanning (requires JAAvila.FluentOperations.Architecture package)
+ArchitectureScannerConfig.UseCecilDependencyScanning(); // activate once in test setup
+// Now HaveDependencyOn/OnlyHaveDependenciesOn/etc. also scan method body IL
+ArchitectureScannerConfig.Reset(); // restore default in teardown
 ```
 
 ## Core Execution Flow


### PR DESCRIPTION
  PrincipalChain.ReInitialize race condition (HIGH): concurrent Check()
  calls shared the same AsyncLocal-inherited ConcurrentDictionary, causing
  cross-thread value corruption between SetValue and Validate. Fix: always
  create a new dictionary and assign to Contexts.Value, triggering
  AsyncLocal copy-on-write isolation per async context.

  ConditionGroup._cachedResult corruption (MEDIUM): plain bool? field on
  singleton caused When() condition results to leak between threads. Fix:
  replace with ConditionCacheContext using static AsyncLocal holding a
  per-Check() ConcurrentDictionary, with GetOrAdd for atomic evaluation.
  Remove ResetConditionGroups and _conditionGroups field.

  CapturedRule._currentModel race (LOW): plain object? field overwritten
  by concurrent SetModelInstance calls. Fix: replace with AsyncLocal for
  per-context isolation.

  Also update llms.txt and docs with architecture testing feature:
  TypeOperationsManager (77 ops), AssemblyOperationsManager (8 ops),
  Types utility, IDependencyScanner, and Architecture package.