### PR TITLE
Include failing element index in SatisfyRespectively error message

### DIFF
--- a/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/ArrayOperationsManager.cs
@@ -2353,11 +2353,11 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
             return this;
         }
 
+        var validator = CollectionSatisfyRespectivelyValidator<T>.New(PrincipalChain, predicates);
+
         ExecutionEngine<ArrayOperationsManager<T>, IEnumerable<T>>
             .New(this)
-            .WithOperation(
-                CollectionSatisfyRespectivelyValidator<T>.New(PrincipalChain, predicates)
-            )
+            .WithOperation(validator)
             .WithTemplate(
                 (template, operation) =>
                     template
@@ -2366,7 +2366,8 @@ public class ArrayOperationsManager<T> : ITestManager<ArrayOperationsManager<T>,
                             operation.MessageKey,
                             operation.ResultValidation,
                             PrincipalChain.GetValue().Count().ToString(),
-                            predicates.Length.ToString()
+                            predicates.Length.ToString(),
+                            validator.FailingIndex.ToString()
                         )
                         .WithReason(reason?.ToString())
             )

--- a/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
+++ b/Distributed/JAAvila.FluentOperations/Manager/CollectionOperationsManager.cs
@@ -2440,12 +2440,11 @@ public class CollectionOperationsManager<T>
         }
 
         var list = PrincipalChain.GetValue().ToList();
+        var validator = CollectionSatisfyRespectivelyValidator<T>.New(PrincipalChain, predicates);
 
         ExecutionEngine<CollectionOperationsManager<T>, IEnumerable<T>>
             .New(this)
-            .WithOperation(
-                CollectionSatisfyRespectivelyValidator<T>.New(PrincipalChain, predicates)
-            )
+            .WithOperation(validator)
             .WithTemplate(
                 (template, operation) =>
                     template
@@ -2454,7 +2453,8 @@ public class CollectionOperationsManager<T>
                             operation.MessageKey,
                             operation.ResultValidation,
                             list.Count.ToString(),
-                            predicates.Length.ToString()
+                            predicates.Length.ToString(),
+                            validator.FailingIndex.ToString()
                         )
                         .WithReason(reason?.ToString())
             )

--- a/Distributed/JAAvila.FluentOperations/Validators/CollectionSatisfyRespectivelyValidator.cs
+++ b/Distributed/JAAvila.FluentOperations/Validators/CollectionSatisfyRespectivelyValidator.cs
@@ -18,6 +18,7 @@ internal class CollectionSatisfyRespectivelyValidator<T>(
     public string Expected { get; } = null!;
     public string ResultValidation { get; set; } = null!;
     public string MessageKey => "Collection.SatisfyRespectively";
+    public int FailingIndex { get; private set; } = -1;
     string IRuleDescriptor.OperationName => "SatisfyRespectively";
     Type IRuleDescriptor.SubjectType => typeof(IEnumerable<>);
     IReadOnlyDictionary<string, object> IRuleDescriptor.Parameters =>
@@ -34,11 +35,15 @@ internal class CollectionSatisfyRespectivelyValidator<T>(
             return false;
         }
 
-        if (list.Where((t, i) => !predicates[i](t)).Any())
+        for (var i = 0; i < list.Count; i++)
         {
-            ResultValidation =
-                "The collection was expected to satisfy the respective predicates for each element, but element at index {0} did not satisfy its predicate.";
-            return false;
+            if (!predicates[i](list[i]))
+            {
+                FailingIndex = i;
+                ResultValidation =
+                    "The collection was expected to satisfy the respective predicates for each element, but element at index {2} did not satisfy its predicate.";
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
The predicate failure branch in CollectionSatisfyRespectivelyValidator used a LINQ Where/Any pattern that discarded the actual failing index. The ResultValidation template referenced {0} for the index, but the managers passed list.Count as {0}, producing incorrect error messages.

Replace the Where/Any with an explicit for-loop that captures the first failing index into a new FailingIndex property. Both Collection and Array managers now pass the failing index as a third format argument ({2}), so the predicate failure message correctly identifies which element did not satisfy its predicate.

Closes #115 